### PR TITLE
Update architecture docs and mark triage agent as disabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,9 @@ Multi-agent AI software engineering system built with Claude Agent SDK. Speciali
 
 ## Architecture Overview
 
-Slack messages → Triage Agent → PM Agent → Specialist Agents (Backend, Mobile)
+Slack messages → PM Agent → Specialist Agents (Backend, Mobile)
 
-- **Triage agent** (Haiku) classifies messages: new task, existing task, status request, cancel
+- **Triage agent** (Haiku) is currently disabled — messages route directly to PM
 - **PM agent** manages tasks, assigns owners, communicates with users via Slack
 - **Specialist agents** (Backend/Mobile) investigate and modify codebases (readonly by default, edit mode after approval)
 - **Plugin agents** handle non-engineering domains (generic, no git infrastructure)

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ npm run dev
 npm run docker:dev
 ```
 
-See [Docker Setup](DOCKER.md) for container deployment or [Local Development](docs/local-development.md) for running without Docker.
+See [Docker Setup](DOCKER.md) for container deployment or [Local Development](docs/guides/local-development.md) for running without Docker.
 
 ## Architecture
 
 Specialized AI agents coordinate like a human engineering team:
 
-- **Triage Agent** (Haiku) - Message classification and routing
-- **PM Agent** (Sonnet) - Task coordination, user communication, GitHub operations
+- ~~**Triage Agent** (Haiku) - Message classification and routing~~ (currently disabled)
+- **PM Agent** (Opus) - Task coordination, user communication
 - **Backend Agent** (Sonnet) - Ruby on Rails engineering
 - **Mobile Agent** (Sonnet) - React Native/iOS/Android engineering
 
@@ -39,23 +39,27 @@ Specialized AI agents coordinate like a human engineering team:
 
 **Architecture:**
 
-- [Architecture Overview](docs/architecture-overview.md) - System design and concepts
-- [Agent Architecture](docs/agent-architecture.md) - AI agent specifications
-- [System Orchestration](docs/system-orchestration.md) - Backend implementation
-- [Task Persistence](docs/task-persistence.md) - Storage and state
-- [Slack Integration](docs/slack-integration.md) - UX layer
-- [GitHub Integration](docs/github-integration-agreements.md) - PR workflow
+- [Architecture Overview](docs/architecture/overview.md) - System design and concepts
+- [Agent Architecture](docs/architecture/agents.md) - AI agent specifications
+- [System Orchestration](docs/architecture/orchestration.md) - Backend implementation
+- [Task Persistence](docs/architecture/persistence.md) - Storage and state
+- [Edit Mode](docs/architecture/edit-mode.md) - Approval flow, worktrees, and git workflow
+- [Slack Integration](docs/architecture/slack-integration.md) - UX layer
+- [GitHub Integration](docs/architecture/github-integration.md) - PR workflow
+- [Plugin System](docs/architecture/plugin-system.md) - Plugin structure and agent registration
+- [Web Research](docs/architecture/web-research.md) - Multi-agent research pipeline
+- [Security](docs/architecture/security.md) - Research budget, defense layers
 
 **Operations:**
 
 - [Docker Setup](DOCKER.md) - Container deployment
-- [Local Development](docs/local-development.md) - Running without Docker
-- [Deployment & Operations](docs/deployment-operations.md) - Production deployment
+- [Local Development](docs/guides/local-development.md) - Running without Docker
+- [Deployment](docs/guides/deployment.md) - Production deployment
 
 ## Technology Stack
 
 - **Runtime:** Node.js with TypeScript
-- **AI:** Claude Agent SDK (Sonnet 4.5, Haiku 4.5)
+- **AI:** Claude Agent SDK (Opus, Sonnet, Haiku)
 - **Integrations:** Slack API, GitHub App
 - **Storage:** File-based sessions
 - **VCS:** Git worktrees

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,11 +60,11 @@ Future work and unimplemented features. These are ideas that have been designed 
 
 ## Quick Reference
 
-**Message flow:** Slack/GitHub → Triage Agent (Haiku) → System → PM Agent → Specialist Agents
+**Message flow:** Slack/GitHub → PM Agent → Specialist Agents (triage agent currently disabled)
 
 **Agent types:**
-- **Triage** (Haiku) — classifies incoming events
-- **PM** (Sonnet) — manages tasks, assigns owners, communicates with users
+- ~~**Triage** (Haiku) — classifies incoming events~~ (currently disabled)
+- **PM** (Opus) — manages tasks, assigns owners, communicates with users
 - **Repo Agents** (Sonnet) — investigate and modify code in specific repositories
 - **Plugin Agents** (Sonnet) — domain-specific agents without git infrastructure
 

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -8,14 +8,16 @@ Archie uses four agent types, each backed by a specific Claude model and serving
 
 | Agent Type | Model | Count | Role |
 |---|---|---|---|
-| Triage Agent | Haiku | 1 (stateless) | Event classifier for Slack messages and GitHub PR comments |
+| ~~Triage Agent~~ | Haiku | 1 (stateless) | Event classifier for Slack messages and GitHub PR comments (**currently disabled**) |
 | PM Agent | Opus | 1 per task | Task manager, user interface, agent coordinator |
 | Repo Agents | Sonnet | 1 per repository per task | Codebase investigation and modification |
 | Plugin Agents | Sonnet (configurable) | 1 per plugin agent per task | Lightweight, read-only domain specialists |
 
-### Triage Agent
+### Triage Agent (currently disabled)
 
 **Source**: `src/system/triage.ts`
+
+> **Note**: The triage agent is currently disabled. All incoming Slack messages are routed directly to the PM agent without classification. The code and prompts remain in the codebase for potential re-enablement.
 
 The triage agent is a stateless classifier that runs once per incoming event. It does not maintain sessions or participate in task coordination. It uses the Haiku model for fast, cost-effective classification.
 
@@ -74,20 +76,7 @@ One PM agent instance is spawned per task. It is the orchestrator: it receives a
 | `Skill` | Load domain-specific PM skills from plugins |
 | `Read`, `Glob`, `Grep` | Read files in the shared task folder |
 
-**Edit mode tools** (available only after user approval):
-
-| Tool | Purpose |
-|---|---|
-| `push_branch` | Push commits from worktree to origin |
-| `create_pull_request` | Create a PR on GitHub |
-| `get_pr_status` | Check PR mergeable state |
-| `get_pr_reviews` | Fetch PR reviews and comments |
-| `update_pr_description` | Update PR body |
-| `add_pr_comment` | Add a general PR comment |
-| `add_review_comment` | Comment on a specific line of code |
-| `resolve_review_thread` | Mark a review thread as resolved |
-| `request_re_review` | Request reviewers to re-review |
-| `trigger_merge_check` | Check and merge ready PRs |
+Note: PR lifecycle tools (push, create PR, merge, etc.) have moved from the PM agent to repo agents via the `repo-tools` MCP server. The PM no longer directly manages git or GitHub operations.
 
 **Key behaviors**:
 
@@ -105,28 +94,38 @@ Repo agents are specialized for a single repository. They investigate code, make
 
 **Model**: Sonnet (with 1M context beta)
 
-**Tools** (via MCP server `repo-agent-tools`):
+**Tools** (via MCP servers `repo-agent-tools` and `repo-tools`):
 
-| Tool | Purpose |
-|---|---|
-| `send_message_to_agent` | Report findings or coordinate with peers |
-| `log_finding` | Write to shared knowledge log |
-| `web_research` | Spawn a research pipeline |
-| `Read`, `Glob`, `Grep` | Investigate repository code |
+| Tool | MCP Server | Availability | Purpose |
+|---|---|---|---|
+| `send_message_to_agent` | `repo-agent-tools` | Always | Report findings or coordinate with peers |
+| `log_finding` | `repo-agent-tools` | Always | Write to shared knowledge log |
+| `web_research` | `research-tools` | Always | Spawn a research pipeline |
+| `fetch` | `repo-tools` | Always | Fetch latest refs from origin |
+| `switch_branch` | `repo-tools` | Always | Switch branches with auto-stash/pop |
+| `list_prs` | `repo-tools` | Always | List PRs with filters |
+| `get_pr` | `repo-tools` | Always | Get full PR details including diff |
+| `get_pr_status` | `repo-tools` | Always | Check PR mergeable state |
+| `get_pr_reviews` | `repo-tools` | Always | Fetch PR reviews and comments |
+| `Read`, `Glob`, `Grep` | (built-in) | Always | Investigate repository code |
+| `git log`, `git diff`, `git show`, `git blame`, `git branch` | (Bash) | Always | Read-only git inspection |
+| `Write`, `Edit` | (built-in) | Edit mode | Modify files in the worktree |
+| `git add`, `git commit`, `git status`, `git merge`, `git restore`, `rm`, `git rm` | (Bash) | Edit mode | Stage, commit, and manage changes |
+| `push_branch` | `repo-tools` | Edit mode | Push commits to origin |
+| `create_pull_request` | `repo-tools` | Edit mode | Create a PR on GitHub |
+| `update_pr` | `repo-tools` | Edit mode | Update PR title/description |
+| `add_pr_comment` | `repo-tools` | Edit mode | Add a general PR comment |
+| `add_review_comment` | `repo-tools` | Edit mode | Comment on a specific line |
+| `resolve_review_thread` | `repo-tools` | Edit mode | Mark a review thread as resolved |
+| `request_re_review` | `repo-tools` | Edit mode | Request reviewers to re-review |
+| `merge_pull_request` | `repo-tools` | Edit mode | Merge a PR |
+| `close_pull_request` | `repo-tools` | Edit mode | Close a PR without merging |
+| `create_branch` | `repo-tools` | Edit mode | Create and switch to a new branch |
+| `list_branches` | `repo-tools` | Edit mode | List branches in the current task |
 
-**Edit mode tools** (when `metadata.edit_allowed === true`):
+**Dual mode system**: Repo agents discover their mode (read-only vs edit) from their available tools. When `Write` and `Edit` are present, they operate in edit mode. When absent, they operate in read-only mode.
 
-| Tool | Purpose |
-|---|---|
-| `Write`, `Edit` | Modify files in the worktree |
-| `git add`, `git commit` | Stage and commit changes |
-| `git status`, `git diff`, `git log` | Inspect working tree state |
-| `git merge` | Resolve conflicts with origin/main |
-| `git restore` | Unstage or discard changes |
-
-**Dual mode system**: Repo agents discover their mode (read-only vs edit) from their available tools. When `Write` and `Edit` are present, they operate in edit mode within an isolated git worktree. When absent, they operate in read-only mode on the base repository.
-
-**Working directory**: In read-only mode, the agent's cwd is the base repository path. In edit mode, it switches to the worktree path. The `additionalDirectories` option gives agents access to both the repository and the shared task folder.
+**Working directory**: The agent's cwd is always a task-local worktree at `sessions/{taskId}/repos/{repoKey}`. In read-only mode, the worktree is at detached HEAD on the base branch. In edit mode, it has a feature branch. The `additionalDirectories` option gives agents access to both the worktree and the shared task folder.
 
 ### Plugin Agents
 
@@ -221,8 +220,8 @@ Different for each agent track:
 - Repository responsibility
 - Task lifecycle context (Research, Implement, Review, Conflicts)
 - Dual mode system (Read-Only vs Edit, determined by available tools)
-- Git workflow (staging, committing, conflict resolution)
-- Restrictions (no push, no fetch, no destructive operations)
+- Git workflow: branch management (`switch_branch`, `create_branch`, `fetch`), staging, committing, PR lifecycle
+- Honesty and transparency guidelines
 - Template variables: `{{REPO_KEY}}`, `{{BASE_BRANCH}}`
 
 **Plugin agents** (`prompts/plugin-agent.md`):

--- a/docs/architecture/edit-mode.md
+++ b/docs/architecture/edit-mode.md
@@ -6,13 +6,13 @@ Archie operates in two modes: **readonly** (the default) and **edit** (after hum
 
 ### Readonly Mode (Default)
 
-When a task starts, all agents operate in readonly mode. Repo agents can read and search code using `Read`, `Glob`, and `Grep` tools, but cannot modify any files or run arbitrary commands. This is the mode used for investigation, analysis, and answering questions about the codebase.
+When a task starts, all agents operate in readonly mode. Repo agents can read and search code using `Read`, `Glob`, and `Grep` tools, plus read-only git commands (`git log`, `git diff`, `git show`, `git blame`, `git branch`) and PR read tools (`list_prs`, `get_pr`, `get_pr_status`, `get_pr_reviews`). They cannot modify any files.
 
-In readonly mode, the repo agent's `cwd` is set to the base repository path (the shared clone configured in repo agent configs).
+In readonly mode, the repo agent's `cwd` is a task-local worktree at `sessions/{taskId}/repos/{repoKey}` in detached HEAD mode at `origin/{baseBranch}`. Readonly worktrees are cleaned up when the task stops or completes.
 
 ### Edit Mode (After Approval)
 
-Once edit mode is approved for a task, repo agents gain access to file modification and local git tools. The agent's `cwd` switches to an isolated worktree, and additional tools become available. Edit mode is a one-way, permanent transition for the task -- once approved, it cannot be revoked.
+Once edit mode is approved for a task, repo agents gain access to file modification tools, local git commands, and PR write tools (push, create PR, merge, etc.). The worktree switches to a feature branch, and additional tools become available. Edit mode is a one-way, permanent transition for the task -- once approved, it cannot be revoked.
 
 ## Human-in-the-Loop Approval Flow
 
@@ -71,36 +71,52 @@ Key properties of this transition:
 
 ## Git Worktree Management
 
-When a repo agent spawns in edit mode, it operates in an isolated git worktree rather than the shared base repository. This is managed by `src/connectors/github/worktree.ts`.
+All repo agents operate in isolated git worktrees, regardless of mode. This is managed by `src/connectors/github/worktree.ts`.
 
 ### `setupWorktree()`
 
-The `setupWorktree()` function creates a new worktree for a repository in a task:
+The `setupWorktree()` function creates a new worktree for a repository in a task. It accepts a `WorktreeCheckout` parameter that determines the checkout mode:
 
+```typescript
+type WorktreeCheckout =
+  | { type: 'detached'; sha?: string }    // Detached HEAD at origin/{baseBranch} or specific SHA
+  | { type: 'branch'; name: string }       // Checkout existing branch (normal)
+  | { type: 'new_branch'; name: string };  // Create new branch from origin/{baseBranch}
+```
+
+Steps:
 1. **Base branch detection**: Uses the provided `baseBranch` parameter, or auto-detects by checking `refs/remotes/origin/HEAD`, then falling back to `origin/main`, then `origin/master`.
-2. **Fetch latest**: Calls `fetchOrigin()` to pull the latest commits for the base branch.
-3. **Feature branch naming**: Creates a branch named `feature/{taskId}` (e.g., `feature/task-01012026-1823-abc123`). The task ID already includes the `task-` prefix.
-4. **Worktree creation**: Runs `git worktree add -b {featureBranch} "{worktreePath}" origin/{baseBranch}` to create the worktree with a new branch based on the latest remote base.
-5. **Existing branch handling**: If the feature branch already exists (e.g., task recovery), it checks for an existing worktree first, then falls back to creating a worktree with the existing branch.
+2. **Fetch latest**: Calls `fetchOrigin(baseRepoPath, baseBranch)` to pull the latest commits for the base branch.
+3. **Worktree creation**: Creates the worktree using the appropriate git command based on checkout type:
+   - `detached`: `git worktree add --detach "{path}" origin/{baseBranch}` (or specific SHA)
+   - `branch`: `git worktree add "{path}" {branchName}`
+   - `new_branch`: `git worktree add -b {branchName} "{path}" origin/{baseBranch}`
+4. **Existing branch handling**: If a `new_branch` already exists (e.g., task recovery), it checks for an existing worktree first, then falls back to creating a worktree with the existing branch.
 
 The worktree is placed at `sessions/{taskId}/repos/{repoKey}` (e.g., `sessions/task-abc123/repos/backend`).
 
-### Lazy Worktree Creation
+### Worktree Creation at Spawn
 
-Worktrees are **not** created when edit mode is approved. They are created lazily when a repo agent is actually spawned in edit mode. This happens inside `spawnRepoAgent()` in `src/agents/spawn.ts`:
+Worktrees are created when a repo agent is spawned. This happens inside the repo track branch of `spawnAgent()` in `src/agents/spawn.ts`:
 
 ```
