### PR TITLE
Improve Slack UX: channel-agnostic messaging, thread URLs, user mentions

### DIFF
--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -38,12 +38,14 @@ The key to managing your turns is understanding who you're waiting for after you
 
 Understanding your communication channels is critical:
 
-**The originating channel** is where your requester lives — the person who asked you to do the work. This could be Slack, CLI, or another system. Your `post_to_slack` tool automatically routes messages to the correct channel. This is your primary channel for:
+**The originating channel** is where your requester lives — the person who asked you to do the work. This could be Slack, CLI, or another system. Your `post_to_user` tool automatically routes messages to the correct channel. This is your primary channel for:
 
 - Acknowledging new work requests
 - Sharing findings and proposing actions
 - Announcing major milestones (deliverables ready, blockers encountered)
 - Asking clarifying questions
+
+**Mentioning users**: When you need to mention someone (e.g. to notify them), use the `@<ID:Name>` format you see in the conversation history (e.g. `@<U1234567:John Smith>`). This ensures they receive a notification. If you don't know the user's ID, just use their plain name without any special formatting.
 
 **The key insight**: Match your communication to the channel where the audience lives.
 
@@ -90,7 +92,7 @@ Use as many of these as needed during your turn:
 
 - `assign_task_owner`: Designate a specific agent as the task owner
 - `send_message_to_agent`: Send instructions or questions to an agent
-- `post_to_slack`: Send updates to the user
+- `post_to_user`: Send updates to the user
 
 ### Thread Management Tools
 
@@ -164,7 +166,7 @@ Go through EACH of these rules explicitly, even if marked N/A:
 - Taking actions AFTER send_message_to_agent? [Should be NO - turn ends naturally, or N/A if not using send_message_to_agent]
 - Calling turn-ending tool when waiting for USER? [Should be YES, or N/A if not waiting for USER]
 - Calling turn-ending tool when waiting for AGENT? [Should be NO, or N/A if not waiting for AGENT]
-- Using post_to_slack to explain BEFORE request_edit_mode? [Should be YES if requesting edit mode, or N/A]
+- Using post_to_user to explain BEFORE request_edit_mode? [Should be YES if requesting edit mode, or N/A]
 - Starting delegation message with protocol language? [Should be YES if delegating, or N/A]
 
 **8. Waiting-For Logic**
@@ -233,7 +235,7 @@ Here's the format your analysis should follow:
 - Actions after send_message_to_agent? [NO / N/A - reason]
 - Turn-ending tool when waiting for USER? [YES / N/A - reason]
 - Turn-ending tool when waiting for AGENT? [NO / N/A - reason]
-- post_to_slack before request_edit_mode? [YES / N/A - reason]
+- post_to_user before request_edit_mode? [YES / N/A - reason]
 - Delegation protocol in message? [YES / N/A - reason]
 
 **Waiting-For Logic:**
@@ -285,13 +287,13 @@ You live inside Slack threads where multiple people may be having a conversation
 
 **Agent reports findings:**
 
-- If needs changes requiring approval: `post_to_slack` explaining → `request_edit_mode` → STOP
+- If needs changes requiring approval: `post_to_user` explaining → `request_edit_mode` → STOP
 - If just informational: `report_completion(message)` with the info
 - If incomplete: ask follow-ups and wait for agent
 
 **Edit mode approved:**
 
-- `post_to_slack` acknowledging ("Starting on the changes now...")
+- `post_to_user` acknowledging ("Starting on the changes now...")
 - Coordinate with agents
 - Wait for agent work
 

--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -118,8 +118,9 @@ When you have Edit tools available, you also have access to:
 
 1. Commit all changes with `git commit`
 2. `push_branch()` to push
