### PR TITLE
Improve Slack UX: eyes reaction, thread muting, participation etiquette

### DIFF
--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -92,6 +92,10 @@ Use as many of these as needed during your turn:
 - `send_message_to_agent`: Send instructions or questions to an agent
 - `post_to_slack`: Send updates to the user
 
+### Thread Management Tools
+
+- `mute_thread`: Unsubscribe from the Slack thread until someone @mentions you again. Use when asked to disengage.
+
 ### Turn-Ending Tools
 
 Call ONE of these, then STOP immediately - these pause the ENTIRE Archie system:
@@ -248,6 +252,27 @@ Here's the format your analysis should follow:
 
 After completing your analysis, execute your planned tool calls in the order specified.
 
+## Thread Participation Etiquette
+
+You live inside Slack threads where multiple people may be having a conversation. Not every message requires your response. Follow these guidelines:
+
+**When to respond:**
+- Someone directly asks you a question or requests work
+- You can add clear, concrete value (a fact, a link, a status update)
+- You're about to start prolonged work — send a brief acknowledgment first ("On it, I'll look into this" or "Checking now") so people know you're working
+- A decision was made that affects your ongoing work
+
+**When to stay silent:**
+- People are talking to each other — don't interrupt a human conversation
+- The message is FYI or informational with no action needed from you
+- Someone is venting, celebrating, or having a social exchange — unless you're directly addressed
+- You've already answered and someone is just acknowledging ("thanks", "ok", "got it")
+
+**When to mute:**
+- If a user asks you to stop following the thread, disengage, step back, or go away, use `mute_thread` to unsubscribe. You will automatically re-engage when someone @mentions you again.
+
+**General principle:** Be like a thoughtful colleague in a group chat — contribute when you have something useful to add, stay quiet when people are just talking amongst themselves. When in doubt, stay silent. It's better to miss one message than to be the bot that replies to everything.
+
 ## Decision Framework for Common Scenarios
 
 **New task from Slack:**
@@ -276,6 +301,17 @@ After completing your analysis, execute your planned tool calls in the order spe
 - Respond warmly and briefly in Slack as Archie - no delegation needed
 - Examples: "Welcome to the team!", "Congrats on the launch!", "Happy to help!"
 - `report_completion(message)` with a friendly response
+
+**Thread message that doesn't need your input:**
+
+- People discussing among themselves, FYI updates, acknowledgments like "thanks" or "ok"
+- `report_completion()` silently — no message, no Slack post
+- See "Thread Participation Etiquette" above
+
+**User asks to disengage / stop following:**
+
+- Use `mute_thread` to unsubscribe — it will notify the thread automatically
+- Then `report_completion()` silently
 
 ## Honesty and Limitations
 

--- a/slack-manifest.yaml
+++ b/slack-manifest.yaml
@@ -19,6 +19,7 @@ oauth_config:
       - users:read
       - usergroups:read
       - files:read
+      - reactions:write
 settings:
   interactivity:
     is_enabled: true

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -101,6 +101,7 @@ const SPAWN_PM_TOOLS = [
   'mcp__pm-agent-tools__report_completion',
   'mcp__pm-agent-tools__request_edit_mode',
   'mcp__pm-agent-tools__get_agents_status',
+  'mcp__pm-agent-tools__mute_thread',
 ];
 
 const SPAWN_REPO_TOOLS = [

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -238,6 +238,40 @@ function createReportCompletionTool(agent: Agent, task: Task) {
   );
 }
 
