### PR TITLE
Fix PR base branch fallback for non-main repos

### DIFF
--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -355,7 +355,7 @@ function createPullRequestTool(agent: Agent, task: Task) {
       const branch = repoInfo?.current_branch;
       const state = branch ? repoInfo?.branch_states?.[branch] : undefined;
       const head = branch || `feature/task-${task.taskId}`;
-      const base = state?.base_branch || 'main';
+      const base = state?.base_branch || agent.def.repo!.baseBranch || 'main';
 
       const result = await client.createPullRequest(githubRepo, head, base, args.title, args.body);
 


### PR DESCRIPTION
## Summary
- The `create_pull_request` tool hardcoded `'main'` as the fallback base branch, ignoring the repo config's `baseBranch`
- Repos with `master` as default branch got GitHub API errors: `{"resource":"PullRequest","field":"base","code":"invalid"}`
- Now falls back to `agent.def.repo!.baseBranch` before `'main'`

## Test plan
- [x] TypeScript typecheck passes
- [x] All 20 PR tools tests pass
- [ ] Verify PR creation works on a repo with `master` as default branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)