### PR TITLE
Read repo config from agent frontmatter

### DIFF
--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -9,11 +9,9 @@
  */
 
 import type { AgentDef } from '../types/agent.js';
-import { getPlugins, getPluginsWithRepoConfigs, type LoadedPlugin, type PmSkillEntry } from '../system/plugin-loader.js';
+import { getPlugins, type LoadedPlugin, type PmSkillEntry } from '../system/plugin-loader.js';
 import { REPOS_DIR } from '../system/workdir.js';
-import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import matter from 'gray-matter';
 
 // ---- Module state ----
 
@@ -38,83 +36,45 @@ export function scanAgentDefs(): AgentDef[] {
   const defs: AgentDef[] = [];
   const seenIds = new Map<string, string>(); // agentId → pluginName (collision detection)
 
-  // --- Repo agents ---
-  const repoPlugins = getPluginsWithRepoConfigs();
-  for (const plugin of repoPlugins) {
-    const repoConfigs = plugin.repoConfigs!;
-    for (const [key, infraConfig] of Object.entries(repoConfigs)) {
-      const agentId = `${key}-agent`;
-
-      // Validate prompt field
-      if (!infraConfig.prompt) {
-        throw new Error(
-          `Missing "prompt" field for "${key}" in ${plugin.name}/repo-config.json. ` +
-          `Each agent must declare its prompt file (e.g. "prompt": "agents/${key}.md").`
-        );
-      }
-
-      // Read agent identity from prompt file
-      const agentFilePath = join(plugin.dir, infraConfig.prompt);
-      if (!existsSync(agentFilePath)) {
-        throw new Error(
-          `Agent prompt file not found: ${agentFilePath} ` +
-          `(declared as "${infraConfig.prompt}" for "${key}" in ${plugin.name}/repo-config.json)`
-        );
-      }
-
-      const agentContent = readFileSync(agentFilePath, 'utf-8');
-      const { data, content } = matter(agentContent);
-
-      checkCollision(agentId, plugin.name, seenIds);
-
-      defs.push({
-        id: agentId,
-        key,
-        role: data.role || '',
-        expertise: data.expertise || '',
-        track: 'repo',
-        pluginName: plugin.name,
-        agentPrompt: content.trim() || undefined,
-        repo: {
-          githubRepo: infraConfig.githubRepo,
-          baseBranch: infraConfig.baseBranch,
-          defaultPath: infraConfig.repoPath || join(REPOS_DIR, key),
-          repoKey: key,
-        },
-      });
-    }
-  }
-
-  // Fail-fast: at least one repo config required (z.enum() crashes on empty array)
-  const repoDefs = defs.filter((d) => d.track === 'repo');
-  if (repoDefs.length === 0) {
-    throw new Error(
-      'No repo configs loaded. Ensure at least one plugin has repo-config.json.'
-    );
-  }
-
-  // --- Plugin agents ---
+  // --- Scan all agents from all plugins ---
   for (const plugin of getPlugins()) {
-    // Skip repo plugins — their agents are already handled above
-    if (plugin.repoConfigs !== null) continue;
-
     for (const agent of plugin.agents) {
       const agentId = `${agent.key}-agent`;
-
       checkCollision(agentId, plugin.name, seenIds);
 
-      defs.push({
-        id: agentId,
-        key: agent.key,
-        role: agent.role,
-        expertise: agent.expertise,
-        model: agent.model,
-        track: 'plugin',
-        pluginName: plugin.name,
-        agentPrompt: agent.prompt,
-        pluginPath: plugin.dir,
-        skillsPath: plugin.skillsPath || undefined,
-      });
+      if (agent.repo) {
+        // Repo agent — has repo metadata in frontmatter
+        defs.push({
+          id: agentId,
+          key: agent.key,
+          role: agent.role,
+          expertise: agent.expertise,
+          model: agent.model,
+          track: 'repo',
+          pluginName: plugin.name,
+          agentPrompt: agent.prompt || undefined,
+          repo: {
+            githubRepo: agent.repo.github,
+            baseBranch: agent.repo.baseBranch,
+            defaultPath: join(REPOS_DIR, agent.key),
+            repoKey: agent.key,
+          },
+        });
+      } else {
+        // Plugin agent — no repo metadata
+        defs.push({
+          id: agentId,
+          key: agent.key,
+          role: agent.role,
+          expertise: agent.expertise,
+          model: agent.model,
+          track: 'plugin',
+          pluginName: plugin.name,
+          agentPrompt: agent.prompt,
+          pluginPath: plugin.dir,
+          skillsPath: plugin.skillsPath || undefined,
+        });
+      }
     }
   }
 

--- a/src/system/plugin-loader.ts
+++ b/src/system/plugin-loader.ts
@@ -36,6 +36,11 @@ export interface PluginAgentDef {
   model?: string;
   /** Markdown body (domain-specific instructions) */
   prompt: string;
+  /** Repo metadata from frontmatter (if present, agent is a repo agent) */
+  repo?: {
+    github: string;
+    baseBranch?: string;
+  };
 }
 
 export interface PmSkillEntry {
@@ -48,11 +53,11 @@ export interface PmSkillEntry {
 export interface LoadedPlugin {
   name: string;
   dir: string;
-  /** Parsed repo-config.json if present — keyed by agent key (e.g. "backend") */
+  /** Parsed repo-config.json if present (legacy, kept for reference) */
   repoConfigs: Record<string, PluginRepoConfig> | null;
   /** PM skills with namespaced names and source paths */
   pmSkills: PmSkillEntry[];
-  /** Generic plugin agent definitions (only for plugins WITHOUT repo-config.json) */
+  /** Agent definitions from agents/*.md — repo or plugin track based on frontmatter */
   agents: PluginAgentDef[];
   /** Absolute path to skills/ directory (for agent craft skills) */
   skillsPath: string | null;
@@ -99,26 +104,35 @@ function scanPlugins(): LoadedPlugin[] {
       }
     }
 
-    // Scan agents/*.md for generic plugins (plugins WITHOUT repo-config.json)
+    // Scan agents/*.md for all plugins
     const agents: PluginAgentDef[] = [];
-    if (!repoConfigs) {
-      const agentsDir = join(pluginDir, 'agents');
-      if (existsSync(agentsDir)) {
-        for (const agentEntry of readdirSync(agentsDir, { withFileTypes: true })) {
-          if (!agentEntry.isFile() || !agentEntry.name.endsWith('.md')) continue;
+    const agentsDir = join(pluginDir, 'agents');
+    if (existsSync(agentsDir)) {
+      for (const agentEntry of readdirSync(agentsDir, { withFileTypes: true })) {
+        if (!agentEntry.isFile() || !agentEntry.name.endsWith('.md')) continue;
 
-          const key = agentEntry.name.replace(/\.md$/, '');
-          const agentContent = readFileSync(join(agentsDir, agentEntry.name), 'utf-8');
-          const { data, content } = matter(agentContent);
+        const key = agentEntry.name.replace(/\.md$/, '');
+        const agentContent = readFileSync(join(agentsDir, agentEntry.name), 'utf-8');
+        const { data, content } = matter(agentContent);
 
-          agents.push({
-            key,
-            role: data.role || '',
-            expertise: data.expertise || '',
-            model: data.model || undefined,
-            prompt: content.trim(),
-          });
+        const agentDef: PluginAgentDef = {
+          key,
+          role: data.role || '',
+          expertise: data.expertise || '',
+          model: data.model || undefined,
+          prompt: content.trim(),
+        };
+
+        // If frontmatter has repo metadata, this is a repo agent
+        const repoMeta = data.metadata?.archie?.repo;
+        if (repoMeta && typeof repoMeta === 'object' && repoMeta.github) {
+          agentDef.repo = {
+            github: repoMeta.github,
+            baseBranch: repoMeta.baseBranch || undefined,
+          };
         }
+
+        agents.push(agentDef);
       }
     }
 


### PR DESCRIPTION
## Summary
- Plugin loader now scans `agents/*.md` for all plugins (not just non-repo ones)
- Registry reads repo metadata from `metadata.archie.repo` in agent frontmatter instead of `repo-config.json`
- Removes hard requirement for repo agents — plugins can have mixed repo + plugin agents
- `repo-config.json` kept for reference but no longer used by the registry

**Companion PR:** sweatco/archie-plugins (adds `metadata.archie.repo` to agent frontmatter)

## Test plan
- [x] Verify server starts and loads agents correctly
- [x] Verify repo agents are detected from frontmatter metadata
- [x] Verify plugin agents still work without repo metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)