+function createMuteThreadTool(agent: Agent, task: Task) {
+  return tool(
+    'mute_thread',
+    'Unsubscribe from the current Slack thread. Messages will be ignored until someone @mentions the bot again. Posts a notification to the thread.',
+    {},
+    async () => {
+      const agentName = agent.def.id as AgentName;
+      logger.agentAction(agentName, 'Muting thread', '');
+      task.touch();
+
+      // Mute all Slack channels
+      let mutedCount = 0;
+      for (const ch of Object.values(task.metadata.channels)) {
+        if (ch.type === 'slack' && !ch.muted) {
+          (ch as import('../types/task.js').SlackChannel).muted = true;
+          mutedCount++;
+        }
+      }
+
+      if (mutedCount === 0) {
+        return ok('No active Slack threads to mute.');
+      }
+
+      task.debouncedSave();
+      await appendAgentFinding(task.taskId, agentName, 'Muted Slack thread — will not process messages until next @mention', 'decision');
+
+      // Notify the thread
+      await task.postToUser("I'll step back from this thread. Mention me again when you need me.", agentName);
+
+      return ok(`Muted ${mutedCount} Slack thread(s). Will resume on next @mention.`);
+    },
+  );
+}
+
 function createGetAgentsStatusTool(agent: Agent, task: Task) {
   return tool(
     'get_agents_status',
@@ -721,6 +755,7 @@ export function createPMAgentMcpServer(agent: Agent, task: Task) {
       createReportCompletionTool(agent, task),
       createRequestEditModeTool(agent, task),
       createGetAgentsStatusTool(agent, task),
+      createMuteThreadTool(agent, task),
     ],
   });
 }

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -126,6 +126,32 @@ export async function postInteractiveToThreads(
 }
 
 /**
+ * Add an emoji reaction to a message.
+ * Failures are silently ignored (duplicate reactions, missing scopes, etc.).
+ */
+export async function addReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
+  try {
+    const client = getSlackClient();
+    await client.reactions.add({ channel, timestamp, name: emoji });
+  } catch {
+    // Silently ignore — already_reacted, missing scope, etc.
+  }
+}
+
+/**
+ * Remove an emoji reaction from a message.
+ * Failures are silently ignored (not_reacted, missing scope, etc.).
+ */
+export async function removeReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
+  try {
+    const client = getSlackClient();
+    await client.reactions.remove({ channel, timestamp, name: emoji });
+  } catch {
+    // Silently ignore — not_reacted, missing scope, etc.
+  }
+}
+
+/**
  * Update an existing message (e.g., to remove buttons after action)
  */
 export async function updateMessage(

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -19,6 +19,7 @@ import {
   getBotUserId,
   fetchSlackThread,
   getBotId,
+  addReaction,
 } from './client.js';
 import { Task } from '../../tasks/task.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
@@ -268,6 +269,12 @@ async function handleSlackEvent(event: {
   thread_ts?: string;
 }): Promise<void> {
   const threadId = event.thread_ts || event.ts;
+
+  // Instant acknowledgment — react before any LLM processing
+  if (event.type === 'app_mention' || event.channel.startsWith('D')) {
+    addReaction(event.channel, event.ts, 'eyes');
+  }
+
   const thread = await fetchSlackThread(event.channel, threadId, event.ts);
 
   logger.system(`Processing #${thread.channel.name} (thread: ${threadId})`);
@@ -306,8 +313,25 @@ async function handleSlackEvent(event: {
   // }
   const taskId = await findTaskByThread(threadId);
   if (taskId) {
-    // Thread reply to an existing task — route to it
     const task = await Task.get(taskId);
+
+    // Check if thread is muted
+    const channelId = `slack:${event.channel}:${threadId}`;
+    const channel = task.metadata.channels[channelId];
+    if (channel?.type === 'slack' && channel.muted) {
+      if (event.type === 'app_mention') {
+        // @mention unmutes the thread
+        channel.muted = false;
+        task.debouncedSave();
+        logger.system(`Thread ${threadId} unmuted by @mention`);
+      } else {
+        // Thread is muted and no @mention — skip
+        logger.system(`Skipping muted thread ${threadId}`);
+        return;
+      }
+    }
+
+    // Thread reply to an existing task — route to it
     await task.append(thread);
     await task.sendMessage(AGENT_PROMPTS.existingTask);
   } else if (event.type === 'app_mention' || event.channel.startsWith('D')) {

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -40,7 +40,7 @@ import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
 import { scanAgentDefs } from '../agents/registry.js';
 import { refreshPlugins } from '../system/workdir.js';
-import { postToThreads, postInteractiveToThreads } from '../connectors/slack/client.js';
+import { postToThreads, postInteractiveToThreads, removeReaction } from '../connectors/slack/client.js';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { logger } from '../system/logger.js';
 import { emitEvent } from '../system/event-bus.js';
@@ -243,6 +243,10 @@ export class Task {
 
     const slackRefs = this.getSlackThreadRefs();
     if (slackRefs.length > 0) {
+      // Remove eyes acknowledgment before posting the reply
+      await Promise.all(
+        slackRefs.map((ref) => removeReaction(ref.channel_id, ref.last_processed_ts, 'eyes')),
+      );
       await postToThreads(slackRefs, message);
     }
   }

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -50,6 +50,7 @@ export interface SlackChannel extends ChannelBase {
   channel_id: string;
   channel_name: string;
   last_processed_ts: string;
+  muted?: boolean;  // When true, messages are not routed to task until next @mention
 }
 
 /** GitHub channel — a PR conversation */


### PR DESCRIPTION
## Summary

- **Eyes reaction**: Instant 👀 on @mentions and DMs before any LLM processing; automatically removed when the bot posts its reply
- **Mute thread**: New `mute_thread` PM tool to unsubscribe from noisy threads; auto-unmutes on next @mention
- **PM prompt**: Thread participation etiquette — guidelines for when to respond, stay silent, or mute

## Test results

- [x] @mention bot → eyes reaction appears immediately, disappears when bot replies
- [x] PM uses `mute_thread` → thread stops receiving messages
- [x] @mention in muted thread → auto-unmutes and processes message
- [x] PM stays silent on FYI messages / human-to-human conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)