### PR TITLE
Fix webhook routing for multi-branch task IDs

### DIFF
--- a/src/connectors/github/webhooks.ts
+++ b/src/connectors/github/webhooks.ts
@@ -135,11 +135,12 @@ export function extractBranchFromPayload(
 
 /**
  * Extract task ID from branch name
- * Branch format: feature/task-{taskId}
+ * Branch format: feature/{taskId} or feature/{taskId}-{N} (multi-branch suffix)
+ * Task ID format: task-YYYYMMDD-HHMM-random
  */
 export function extractTaskIdFromBranch(branch: string | undefined): string | undefined {
   if (!branch) return undefined;
-  const match = branch.match(/^feature\/(task-[a-z0-9-]+)$/i);
+  const match = branch.match(/^feature\/(task-\d{8}-\d{4}-[a-z0-9]+)(?:-\d+)?$/i);
   return match ? match[1] : undefined;
 }
 


### PR DESCRIPTION
## Summary
- `extractTaskIdFromBranch` matched the `-2` suffix from `feature/task-xxx-2` as part of the task ID
- Webhook events on secondary branches always got "Task not found"
- New regex matches exact task ID format (`task-YYYYMMDD-HHMM-random`) and strips optional `-N` suffix

## Test plan
- [x] Typecheck passes
- [x] Regex verified: single branch, `-2`, `-13` all extract correct task ID
- [ ] Deploy and verify webhook events on secondary branches route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)