-spawnRepoAgent() called
-  -> Check metadata.edit_allowed
-  -> If true:
-    -> Check if worktree already exists (repoInfo.worktree_path)
-    -> If yes: reuse existing worktree, fetch origin for latest base
-    -> If no:  call setupWorktree(), update metadata with worktree info
-  -> If false:
-    -> Use base repo path in readonly mode
+spawnAgent() called (repo track)
+  -> Check if worktree already exists at task-local path
+  -> If yes: reuse existing worktree, fetch origin for latest base
+  -> If no:
+    -> Determine checkout target from previous branch state + edit mode:
+      - edit_allowed && no previous branch: new_branch (feature/{taskId})
+      - had an owned branch: branch (restore it)
+      - was on existing branch: detached at recorded SHA
+      - default: detached HEAD at base branch
+    -> Call setupWorktree() with the checkout target
+    -> Update metadata with worktree info and branch state
+    -> Start a fresh SDK session (cwd changed)
 ```
 
-This means the worktree is created on-demand the first time an agent needs it after approval, not at approval time. This is important because edit mode approval may happen while no agents are running.
+### Worktree Cleanup
+
+When a readonly task stops or completes, the `removeWorktree()` function (`src/connectors/github/worktree.ts`) is called to clean up the worktree from the base repository. This uses `git worktree remove --force` and falls back to `git worktree prune` if the directory is already gone.
 
 ### Worktree Metadata
 
@@ -108,17 +124,41 @@ After worktree creation, the following fields are stored in `metadata.repositori
 
 ```typescript
 interface RepositoryInfo {
-  path: string;               // Base repository path
-  worktree_path?: string;     // Path to active worktree (edit mode)
-  feature_branch?: string;    // Branch name in worktree (feature/task-{id})
-  base_branch?: string;       // Base branch (main, master, etc.)
-  pr_number?: number;         // PR number for this repo in this task
+  path: string;                                    // Base repository path
+  worktree_path?: string;                          // Path to active worktree
+  current_branch?: string;                         // Branch agent is on (key into branch_states)
+  branch_states?: Record<string, BranchState>;     // Per-branch tracking
+  // Legacy fields (mirrored from current branch state for rollback safety):
+  feature_branch?: string;
+  base_branch?: string;
+  pr_number?: number;
+  last_processed_comment_id?: number;
 }
 ```
 
