### PR TITLE
Log raw GitHub webhook payloads

### DIFF
--- a/src/connectors/github/events.ts
+++ b/src/connectors/github/events.ts
@@ -77,6 +77,8 @@ async function handleGitHubWebhook(
   eventType: string,
   payload: Record<string, unknown>
 ): Promise<void> {
+  logger.system(`GitHub raw event: ${eventType}\n${JSON.stringify(payload, null, 2)}`);
+
   const context = formatGitHubContext(eventType, payload);
 
   logger.system(


### PR DESCRIPTION
## Summary
- Adds full JSON payload logging for incoming GitHub webhooks before parsing/routing
- Temporary debugging aid to inspect real webhook data during PR testing

## Test plan
- [ ] Deploy and trigger a PR event, verify raw payload appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)