### PR TITLE
Remove raw GitHub webhook payload logging

### DIFF
--- a/src/connectors/github/events.ts
+++ b/src/connectors/github/events.ts
@@ -77,8 +77,6 @@ async function handleGitHubWebhook(
   eventType: string,
   payload: Record<string, unknown>
 ): Promise<void> {
-  logger.system(`GitHub raw event: ${eventType}\n${JSON.stringify(payload, null, 2)}`);
-
   const context = formatGitHubContext(eventType, payload);
 
   logger.system(


### PR DESCRIPTION
## Summary
- Removes verbose raw JSON payload logging added in #18
- No longer needed after inspecting real webhook data

## Test plan
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)