+### Per-Branch State (`BranchState`)
+
+Each branch the agent creates or visits is tracked independently:
+
+```typescript
+interface BranchState {
+  owned: boolean;                      // true = agent created, false = existing branch
+  head_sha: string;                    // HEAD position when agent last left this branch
+  base_branch?: string;                // PR target branch (e.g. 'main')
+  pr_number?: number;                  // PR associated with this branch
+  last_processed_comment_id?: number;  // GitHub comment triage cursor
+  stash_name?: string;                 // Set if dirty work was auto-stashed
+}
+```
+
+Branch state helpers live in `src/connectors/github/branch-state.ts`:
+- `hydrateBranchState()` -- initialize `branch_states` from a newly created branch
+- `mirrorLegacyFields()` -- sync current branch state to legacy top-level fields
+- `findBranchStateByPR()` -- look up a branch by its PR number (for webhook routing)
+
 ## Tool Restrictions
 
-The allowed tools for a repo agent are determined at spawn time based on the `edit_allowed` flag. In `src/agents/spawn.ts` (via `src/agents/agent.ts`), the `allowedTools` array is constructed conditionally:
+The allowed tools for a repo agent are determined at spawn time based on the `edit_allowed` flag. In `src/agents/spawn.ts`, the `allowedTools` array is constructed conditionally:
 
 ### Readonly Mode Tools
 - `Read` -- Read file contents
@@ -127,19 +167,44 @@ The allowed tools for a repo agent are determined at spawn time based on the `ed
 - `mcp__repo-agent-tools__send_message_to_agent` -- Inter-agent communication
 - `mcp__repo-agent-tools__log_finding` -- Write to shared knowledge log
 - `mcp__research-tools__web_research` -- Web research
+- `mcp__repo-tools__fetch` -- Fetch latest refs from origin
+- `mcp__repo-tools__switch_branch` -- Switch branches with auto-stash
+- `mcp__repo-tools__list_prs` -- List PRs with filters
+- `mcp__repo-tools__get_pr` -- Get full PR details including diff
+- `mcp__repo-tools__get_pr_status` -- Check PR mergeable state
+- `mcp__repo-tools__get_pr_reviews` -- Fetch PR reviews and comments
+- `Bash(git log*)` -- View commit history
+- `Bash(git diff*)` -- View changes
+- `Bash(git show *)` -- Inspect commits
+- `Bash(git blame *)` -- Line-by-line attribution
+- `Bash(git branch -r*)` -- List remote branches
+- `Bash(git branch --show-current)` -- Show current branch name
+- `Bash(git ls-files*)` -- List tracked files
+- `Bash(git ls-tree *)` -- List tree contents
 
 ### Edit Mode Additional Tools
 - `Write` -- Write entire file contents
 - `Edit` -- Make targeted edits to files
-- `Bash(git add:*)` -- Stage changes
-- `Bash(git commit:*)` -- Create commits
-- `Bash(git status:*)` -- Check working tree status
-- `Bash(git diff:*)` -- View changes
-- `Bash(git log:*)` -- View commit history
-- `Bash(git merge:*)` -- Merge branches (for conflict resolution with origin/main)
-- `Bash(git restore:*)` -- Unstage or discard changes
+- `Bash(rm *)` -- Delete files
+- `Bash(git add *)` -- Stage changes
+- `Bash(git rm *)` -- Remove tracked files
+- `Bash(git commit *)` -- Create commits
+- `Bash(git status*)` -- Check working tree status
+- `Bash(git merge *)` -- Merge branches (for conflict resolution with origin/main)
+- `Bash(git restore *)` -- Unstage or discard changes
+- `mcp__repo-tools__push_branch` -- Push commits to origin
+- `mcp__repo-tools__create_pull_request` -- Create a PR on GitHub
+- `mcp__repo-tools__update_pr` -- Update PR title/description
+- `mcp__repo-tools__add_pr_comment` -- Add a general PR comment
+- `mcp__repo-tools__add_review_comment` -- Comment on a specific line
+- `mcp__repo-tools__resolve_review_thread` -- Mark a review thread as resolved
+- `mcp__repo-tools__request_re_review` -- Request reviewers to re-review
+- `mcp__repo-tools__merge_pull_request` -- Merge a PR
+- `mcp__repo-tools__close_pull_request` -- Close a PR without merging
+- `mcp__repo-tools__create_branch` -- Create and switch to a new branch
+- `mcp__repo-tools__list_branches` -- List branches in the current task
 
-Note that `git push` and `git fetch` are not available to repo agents. Remote operations are handled exclusively by the PM agent via the `push_branch` MCP tool (see [GitHub Integration](./github-integration.md)).
+Note: Bash permission patterns use space syntax (e.g., `Bash(git add *)`) not colon syntax.
 
 ## Branch Strategy
 
@@ -172,17 +237,18 @@ Key isolation properties:
 
 ## Session Handling on Mode Transition
 
-When a repo agent transitions from readonly to edit mode (worktree created for the first time), the agent's working directory changes from the base repo to the worktree. Since the `cwd` change is not a child path of the original, `spawnAgent()` sets `startFreshSession = true`, which causes the agent to start a fresh Claude Agent SDK session instead of resuming the previous one. This ensures the agent's filesystem context is correct for the new working directory.
+When a new worktree is created (either for a fresh readonly task or after edit mode approval), `spawnAgent()` sets `startFreshSession = true`, which causes the agent to start a fresh Claude Agent SDK session. This ensures the agent's filesystem context is correct for the new working directory.
 
-If the worktree already exists (e.g., task was stopped and reactivated), the existing session ID is reused and the agent fetches the latest origin to ensure `origin/main` is up-to-date for potential conflict resolution.
+If the worktree already exists (e.g., task was stopped and reactivated), the existing session ID is reused and the agent fetches the latest origin to ensure remote refs are up-to-date.
 
 ## Relevant Source Files
 
-- `src/connectors/github/worktree.ts` -- `setupWorktree()`, `worktreeExists()`, `getWorktreeBranch()`, base branch detection
-- `src/agents/spawn.ts` -- `spawnRepoAgent()` with edit mode logic, tool restriction, worktree creation trigger
-- `src/tasks/task.ts` -- `onRequestEditMode` callback, `handleEditModeApproval()`, `handleEditModeDenial()`
+- `src/connectors/github/worktree.ts` -- `setupWorktree()`, `removeWorktree()`, `worktreeExists()`, `getWorktreeBranch()`, `WorktreeCheckout` type, base branch detection
+- `src/connectors/github/branch-state.ts` -- `hydrateBranchState()`, `mirrorLegacyFields()`, `findBranchStateByPR()` (per-branch state helpers)
+- `src/agents/spawn.ts` -- `spawnAgent()` with repo track logic, tool restriction, worktree creation trigger
+- `src/agents/tools.ts` -- `repo-tools` MCP server (git workflow + PR tools), `request_edit_mode` tool definition
+- `src/tasks/task.ts` -- `handleEditModeApproval()`, `handleEditModeDenial()`
 - `src/connectors/slack/events.ts` -- `approve_edit_mode` and `deny_edit_mode` Bolt action handlers
-- `src/agents/tools.ts` -- `request_edit_mode` tool definition
-- `src/types/task.ts` -- `TaskMetadata.edit_allowed`, `RepositoryInfo` with worktree fields
-- `src/connectors/github/client.ts` -- `configureGitIdentity()`, `fetchOrigin()`
+- `src/types/task.ts` -- `TaskMetadata.edit_allowed`, `RepositoryInfo` with `branch_states`, `BranchState` type
+- `src/connectors/github/client.ts` -- `configureGitIdentity()`, `fetchOrigin()` (with optional branch parameter)
 - `src/connectors/github/webhooks.ts` -- `extractTaskIdFromBranch()` for branch-to-task mapping

--- a/docs/architecture/github-integration.md
+++ b/docs/architecture/github-integration.md
@@ -93,24 +93,38 @@ These messages are written to the task's knowledge log so the PM agent can under
 
 ## GitHub MCP Tools
 
-The PM agent has access to a suite of GitHub tools defined in `src/agents/tools.ts`. These tools are callback-based -- the tool definitions call into `PMToolCallbacks`, and the actual implementations live in `src/tasks/task.ts`.
+GitHub and git tools are exposed to **repo agents** via the `repo-tools` MCP server, defined in `src/agents/tools.ts` (`createRepoToolsMcpServer`). Access is controlled at spawn time by the `allowedTools` list: read tools are always available, write tools are gated on `edit_allowed`.
 
-### Available Tools
+### Available Tools (via `repo-tools` MCP server)
+
+**Always available (read-only and edit mode):**
 
 | Tool | Description |
 |---|---|
-| `push_branch` | Push commits from a worktree to origin. Takes a `repo_key` (e.g., "backend"). Uses `git push -u origin HEAD:{branch}` via CLI. |
-| `create_pull_request` | Create a PR on GitHub. Takes `repo_key`, `title`, `body`. Stores the PR number in task metadata for tracking. |
+| `fetch` | Fetch latest refs from origin. |
+| `switch_branch` | Switch to a different branch. Auto-stashes dirty work, auto-pops on return. |
+| `list_prs` | List pull requests with optional filters (state, base, sort, limit). |
+| `get_pr` | Get full PR details: title, description, diff, state, and branches. |
 | `get_pr_status` | Get PR state, mergeable status, and approval status. Returns `state`, `mergeable`, `mergeableState`, `approved`. |
 | `get_pr_reviews` | Fetch all reviews and inline comments on a PR. Groups comments by review and includes file paths and line numbers. |
-| `update_pr_description` | Update the body/description of an existing PR. |
+
+**Edit mode only:**
+
+| Tool | Description |
+|---|---|
+| `push_branch` | Push commits from the local worktree to origin. Uses `git push -u origin HEAD:{branch}` for owned branches. |
+| `create_pull_request` | Create a PR on GitHub. Stores the PR number in the current branch's `BranchState`. |
+| `update_pr` | Update the title and/or description of an existing PR (both fields optional). |
 | `add_pr_comment` | Add a general comment to a PR (issue comment). |
 | `add_review_comment` | Add a comment on a specific file and line in a PR diff. |
 | `resolve_review_thread` | Mark a review comment thread as resolved (placeholder -- requires GraphQL in production). |
 | `request_re_review` | Request re-review from all previous reviewers. Fetches existing reviewers and sends review requests. |
-| `trigger_merge_check` | Manually trigger the merge orchestrator. Returns merged, pending, and conflicted PR lists. |
+| `merge_pull_request` | Merge a pull request. Checks mergeability first and returns status if not ready. |
+| `close_pull_request` | Close a pull request without merging. |
+| `create_branch` | Create a new branch (auto-named from task ID) and switch to it. |
+| `list_branches` | List branches created or visited by this agent in the current task. |
 
-All tools that take a `repo_key` parameter dynamically build the allowed values from loaded repo agent configurations.
+Each repo agent's tools are scoped to its own repository (the `githubRepo` from the agent's config). PR numbers are stored per-branch in `BranchState.pr_number`.
 
 ## Merge Orchestrator
 
@@ -121,7 +135,7 @@ The merge orchestrator (`src/connectors/github/merge.ts`) is a system-level comp
 The merge orchestrator is triggered by:
 
 1. **Webhook events** -- Via `handleMergeCheckDirect()` on PR approval, push, CI completion.
-2. **PM tool call** -- Via `trigger_merge_check` MCP tool.
+2. **Repo agent tool call** -- Repo agents can merge individual PRs via the `merge_pull_request` tool on the `repo-tools` MCP server. The merge orchestrator runs automatically for webhook-triggered checks.
 
 ### Debouncing
 
@@ -129,7 +143,7 @@ Webhook-triggered merge checks are debounced per task with a 5-second delay (`ME
 
 ### Merge Logic
 
