### PR TITLE
Pin Claude Code CLI to 2.1.96

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN apk add --no-cache git openssh-client git-lfs bash libcrypto3=3.5.5-r0 libss
 ENV SHELL=/bin/bash
 
 # Install Claude Code CLI globally
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@2.1.96
 
 # Set working directory
 WORKDIR /app

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -15,7 +15,7 @@ RUN apk add --no-cache git openssh-client git-lfs bash libcrypto3=3.5.5-r0 libss
 ENV SHELL=/bin/bash
 
 # Install Claude Code CLI globally
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@2.1.96
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Pin `@anthropic-ai/claude-code` to `2.1.96` in both `Dockerfile.dev` and `Dockerfile.prod`
- Prevents surprise breakages from unpinned `npm install -g`

## Test plan
- [ ] Docker build succeeds with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)