-3. `create_pull_request(title, body)` with a clear description
-4. Notify pm-agent: "PR #123 created: <url>"
+3. Read `metadata.json` from the shared folder to find the originating channel URL (look for the `default_channel` key, then find that channel's `url` field in `channels`). If available, include a link at the bottom of the PR body using the channel's type and name (e.g. `Slack thread in #channel-name: <url>`)
+4. `create_pull_request(title, body)` with a clear description
+5. Notify pm-agent: "PR #123 created: <url>"
 
 ### Handling Reviews
 

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -96,7 +96,7 @@ function getRegisteredToolNames(server: ReturnType<typeof createRepoToolsMcpServ
 
 const SPAWN_PM_TOOLS = [
   'mcp__pm-agent-tools__send_message_to_agent',
-  'mcp__pm-agent-tools__post_to_slack',
+  'mcp__pm-agent-tools__post_to_user',
   'mcp__pm-agent-tools__assign_task_owner',
   'mcp__pm-agent-tools__report_completion',
   'mcp__pm-agent-tools__request_edit_mode',

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -121,12 +121,12 @@ function createLogFindingTool(agent: Agent, task: Task) {
 
 // ---- PM-only tools ----
 
-function createPostToSlackTool(agent: Agent, task: Task) {
+function createPostToUserTool(agent: Agent, task: Task) {
   return tool(
-    'post_to_slack',
-    'Post a message to the Slack thread(s) associated with this task. Write naturally, like a human PM.',
+    'post_to_user',
+    'Send a message to the user. Routes to the originating channel (Slack thread, CLI, etc.). Write naturally, like a human PM.',
     {
-      message: z.string().describe('The message to post to Slack'),
+      message: z.string().describe('The message to send to the user'),
     },
     async (args) => {
       const agentName = agent.def.id as AgentName;
@@ -750,7 +750,7 @@ export function createPMAgentMcpServer(agent: Agent, task: Task) {
     version: '1.0.0',
     tools: [
       createSendMessageTool(agent, task),
-      createPostToSlackTool(agent, task),
+      createPostToUserTool(agent, task),
       createAssignTaskOwnerTool(agent, task),
       createReportCompletionTool(agent, task),
       createRequestEditModeTool(agent, task),

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -13,6 +13,7 @@ import { logger } from '../../system/logger.js';
 let slackClient: WebClient | null = null;
 let botUserId: string | null = null;
 let botId: string | null = null;
+let workspaceUrl: string | null = null;
 
 /**
  * Initialize the Slack client and fetch bot user ID
@@ -25,7 +26,8 @@ export async function initSlackClient(token: string): Promise<void> {
     const authResult = await slackClient.auth.test();
     botUserId = authResult.user_id as string;
     botId = authResult.bot_id as string | undefined ?? null;
-    logger.slack(`Bot user ID: ${botUserId}, bot ID: ${botId}`);
+    workspaceUrl = (authResult.url as string | undefined)?.replace(/\/$/, '') ?? null;
+    logger.slack(`Bot user ID: ${botUserId}, bot ID: ${botId}, workspace: ${workspaceUrl}`);
   } catch (error) {
     logger.warn('Slack', 'Failed to get bot user ID', error);
   }
@@ -43,6 +45,17 @@ export function getBotUserId(): string | null {
  */
 export function getBotId(): string | null {
   return botId;
+}
+
+/**
+ * Build a full Slack URL for a thread.
+ * Format: https://{workspace}.slack.com/archives/{channel}/p{ts_without_dot}
+ * Returns null if workspace URL is not available.
+ */
+export function buildThreadUrl(channelId: string, threadTs: string): string | null {
+  if (!workspaceUrl) return null;
+  const tsNoDot = threadTs.replace('.', '');
+  return `${workspaceUrl}/archives/${channelId}/p${tsNoDot}`;
 }
 
 /**
@@ -65,8 +78,8 @@ export async function postToThread(
 ): Promise<string | undefined> {
   const client = getSlackClient();
 
-  // Convert markdown to Slack mrkdwn format
-  const slackText = slackifyMarkdown(text);
+  // Restore @<ID:Name> mentions to <@ID> before slackify (which would escape the angle brackets)
+  const slackText = slackifyMarkdown(restoreMentions(text));
 
   const result = await client.chat.postMessage({
     channel,
@@ -253,6 +266,15 @@ async function fetchMentionInfo(
   }
 
   return { userInfoMap, groupInfoMap, channelInfoMap };
+}
+
+/**
+ * Restore @<ID:Name> mention format back to Slack's <@ID> syntax for outgoing messages.
+ * Agents see users as @<U123:John Smith> in conversation history and are taught to use
+ * this format when mentioning users. This converts them back so Slack sends notifications.
+ */
+function restoreMentions(text: string): string {
+  return text.replace(/@<([A-Z0-9]+):[^>]+>/g, '<@$1>');
 }
 
 /**

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -40,7 +40,7 @@ import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
 import { scanAgentDefs } from '../agents/registry.js';
 import { refreshPlugins } from '../system/workdir.js';
-import { postToThreads, postInteractiveToThreads, removeReaction } from '../connectors/slack/client.js';
+import { postToThreads, postInteractiveToThreads, removeReaction, buildThreadUrl } from '../connectors/slack/client.js';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { logger } from '../system/logger.js';
 import { emitEvent } from '../system/event-bus.js';
@@ -206,6 +206,7 @@ export class Task {
         channel_id: thread.channel.id,
         channel_name: thread.channel.name,
         last_processed_ts: thread.currentMessageTs,
+        url: buildThreadUrl(thread.channel.id, thread.threadId) ?? undefined,
       };
       this.metadata.default_channel ??= channelId;
 

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -50,6 +50,7 @@ export interface SlackChannel extends ChannelBase {
   channel_id: string;
   channel_name: string;
   last_processed_ts: string;
+  url?: string;     // Full Slack URL to the thread (e.g. https://workspace.slack.com/archives/C.../p...)
   muted?: boolean;  // When true, messages are not routed to task until next @mention
 }
 


### PR DESCRIPTION
## Summary

- **Rename `post_to_slack` → `post_to_user`**: Tool now reflects that it routes to any channel (Slack, CLI, etc.), fixing PM confusion on CLI-originated tasks
- **Thread URL in metadata**: Store full Slack thread URL on channel creation; repo agent includes originating thread link in PR descriptions for reviewer traceability
- **User mention restoration**: Convert `@<ID:Name>` format back to native `<@ID>` on outgoing messages so mentioned users receive Slack notifications; PM prompt teaches the format

## Test plan

- [x] PM uses `post_to_user` correctly from both Slack and CLI tasks
- [x] New tasks show `url` field in channel metadata
- [ ] Repo agent includes originating thread link in PR body
- [x] Mentioning a user with `@<U123:Name>` in PM response triggers Slack notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)