-`triggerMergeCheck()` collects all PRs linked to a task (from `metadata.repositories[repoKey].pr_number`) and categorizes them:
+`triggerMergeCheck()` collects all PRs linked to a task (from `branch_states` across all repositories, with legacy fallback to `repoInfo.pr_number`) and categorizes them:
 
 | Category | Criteria | Action |
 |---|---|---|
@@ -142,16 +156,25 @@ The `blocked` + `mergeable=true` case handles a known GitHub Rulesets issue wher
 
 ### Linked PR Checking
 
-A single task can have PRs across multiple repositories. The orchestrator checks all of them together. PRs are linked via the `pr_number` field in `RepositoryInfo`:
+A single task can have PRs across multiple repositories and multiple branches. The orchestrator collects all PRs from `branch_states` across all repositories:
 
 ```typescript
-interface RepositoryInfo {
-  pr_number?: number;  // PR number for this repo in this task
-  // ...
+// From src/connectors/github/merge.ts
+for (const [repoKey, repoInfo] of Object.entries(task.metadata.repositories)) {
+  if (repoInfo.branch_states) {
+    for (const state of Object.values(repoInfo.branch_states)) {
+      if (state.pr_number) {
+        linkedPRs.push({ repoKey, prNumber: state.pr_number });
+      }
+    }
+  } else if (repoInfo.pr_number) {
+    // Legacy fallback for tasks created before branch_states
+    linkedPRs.push({ repoKey, prNumber: repoInfo.pr_number });
+  }
 }
 ```
 
-PR numbers are stored when the PM calls `create_pull_request` and are referenced in log entries using the `repo#123` format (e.g., `backend#42`).
+PR numbers are stored when a repo agent calls `create_pull_request` and are referenced in log entries using the `repo#123` format (e.g., `backend#42`).
 
 ### PM Notification
 
@@ -200,11 +223,11 @@ The system is designed so that the PM agent is only reactivated for GitHub event
 
 ## Relevant Source Files
 
-- `src/connectors/github/client.ts` -- GitHubClient class, Octokit wrapper, git identity configuration, GIT_ASKPASS
+- `src/connectors/github/client.ts` -- GitHubClient class, Octokit wrapper, git identity configuration, GIT_ASKPASS, `listPRs`, `getPRDetails`, `mergePullRequest`, `closePullRequest`
 - `src/connectors/github/events.ts` -- GitHub webhook dispatch, triage processing (`processGitHubTriage`)
 - `src/connectors/github/webhooks.ts` -- Signature verification, deterministic routing, context extraction, event formatting, merge check debouncing
