### PR TITLE
Fix DMs with @mention being silently dropped

### DIFF
--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -96,8 +96,11 @@ export async function mountSlackApp(
       !event.subtype &&
       (isThreadReply || isDm)
     ) {
+      // In channels, @mentions are handled by app_mention handler, so skip them here
+      // to avoid double-processing. But in DMs, app_mention doesn't fire, so we must
+      // process mention-containing DMs here.
       const botUserId = getBotUserId();
-      if (botUserId && event.text?.includes(`<@${botUserId}>`)) {
+      if (!isDm && botUserId && event.text?.includes(`<@${botUserId}>`)) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- DMs to Archie that included an `@Archie` mention were silently dropped
- The `message` handler skipped all messages containing a bot mention to avoid double-processing with `app_mention`, but `app_mention` doesn't fire in DMs
- Added `!isDm` guard so the skip only applies in channels

## Test plan
- [ ] DM Archie without mentioning — should work (unchanged)
- [ ] DM Archie with `@Archie` in the message — should now work
- [ ] Mention `@Archie` in a channel — should work via `app_mention` (unchanged)
- [ ] Reply in a thread with `@Archie` — should work (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)