-- `src/connectors/github/merge.ts` -- Auto-merge logic, linked PR checking, PM notification
-- `src/connectors/github/worktree.ts` -- Git worktree lifecycle
-- `src/agents/tools.ts` -- GitHub MCP tool definitions (PM agent tools)
-- `src/tasks/task.ts` -- GitHub tool callback implementations (`onPushBranch`, `onCreatePullRequest`, etc.)
-- `src/types/task.ts` -- `RepositoryInfo` type with PR tracking fields
+- `src/connectors/github/merge.ts` -- Auto-merge logic, linked PR checking (reads from `branch_states`), PM notification
+- `src/connectors/github/worktree.ts` -- Git worktree lifecycle (`setupWorktree`, `removeWorktree`, `WorktreeCheckout`)
+- `src/connectors/github/branch-state.ts` -- Per-branch state helpers (`hydrateBranchState`, `mirrorLegacyFields`, `findBranchStateByPR`)
+- `src/agents/tools.ts` -- `repo-tools` MCP server (git workflow + PR tools for repo agents), `pm-agent-tools` MCP server
+- `src/types/task.ts` -- `RepositoryInfo` with `branch_states`, `BranchState` type with per-branch PR tracking

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -178,9 +178,12 @@ It is idempotent: if the agent is already in `task.spawned`, it returns immediat
 
 ```
 task.ensureAgentSpawned(agentName)
-  --> create tool callbacks
   --> check for existing session ID (for SDK resume)
-  --> spawnAgent() in src/agents/spawn.ts handles all agent types
+  --> spawnAgent() in src/agents/spawn.ts handles all agent types:
+      --> updateAgentState(active) early to prevent false idle detection
+      --> build track-specific config (prompt, cwd, tools, MCP servers)
+      --> for repo track: create worktree if needed
+      --> start SDK query() with session recovery loop
   --> register handle in task.handles
   --> add to task.spawned
   --> attach crash handler: handle.running.then(() => updateAgentState(inactive))
@@ -221,29 +224,45 @@ Tools are defined in `src/agents/tools.ts` and exposed via MCP servers created p
 | `report_completion` | Optionally post to Slack, then complete the task |
 | `request_edit_mode` | Post Approve/Deny buttons to Slack, pause task until response |
 | `get_agents_status` | Return active/idle status of all spawned agents |
-| `push_branch` | Push commits from local worktree to origin (GIT_ASKPASS auth) |
-| `create_pull_request` | Create a GitHub PR and store PR number in metadata |
-| `get_pr_status` | Get PR state, mergeable status, approval status |
-| `get_pr_reviews` | Fetch all reviews and line-level comments on a PR |
-| `update_pr_description` | Update the body of a PR |
-| `add_pr_comment` | Add a general comment to a PR |
-| `add_review_comment` | Add a comment on a specific file line in a PR |
-| `resolve_review_thread` | Mark a review comment thread as resolved |
-| `request_re_review` | Request reviewers to re-review after changes |
-| `trigger_merge_check` | Check all linked PRs and merge any that are ready |
 
-### Repo Agent Tools (via `createRepoAgentMcpServer`)
+### Base Agent Tools (via `createBaseAgentMcpServer`, named `repo-agent-tools`)
+
+Used by both repo agents and plugin agents:
 
 | Tool | Description |
 |---|---|
 | `send_message_to_agent` | Send a message to another agent |
 | `log_finding` | Write an entry to the shared knowledge log (discovery, decision, completion, blocker) |
 
-### Callback architecture
+### Repo Tools (via `createRepoToolsMcpServer`, named `repo-tools`)
 
-All tools delegate to callback functions (`PMToolCallbacks` / `RepoAgentToolCallbacks`)
-created per agent per task by `task.createToolCallbacks()` in `src/tasks/task.ts`. This
-decouples tool definitions from runtime state, enabling testing and isolation.
+Used by repo agents only. Access controlled by `allowedTools` at spawn time:
+
+| Tool | Availability | Description |
+|---|---|---|
+| `fetch` | Always | Fetch latest refs from origin |
+| `switch_branch` | Always | Switch branches with auto-stash/pop |
+| `list_prs` | Always | List PRs with optional filters |
+| `get_pr` | Always | Get full PR details including diff |
+| `get_pr_status` | Always | Get PR state, mergeable status, approval status |
+| `get_pr_reviews` | Always | Fetch all reviews and line-level comments on a PR |
+| `push_branch` | Edit mode | Push commits from local worktree to origin |
+| `create_pull_request` | Edit mode | Create a GitHub PR and store PR number in branch state |
+| `update_pr` | Edit mode | Update the title and/or description of a PR |
+| `add_pr_comment` | Edit mode | Add a general comment to a PR |
+| `add_review_comment` | Edit mode | Add a comment on a specific file line in a PR |
+| `resolve_review_thread` | Edit mode | Mark a review comment thread as resolved |
+| `request_re_review` | Edit mode | Request reviewers to re-review after changes |
+| `merge_pull_request` | Edit mode | Merge a PR (checks mergeability first) |
+| `close_pull_request` | Edit mode | Close a PR without merging |
+| `create_branch` | Edit mode | Create a new branch (auto-named) and switch to it |
+| `list_branches` | Edit mode | List branches in the current task |
+
+### Tool architecture
+
+Tools are defined as self-contained functions in `src/agents/tools.ts`. Each tool receives
+the `Agent` and `Task` instances directly, importing external systems (GitHub, Slack,
+persistence) as needed. The MCP servers are created per agent per task at spawn time.
 
 ### Research budget (Defense 4)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -27,8 +27,8 @@ Archie (Autonomous Responsive and Collaborative Hyper Intelligent Employee) is a
               └──────┬──────┘  └────────┬────────┘
                      │                  │
                     ┌▼──────────────────▼─────┐
-                    │     Triage Agent        │
-                    │  (Haiku — classifier)   │
+                    │   Triage Agent          │
+                    │  (Haiku — disabled)     │
                     └────────────┬────────────┘
                                  │
 ─────────────────────────────────┼─────────────────── Task Layer
@@ -63,11 +63,11 @@ Archie (Autonomous Responsive and Collaborative Hyper Intelligent Employee) is a
 | Component | Technology |
 |---|---|
 | Runtime | Node.js >= 20, TypeScript, ES modules |
-| Agent Framework | `@anthropic-ai/claude-agent-sdk` ^0.1.0 |
-| Models | Haiku (triage), Opus (PM), Sonnet (repo agents, plugin agents, research) |
+| Agent Framework | `@anthropic-ai/claude-agent-sdk` ^0.2.77 |
+| Models | Opus (PM), Sonnet (repo agents, plugin agents, research). Haiku (triage — currently disabled) |
 | Slack Integration | `@slack/bolt` ^4.6.0, `@slack/web-api` ^7.0.0 |
 | GitHub Integration | `@octokit/app` ^16.1.2, `@octokit/webhooks` ^14.2.0 |
-| Schema Validation | `zod` ^3.22.0, `zod-to-json-schema` ^3.25.0 |
+| Schema Validation | `zod` ^4.3.6, `zod-to-json-schema` ^3.25.0 |
 | Prompt Parsing | `gray-matter` ^4.0.3 (frontmatter extraction) |
 | Markdown | `slackify-markdown` ^4.5.0 (Slack formatting) |
 | Build | `tsc` (TypeScript compiler), `tsx` (dev mode) |
@@ -101,16 +101,18 @@ Each task gets its own `Task` instance (a class that encapsulates runtime state)
 
 ### Git Worktrees
 
-In edit mode, repo agents work in isolated git worktrees (`src/connectors/github/worktree.ts`). Each worktree gets a feature branch (`feature/task-{taskId}`) based on the repository's default branch. Agents commit locally; the PM agent handles `git push`, PR creation, and remote operations via GitHub API.
+All repo agents work in isolated git worktrees (`src/connectors/github/worktree.ts`), regardless of mode. In **readonly mode**, the worktree is created in detached HEAD at `origin/{baseBranch}`. In **edit mode**, the worktree has a feature branch (`feature/task-{taskId}`) based on the repository's default branch. Agents can track multiple branches per worktree via `BranchState` records. Agents commit locally and manage their own PRs via `repo-tools` MCP server; worktrees for readonly tasks are cleaned up on task stop/complete.
 
 ### Plugin Architecture
 
 Agents and capabilities are loaded dynamically from a `plugins/` directory (`src/system/plugin-loader.ts`). Each plugin can provide:
 
-- **Repo agents**: Via `repo-config.json` (infrastructure config) + `agents/*.md` (identity/prompts)
-- **Plugin agents**: Via `agents/*.md` in plugins without `repo-config.json` (lightweight, read-only)
-- **PM skills**: Via `pm-skills/` directories (domain-specific workflows symlinked into task workspaces)
+- **Repo agents**: Via `agents/*.md` with repo metadata in frontmatter (or legacy `repo-config.json`)
+- **Plugin agents**: Via `agents/*.md` without repo metadata (lightweight, read-only)
+- **PM overlay**: Via `pm/` plugin (`agents/pm.md` body appended to PM prompt)
 - **Agent skills**: Via `skills/` directories (agent-specific capabilities symlinked at spawn)
+- **Hooks**: Via `hooks/hooks.json` (plugin-defined hooks injected into agent settings)
+- **MCP servers**: Via root `.mcp.json` (agent frontmatter references server names)
 
 See [plugin-system.md](plugin-system.md) for details.
 
@@ -125,14 +127,9 @@ See [plugin-system.md](plugin-system.md) for details.
 2. Route filters (bot messages)
    → routeSlackEvent() discards own bot messages or passes through
 
-3. Triage Agent classifies (Haiku, structured JSON output)
-   → new_task | existing_task | cancel_task | noop
-
-4. Event handler routes based on triage result:
-   → new_task:      Task.createFromSlackThread() → task.sendMessage(pm-agent)
-   → existing_task: Task.get()   → append to knowledge.log → task.sendMessage(pm-agent)
-   → cancel_task:   task.stop()  → post cancellation to Slack
-   → noop:          no action
+3. Message routed directly to PM (triage agent is currently disabled)
+   → New thread: Task.createFromSlackThread() → task.sendMessage(pm-agent)
+   → Existing thread: Task.get() → append to knowledge.log → task.sendMessage(pm-agent)
 
 5. PM Agent processes input:
    → Reads knowledge.log for context
@@ -154,10 +151,9 @@ See [plugin-system.md](plugin-system.md) for details.
 
 2. connectors/github/webhooks.ts performs deterministic routing:
    → Matches task by branch name (feature/task-{id}) or PR number
-   → Routes to: triage (comments), direct (reviews, CI), merge_check, or discard
+   → Routes to: direct (reviews, CI, comments), merge_check, or discard
 
-3. For PR comments: Triage Agent classifies (existing_task or noop)
-4. For deterministic events: Direct routing to PM agent
+3. Events routed directly to PM agent (triage currently disabled for GitHub too)
 5. For merge checks: Merge orchestrator evaluates and merges if ready
 ```
 
@@ -178,7 +174,8 @@ src/
 │       ├── events.ts            # GitHub webhook dispatch, triage processing
 │       ├── webhooks.ts          # Signature verification, routing, context extraction, formatting
 │       ├── merge.ts             # PR merge logic, linked PR checking
-│       └── worktree.ts          # Git worktree lifecycle
+│       ├── worktree.ts          # Git worktree lifecycle (setup, remove, detached/branch modes)
+│       └── branch-state.ts      # Per-branch state helpers (hydrate, mirror legacy, find by PR)
 ├── agents/
 │   ├── agent.ts                 # Agent class: prompt composition, spawning, session management
 │   ├── spawn.ts                 # Agent spawn entrypoint, worktree setup, tool wiring
@@ -193,7 +190,7 @@ src/
 ├── system/
 │   ├── shutdown.ts              # Shutdown state (getIsShuttingDown / setShuttingDown)
 │   ├── logger.ts                # Unified color-coded logger
-│   ├── triage.ts                # Triage agent (Haiku classifier for Slack/GitHub)
+│   ├── triage.ts                # Triage agent (Haiku classifier — currently disabled)
 │   ├── plugin-loader.ts         # Plugin directory scanner
 │   └── workdir.ts               # Bootstrap: path constants, clone/pull/fetch helpers
 ├── mcp/

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -32,10 +32,14 @@ sessions/
       memory/                              # agent memory (created at task init)
       attachments/                         # downloaded Slack file attachments
         {file_id}-{filename}               # e.g. F08ABC123-screenshot.png
-      .claude/
-        skills/                            # symlinked PM skills from plugins
-          {namespacedSkillName} -> ...     # symlink to plugin skill source
-    repos/                                 # git worktrees for edit mode (created on demand)
+    agents/
+      pm/                                  # PM agent workspace
+        .claude/
+          skills/                          # symlinked PM skills from plugins
+      {agentKey}/                          # Plugin agent workspaces
+        .claude/
+          skills/                          # symlinked agent skills
+    repos/                                 # git worktrees (always created; detached HEAD for RO, feature branch for RW)
 ```
 
 ### Path helpers (`src/tasks/persistence.ts`)
@@ -74,7 +78,9 @@ interface TaskMetadata {
   task_id: string;                              // e.g. "task-20251223-1712-a3f9k2"
   task_owner: AgentName | null;                 // agent leading the task, or null
   participants: AgentName[];                    // all agents that have participated
-  slack_threads: SlackThread[];                 // linked Slack threads
+  channels: Record<string, Channel>;            // active message delivery targets, keyed by channel ID
+  default_channel: string | null;               // channel ID of originating channel
+  slack_threads?: SlackThreadRef[];             // legacy — only on old tasks, removed after migration
   agent_sessions: Record<string, AgentSessionState | string>;  // per-agent session state
   repositories: Record<string, RepositoryInfo>; // per-repo metadata
   status: TaskStatus;                           // 'in_progress' | 'stopped' | 'completed'
@@ -87,30 +93,72 @@ interface TaskMetadata {
 }
 ```
 
-### SlackThread
+### Channel (replaces legacy `slack_threads`)
 
 ```typescript
-interface SlackThread {
+type Channel = SlackChannel | GitHubChannel;
+
+interface SlackChannel {
+  type: 'slack';
   thread_id: string;        // Slack thread timestamp ID
   channel_id: string;       // Slack channel ID
+  channel_name: string;     // Human-readable channel name
   last_processed_ts: string; // timestamp of last processed message (for dedup)
 }
+
+interface GitHubChannel {
+  type: 'github';
+  repo: string;             // GitHub repo identifier
+  pr_number: number;        // PR number
+}
 ```
+
+The `channels` field is keyed by a unique channel ID (e.g., `"{channel_id}:{thread_id}"` for Slack). The `default_channel` field identifies the originating channel. Legacy `slack_threads` arrays are migrated on first load.
+
+### SlackThreadRef (legacy)
+
+```typescript
+interface SlackThreadRef {
+  thread_id: string;
+  channel_id: string;
+  last_processed_ts: string;
+}
+```
+
+Present only on old tasks loaded from disk. Migrated to `channels` on first access.
 
 ### RepositoryInfo
 
 ```typescript
 interface RepositoryInfo {
-  path: string;                          // default repo path on disk
+  path: string;                                    // base repo path on disk
+  worktree_path?: string;                          // path to task-local worktree
+  current_branch?: string;                         // branch agent is on (key into branch_states)
+  branch_states?: Record<string, BranchState>;     // per-branch tracking
+  // Legacy fields (mirrored from current branch state for rollback safety):
   branch?: string;
-  base_branch?: string;                  // target branch for PRs (e.g. "main")
+  base_branch?: string;
   base_sha?: string;
-  worktree_path?: string;               // path to git worktree (edit mode)
-  feature_branch?: string;              // branch name (e.g. "feature/task-{id}")
-  pr_number?: number;                   // GitHub PR number
-  last_processed_comment_id?: number;   // dedup cursor for GitHub PR comments
+  feature_branch?: string;
+  pr_number?: number;
+  last_processed_comment_id?: number;
 }
 ```
+
+### BranchState
+
+```typescript
+interface BranchState {
+  owned: boolean;                      // true = agent created, false = existing branch (detached HEAD)
+  head_sha: string;                    // HEAD position when agent last left this branch
+  base_branch?: string;                // PR target branch (e.g. 'main', 'master')
+  pr_number?: number;                  // PR associated with this branch
+  last_processed_comment_id?: number;  // triage tracking for this branch's PR
+  stash_name?: string;                 // set if dirty work was auto-stashed when leaving
+}
+```
+
+Branch state tracks each branch the agent creates or visits. The `owned` flag distinguishes agent-created branches (checked out normally) from existing branches (visited in detached HEAD mode). Legacy top-level fields (`feature_branch`, `pr_number`, etc.) are mirrored from the current branch state by `mirrorLegacyFields()` in `src/connectors/github/branch-state.ts` for backward compatibility.
 
 ### AgentSessionState
 
@@ -252,7 +300,7 @@ timestamp of the most recently processed message in that thread.
 
 When a new Slack thread is linked to an existing task (`handleExistingTask()` in
 `connectors/slack/events.ts`), the full thread history is appended to the knowledge log and the
-thread is added to `metadata.slack_threads` with `last_processed_ts` set to the
+thread is added to `metadata.channels` as a `SlackChannel` with `last_processed_ts` set to the
 current message's timestamp.
 
 ### Existing thread
@@ -274,9 +322,11 @@ existingThread.last_processed_ts = message.ts;
 
 ### GitHub comment deduplication
 
-Similarly, `RepositoryInfo.last_processed_comment_id` tracks the most recently
+Similarly, `BranchState.last_processed_comment_id` (per-branch) tracks the most recently
 processed GitHub PR comment ID. When GitHub triage fires, only comments with
-`id > last_processed_comment_id` are appended to the knowledge log.
+`id > last_processed_comment_id` are appended to the knowledge log. The legacy
+`RepositoryInfo.last_processed_comment_id` is still supported for backward compatibility
+and mirrored from the current branch state.
 
 ---
 

--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -6,12 +6,12 @@ Archie uses a plugin-based architecture to define agents and their capabilities.
 
 ### Repo Agent Track (Engineering)
 
-Repo agents are tied to a specific Git repository and have access to git infrastructure (worktrees, branches, PRs). They operate in either read-only or edit mode depending on task state.
+Repo agents are tied to a specific Git repository and have access to git infrastructure (worktrees, branches, PRs via `repo-tools` MCP server). They operate in either read-only or edit mode depending on task state.
 
-- Defined by a `repo-config.json` in the plugin directory
-- Each key in `repo-config.json` becomes an agent (e.g., `"backend"` becomes `backend-agent`)
-- Infrastructure config (GitHub repo, base branch, repo path) comes from `repo-config.json`
-- Agent identity and domain instructions come from the `agents/*.md` file referenced by the `prompt` field
+- Identified by `metadata.archie.repo` in their markdown frontmatter (or legacy `repo-config.json`)
+- Each `agents/*.md` file with repo metadata becomes an agent (e.g., `backend.md` becomes `backend-agent`)
+- Infrastructure config (GitHub repo, base branch) comes from frontmatter `metadata.archie.repo`
+- Agent identity and domain instructions come from the frontmatter and markdown body
 
 **Source:** `src/agents/spawn.ts`, `src/agents/registry.ts`, `src/types/agent.ts`
 
@@ -23,41 +23,76 @@ Plugin agents are lightweight, read-only agents for domains that do not need git
 - Each `.md` file becomes an agent (e.g., `agents/copywriter.md` becomes `copywriter-agent`)
 - Agent identity, expertise, and optional model override come from frontmatter
 - Domain-specific instructions come from the markdown body
-- Tools: `Read`, `Glob`, `Grep`, `Skill`, `send_message_to_agent`, `log_finding`, `web_research`
+- Tools: `Read`, `Glob`, `Grep`, `Skill`, `send_message_to_agent` (via `repo-agent-tools`), `log_finding` (via `repo-agent-tools`), `web_research` (via `research-tools`)
 
 **Source:** `src/agents/spawn.ts`, `src/agents/registry.ts`, `src/types/agent.ts`
 
 ## Plugin Directory Structure
 
-Each plugin is a subdirectory under the `plugins/` directory (at `$ARCHIE_WORKDIR/plugins/`, auto-cloned from `ARCHIE_PLUGINS` git URL). The structure follows standard Claude Code conventions with Archie-specific extensions:
+Each plugin is a subdirectory under the `plugins/` directory (at `$ARCHIE_WORKDIR/plugins/`, auto-cloned from `ARCHIE_PLUGINS` git URL). Every plugin **must** have a `.claude-plugin/plugin.json` manifest to be loaded. The structure follows standard Claude Code conventions with Archie-specific extensions:
 
 ```
 plugins/
-  engineering/                    # Repo plugin (has repo-config.json)
-    repo-config.json              # Infrastructure configs for repo agents
+  engineering/                    # Repo plugin (agents with repo frontmatter)
+    .claude-plugin/
+      plugin.json                 # Required: { name, version, description }
+    repo-config.json              # Legacy infrastructure configs (optional)
     agents/
-      backend.md                  # Agent prompt (frontmatter + body)
+      backend.md                  # Agent prompt (frontmatter with repo metadata + body)
       mobile.md
-    pm-skills/                    # PM skill directories
-      workflow/
-        SKILL.md                  # Claude Code skill definition
     skills/                       # Agent craft skills (symlinked into agent workspaces)
       debugging/
         SKILL.md
+    hooks/
+      hooks.json                  # Plugin-defined hooks (injected into agent settings)
 
-  marketing/                      # Generic plugin (no repo-config.json)
+  marketing/                      # Generic plugin (no repo metadata in frontmatter)
+    .claude-plugin/
+      plugin.json                 # Required manifest
     agents/
       copywriter.md               # Becomes copywriter-agent
       brand-strategist.md         # Becomes brand-strategist-agent
-    pm-skills/
-      campaign-review/
-        SKILL.md
     skills/
       tone-analysis/
         SKILL.md
+
+  pm/                             # Special PM overlay plugin
+    .claude-plugin/
+      plugin.json
+    agents/
+      pm.md                       # Body appended to PM prompt; frontmatter configures MCP/tools
 ```
 
-A plugin is classified as a **repo plugin** if it contains `repo-config.json`, or a **generic plugin** if it does not. This distinction is mutually exclusive: plugins with `repo-config.json` do not have their `agents/*.md` files loaded as plugin agents (those agents are handled by `repo-configs.ts` instead).
+An agent is classified as a **repo agent** if its frontmatter contains `metadata.archie.repo` with a `github` field. Otherwise it is a **plugin agent**. The `repo-config.json` file is still supported as a legacy format but frontmatter-based repo config is preferred.
+
+### Plugin Manifest (`plugin.json`)
+
+Every plugin directory must contain `.claude-plugin/plugin.json` with at least:
+
+```json
+{
+  "name": "engineering",
+  "version": "1.0.0",
+  "description": "Engineering agents for backend and mobile repositories"
+}
+```
+
+Directories without a valid manifest are silently skipped during scanning.
+
+### Plugin Hooks (`hooks/hooks.json`)
+
+Plugins can define hooks that are injected into agent workspace settings. The `hooks.json` file follows the Claude Code settings hooks format. The `${CLAUDE_PLUGIN_ROOT}` placeholder is substituted with the actual plugin directory path at load time.
+
+### PM Overlay Plugin
+
+A plugin named `pm` is treated specially. Its `agents/pm.md` file provides:
+- **Body**: Appended to the PM agent's system prompt (for business context, team-specific instructions)
+- **Frontmatter `mcpServers`**: Additional MCP server names the PM should have access to
+- **Frontmatter `tools`/`disallowedTools`**: Additional tool permissions for the PM
+
+### Root MCP Config
+
+A single `.mcp.json` file at the plugins directory root (`$ARCHIE_WORKDIR/plugins/.mcp.json`) provides MCP server connection configs. Individual agents reference server names from this file via their frontmatter `mcpServers: [...]` field. Environment variables matching `${MCP_*}` are substituted at load time.
 
 ## Plugin Loader
 
@@ -67,21 +102,24 @@ The plugin loader (`src/system/plugin-loader.ts`) runs once at startup using syn
 
 1. Read all entries in `PLUGINS_DIR` (at `$ARCHIE_WORKDIR/plugins/`)
 2. For each subdirectory:
-   - Check for `repo-config.json` and parse it if present
-   - Scan `pm-skills/` for subdirectories, building namespaced skill entries (`{pluginName}-{skillDirName}`)
-   - If **no** `repo-config.json`: scan `agents/*.md` for generic agent definitions, parsing frontmatter with `gray-matter`
+   - **Require** `.claude-plugin/plugin.json` with `name`, `version`, `description` -- skip if missing
+   - Check for `repo-config.json` and parse it if present (legacy support)
+   - Scan `agents/*.md` for all agent definitions, parsing frontmatter with `gray-matter`
+   - If frontmatter contains `metadata.archie.repo.github`, the agent is classified as a repo agent
    - Check for `skills/` directory and record its absolute path
+   - Check for `hooks/hooks.json` and parse if present (with `${CLAUDE_PLUGIN_ROOT}` substitution)
 3. Return the array of `LoadedPlugin` objects
 
 ```typescript
 // From src/system/plugin-loader.ts
 export interface LoadedPlugin {
-  name: string;                                          // Directory name
+  name: string;                                          // Plugin name (from manifest)
   dir: string;                                           // Absolute path
-  repoConfigs: Record<string, PluginRepoConfig> | null;  // null for generic plugins
-  pmSkills: PmSkillEntry[];                              // Namespaced PM skills
-  agents: PluginAgentDef[];                              // Generic agents (empty for repo plugins)
+  manifest: PluginManifest;                              // Parsed plugin.json
+  repoConfigs: Record<string, PluginRepoConfig> | null;  // Legacy repo-config.json
+  agents: PluginAgentDef[];                              // All agents (repo + plugin track)
   skillsPath: string | null;                             // Absolute path to skills/ if exists
+  hooks: Record<string, any> | null;                     // Parsed hooks/hooks.json
 }
 ```
 
@@ -91,56 +129,80 @@ Agent definition files use YAML frontmatter parsed by the `gray-matter` library:
 
 ```markdown
 ---
-role: Senior copywriter
-expertise: Ad copy, landing pages, email campaigns
-model: haiku
+role: Senior backend engineer
+expertise: Ruby on Rails, PostgreSQL, API design
+model: sonnet
+metadata:
+  archie:
+    repo:
+      github: org/backend-repo
+      baseBranch: main
+mcpServers:
+  - teamcity
+  - bugsnag
+tools:
+  - "mcp__teamcity__*"
+disallowedTools:
+  - WebSearch
 ---
 
 ## Domain Instructions
 
-You specialize in crafting compelling copy...
+You specialize in the backend service...
 ```
 
 Fields:
 - **`role`** (string): Short role description, used in peer agent lists
 - **`expertise`** (string): Detailed expertise description, used in the agent's own prompt
 - **`model`** (string, optional): Model override (defaults to `sonnet` if not specified)
+- **`metadata.archie.repo`** (object, optional): If present with a `github` field, classifies the agent as a repo agent with `github` (repo identifier) and optional `baseBranch`
+- **`mcpServers`** (string[], optional): MCP server names from the root `.mcp.json` that this agent should have access to
+- **`tools`** (string[], optional): Additional tool allowlist entries
+- **`disallowedTools`** (string[], optional): Tool denylist entries
 
 The markdown body (everything after the frontmatter) becomes the Layer 3 domain-specific prompt.
 
-## Repo Plugin: `repo-config.json` Format
+## Repo Agent Configuration
 
-The `repo-config.json` file maps agent keys to their infrastructure configuration:
+Repo agents are identified by the `metadata.archie.repo` field in their frontmatter. The `github` field is required and specifies the GitHub repository identifier:
+
+```markdown
+---
+role: Senior backend engineer
+expertise: Ruby on Rails, PostgreSQL
+metadata:
+  archie:
+    repo:
+      github: org/backend-repo
+      baseBranch: main
+---
+```
+
+### Agent Derivation
+
+Each agent `.md` file with repo metadata produces a `RepoAgentConfig`:
+- Agent ID: `{key}-agent` (e.g., filename `backend.md` becomes `backend-agent`)
+- Repository path: `$ARCHIE_WORKDIR/repos/{key}` by default
+- GitHub repo: from `metadata.archie.repo.github`
+- Base branch: from `metadata.archie.repo.baseBranch` (defaults to `"main"`)
+- Identity (role, expertise): from frontmatter
+- Domain prompt (Layer 3): from markdown body
+
+### Legacy `repo-config.json`
+
+The `repo-config.json` format is still supported for backward compatibility. It maps agent keys to infrastructure configs:
 
 ```json
 {
   "backend": {
     "githubRepo": "org/backend-repo",
     "baseBranch": "main",
-    "repoPath": "/repos/backend",
     "prompt": "agents/backend.md"
-  },
-  "mobile": {
-    "githubRepo": "org/mobile-app",
-    "baseBranch": "develop",
-    "prompt": "agents/mobile.md"
   }
 }
 ```
 
-Fields per agent key:
-- **`githubRepo`** (string, required): GitHub repository identifier (e.g., `"org/repo"`)
-- **`baseBranch`** (string, optional): Base branch for PRs and merges (defaults to `"main"`)
-- **`repoPath`** (string, optional): Absolute path to the repository on disk (defaults to `$ARCHIE_WORKDIR/repos/{key}`)
-- **`prompt`** (string, required): Relative path to the agent's markdown prompt file
-
-### Agent Derivation
-
-Each key in `repo-config.json` produces a `RepoAgentConfig`:
-- Agent ID: `{key}-agent` (e.g., `"backend"` becomes `"backend-agent"`)
-- Repository path: `repoPath` from config, or `$ARCHIE_WORKDIR/repos/{key}`
-- Identity (role, expertise): parsed from the referenced `agents/{key}.md` frontmatter
-- Domain prompt (Layer 3): parsed from the referenced `agents/{key}.md` body
+When both frontmatter repo metadata and `repo-config.json` exist, the frontmatter takes precedence.
 
 **Source:** `src/agents/registry.ts`
 
@@ -160,29 +222,17 @@ If a collision is detected, the system throws an error with a message identifyin
 
 **Source:** `src/agents/registry.ts`
 
-## PM Skills vs Agent Skills
+## Agent Skills
 
-The plugin system distinguishes between two kinds of skills:
+### Skills (`skills/`)
 
-### PM Skills (`pm-skills/`)
-
-Skills intended for the PM agent. Each subdirectory under `pm-skills/` is a Claude Code skill directory (containing `SKILL.md`). The plugin loader namespaces these as `{pluginName}-{skillDirName}` to avoid collisions across plugins.
-
-At task creation time, all PM skills from all loaded plugins are symlinked into the PM agent's workspace:
-
-```
-sessions/{task-id}/shared/.claude/skills/{pluginName}-{skillDirName} -> plugins/{pluginName}/pm-skills/{skillDirName}
-```
-
-**Source:** `src/tasks/task.ts` (task creation), `src/system/plugin-loader.ts` (scanning)
-
-### Agent Skills (`skills/`)
-
-Skills intended for plugin agents. Each subdirectory under `skills/` is a Claude Code skill directory. At agent spawn time, these are symlinked into the agent's workspace:
+Skills intended for agents. Each subdirectory under `skills/` is a Claude Code skill directory (containing `SKILL.md`). At agent spawn time, these are symlinked into the agent's workspace:
 
 ```
 sessions/{task-id}/agents/{agentKey}/.claude/skills/{skillName} -> plugins/{pluginName}/skills/{skillName}
 ```
+
+The PM agent also gets its own workspace with skills symlinked from its plugin at spawn time.
 
 **Source:** `src/agents/spawn.ts` (`setupAgentWorkspace`)
 
@@ -193,21 +243,22 @@ Each task gets an isolated directory under `sessions/`. The PM agent and each sp
 ```
 sessions/
   task-20260222-1400-a3f9k2/
-    shared/                              # PM agent's working directory
+    shared/                              # Shared task state
       knowledge.log                      # Shared conversation log (all agents)
       metadata.json                      # Task metadata (status, threads, sessions)
-      memory/                            # PM memory storage
+      memory/                            # Agent memory storage
       attachments/                       # Downloaded Slack files
       researches/                        # Research results (JSON files)
-      .claude/
-        skills/
-          engineering-workflow/  -> ...   # Symlinked PM skills
     agents/
+      pm/                                # PM agent workspace
+        .claude/
+          skills/
+            workflow/  -> ...            # Symlinked PM skills
       copywriter/                        # Plugin agent workspace
         .claude/
           skills/
             tone-analysis/  -> ...       # Symlinked agent skills
-    repos/                               # Git worktrees (edit mode only)
+    repos/                               # Git worktrees (always created; detached HEAD for RO, feature branch for RW)
       backend/                           # Worktree for backend-agent
     researches/                          # Per-research isolated storage
       {uuid}/
@@ -232,10 +283,13 @@ sessions/
 
 ### What goes in `plugins/` (domain-specific)
 
-- `repo-config.json`: repository infrastructure mapping
-- `agents/*.md`: agent identity, expertise, and domain-specific instructions
-- `pm-skills/`: PM skill directories (Claude Code skills for the PM agent)
-- `skills/`: agent skill directories (Claude Code skills for plugin agents)
+- `.claude-plugin/plugin.json`: required manifest (name, version, description)
+- `repo-config.json`: legacy repository infrastructure mapping (optional)
+- `agents/*.md`: agent identity, expertise, repo config (via frontmatter), and domain-specific instructions
+- `pm/agents/pm.md`: PM overlay prompt (body appended to PM system prompt)
+- `skills/`: agent skill directories (Claude Code skills for agents)
+- `hooks/hooks.json`: plugin-defined hooks (injected into agent settings)
+- `.mcp.json` (at plugins root): MCP server connection configs
 
 This separation means new agents can be added by creating a plugin directory with the appropriate files -- no changes to core source code are required.
 
@@ -257,7 +311,7 @@ Shared by all agents. Defines:
 
 Track-specific behavior added on top of Layer 1:
 
-- **Repo agents** use `prompts/repo-agent.md`: repository responsibility, dual mode system (read-only vs edit), git workflow, task lifecycle context
+- **Repo agents** use `prompts/repo-agent.md`: repository responsibility, dual mode system (read-only vs edit), git workflow (branch management, PR lifecycle), task lifecycle context, honesty guidelines
 - **Plugin agents** use `prompts/plugin-agent.md`: read-only mode, available tools (Read, Glob, Grep, Skill), workspace description
 
 ### Layer 3: Plugin Override (Domain-Specific)

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -104,7 +104,7 @@ Additionally, each agent's core prompt (`prompts/agent-core.md`) includes standi
 Both hooks (persistence + defense tagging) are wired on every agent's PostToolUse array:
 
 ```typescript
-// From src/agents/spawn.ts (same in plugin-agent.ts, pm.ts)
+// From src/agents/spawn.ts (applied to all agent tracks)
 hooks: {
   PostToolUse: [
     createResearchPostToolHook({ getSharedDir, getTaskId, getAgentId }),
@@ -152,19 +152,24 @@ Repo agents start in **read-only mode** with only `Read`, `Glob`, `Grep` tools. 
 2. System posts Slack message with Approve/Deny buttons
 3. Task pauses (all agents stop)
 4. User clicks Approve -> task resumes with `edit_allowed: true`
-5. Repo agents gain `Write`, `Edit`, and local git commands (`git add`, `git commit`, `git diff`, `git status`, `git log`, `git merge`, `git restore`)
+5. Repo agents gain `Write`, `Edit`, local git commands (`git add`, `git commit`, `git status`, `git merge`, `git restore`, `rm`, `git rm`), and PR lifecycle tools (`push_branch`, `create_pull_request`, `update_pr`, `merge_pull_request`, etc.)
 
-Even in edit mode, repo agents cannot push to remote -- only the PM agent has `push_branch` and `create_pull_request` tools.
+In edit mode, repo agents manage their own PRs directly via the `repo-tools` MCP server. Note that even in readonly mode, agents have access to read-only git commands (`git log`, `git diff`, `git show`, `git blame`, `git branch`) and PR read tools (`fetch`, `switch_branch`, `list_prs`, `get_pr`, `get_pr_status`, `get_pr_reviews`).
 
 ```typescript
-// From src/agents/spawn.ts — edit mode tool gating
+// From src/agents/spawn.ts — edit mode tool gating (partial)
 allowedTools: [
   "Read", "Glob", "Grep",
+  "mcp__repo-tools__fetch", "mcp__repo-tools__switch_branch",
+  "mcp__repo-tools__list_prs", "mcp__repo-tools__get_pr",
+  "Bash(git log*)", "Bash(git diff*)", "Bash(git show *)",
   ...(editAllowed ? [
     "Write", "Edit",
-    "Bash(git add:*)", "Bash(git commit:*)", "Bash(git status:*)",
-    "Bash(git diff:*)", "Bash(git log:*)", "Bash(git merge:*)",
-    "Bash(git restore:*)",
+    "Bash(git add *)", "Bash(git commit *)", "Bash(git status*)",
+    "Bash(git merge *)", "Bash(git restore *)", "Bash(rm *)", "Bash(git rm *)",
+    "mcp__repo-tools__push_branch", "mcp__repo-tools__create_pull_request",
+    "mcp__repo-tools__merge_pull_request", "mcp__repo-tools__create_branch",
+    // ... additional PR write tools
   ] : []),
 ],
 ```
@@ -173,9 +178,9 @@ allowedTools: [
 
 ### PR Review Enforcement
 
-All code changes go through GitHub pull requests. The PM agent creates PRs via the `create_pull_request` tool, and merge is gated on external PR review approval. The `trigger_merge_check` tool checks that PRs are approved, CI is passing, and there are no conflicts before merging.
+All code changes go through GitHub pull requests. Repo agents create PRs via the `create_pull_request` tool on the `repo-tools` MCP server, and merge is gated on external PR review approval. The `merge_pull_request` tool checks that PRs are approved, CI is passing, and there are no conflicts before merging. The merge orchestrator also runs automatically on webhook events (approval, push, CI completion).
 
-**Source:** `src/agents/tools.ts` (`createPullRequestTool`, `createTriggerMergeCheckTool`)
+**Source:** `src/agents/tools.ts` (`createPullRequestTool`, `createMergePRTool`), `src/connectors/github/merge.ts`
 
 ### Plugin Agent Isolation
 
@@ -292,9 +297,9 @@ This log is readable by all agents and provides a full audit trail of task activ
 
 | Agent Type | Read Code | Write Code | Git Operations | Slack | GitHub PRs | Web Research |
 |-----------|-----------|-----------|---------------|-------|-----------|-------------|
-| PM Agent | Via shared/ | No | No | Yes | Yes (create, push, merge) | Yes |
-| Repo Agent (readonly) | Yes | No | No | No | No | Yes |
-| Repo Agent (edit mode) | Yes | Yes | Local only (add, commit, diff, merge) | No | No | Yes |
+| PM Agent | Via shared/ | No | No | Yes | No | Yes |
+| Repo Agent (readonly) | Yes | No | Read-only (log, diff, show, blame, branch, fetch, switch) | No | Read (list, get, status, reviews) | Yes |
+| Repo Agent (edit mode) | Yes | Yes | Full (add, commit, merge, restore, push, create branch) | No | Full (create, update, merge, close, comment) | Yes |
 | Plugin Agent | Workspace only | No | No | No | No | Yes |
 | Researcher (inner) | No | notes/ only | No | No | No | WebSearch, WebFetch |
 | Report Writer (inner) | notes/ only | No | No | No | No | No |

--- a/docs/architecture/slack-integration.md
+++ b/docs/architecture/slack-integration.md
@@ -82,17 +82,19 @@ User @mentions Archie in Slack thread
 
 ## Multi-Thread Support
 
-A single task can be associated with multiple Slack threads. The `TaskMetadata` type (`src/types/task.ts`) holds an array of `SlackThread` objects:
+A single task can be associated with multiple Slack threads (and other channel types). The `TaskMetadata` type (`src/types/task.ts`) holds a `channels` record keyed by channel ID:
 
 ```typescript
-interface SlackThread {
+interface SlackChannel {
+  type: 'slack';
   thread_id: string;
   channel_id: string;
+  channel_name: string;
   last_processed_ts: string;
 }
 ```
 
-When triage classifies a message as `existing_task` and the thread is not yet tracked for that task, the event handler adds the new thread to `metadata.slack_threads` and posts a linking confirmation: "Got it, I've linked this to the ongoing investigation." All subsequent `post_to_slack` calls from the PM agent post to every tracked thread.
+When triage classifies a message as `existing_task` and the thread is not yet tracked for that task, the event handler adds the new thread to `metadata.channels` and posts a linking confirmation. All subsequent `post_to_slack` calls from the PM agent post to every tracked Slack channel.
 
 ## Message Deduplication
 


### PR DESCRIPTION
## Summary

- Update all architecture docs to reflect the git workflow changes from #10
- Fix broken documentation links in README.md
- Mark triage agent as currently disabled across all docs

## Test plan
- [x] Documentation-only changes, no code affected
- [ ] Review doc accuracy against current codebase

> **Note**: This PR includes the commits from #10 as its base. Merge #10 first, then this PR will show only the doc changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)