### PR TITLE
Add Slack dry-run mode and accept file_share/thread_broadcast subtypes

### DIFF
--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -118,7 +118,7 @@ When you have Edit tools available, you also have access to:
 
 1. Commit all changes with `git commit`
 2. `push_branch()` to push
-3. Read `metadata.json` from the shared folder to find the originating channel URL (look for the `default_channel` key, then find that channel's `url` field in `channels`). If available, include a link at the bottom of the PR body using the channel's type and name (e.g. `Slack thread in #channel-name: <url>`)
+3. Read `metadata.json` from the shared folder to find the originating channel (look for the `default_channel` key, then find that channel in `channels`). If the `channel_name` starts with `DM with`, do NOT include the URL — instead write `Requested by <name>` using the name from `channel_name`. Otherwise, include a link at the bottom of the PR body using the channel name (e.g. `Slack thread in #channel-name: <url>`)
 4. `create_pull_request(title, body)` with a clear description
 5. Notify pm-agent: "PR #123 created: <url>"
 

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -668,9 +668,17 @@ export async function getChannelInfo(channelId: string): Promise<{ id: string; n
 
   try {
     const result = await client.conversations.info({ channel: channelId });
+    const channel = result.channel as { name?: string; is_im?: boolean; user?: string } | undefined;
+
+    // For DMs, resolve the other user's name instead of showing a raw ID
+    if (channel?.is_im && channel.user) {
+      const userInfo = await getUserInfo(channel.user);
+      return { id: channelId, name: `DM with ${userInfo.realName}` };
+    }
+
     return {
       id: channelId,
-      name: result.channel?.name || channelId,
+      name: channel?.name || channelId,
     };
   } catch (error) {
     logger.warn('Slack', `Failed to get channel info for ${channelId}`);

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -14,6 +14,18 @@ let slackClient: WebClient | null = null;
 let botUserId: string | null = null;
 let botId: string | null = null;
 let workspaceUrl: string | null = null;
+let dryRun = false;
+
+/**
+ * Enable dry-run mode: receive and process events but suppress all outgoing Slack messages.
+ */
+export function setSlackDryRun(enabled: boolean): void {
+  dryRun = enabled;
+}
+
+export function isSlackDryRun(): boolean {
+  return dryRun;
+}
 
 /**
  * Initialize the Slack client and fetch bot user ID
@@ -76,6 +88,10 @@ export async function postToThread(
   threadTs: string,
   text: string
 ): Promise<string | undefined> {
+  if (dryRun) {
+    logger.system(`[DRY RUN] postToThread ${channel}:${threadTs} — ${text.slice(0, 120)}`);
+    return undefined;
+  }
   const client = getSlackClient();
 
   // Restore @<ID:Name> mentions to <@ID> before slackify (which would escape the angle brackets)
@@ -113,6 +129,10 @@ export async function postInteractiveToThread(
   text: string,
   blocks: unknown[]
 ): Promise<string | undefined> {
+  if (dryRun) {
+    logger.system(`[DRY RUN] postInteractiveToThread ${channel}:${threadTs} — ${text.slice(0, 120)}`);
+    return undefined;
+  }
   const client = getSlackClient();
 
   const result = await client.chat.postMessage({
@@ -143,6 +163,7 @@ export async function postInteractiveToThreads(
  * Failures are silently ignored (duplicate reactions, missing scopes, etc.).
  */
 export async function addReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
+  if (dryRun) return;
   try {
     const client = getSlackClient();
     await client.reactions.add({ channel, timestamp, name: emoji });
@@ -156,6 +177,7 @@ export async function addReaction(channel: string, timestamp: string, emoji: str
  * Failures are silently ignored (not_reacted, missing scope, etc.).
  */
 export async function removeReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
+  if (dryRun) return;
   try {
     const client = getSlackClient();
     await client.reactions.remove({ channel, timestamp, name: emoji });
@@ -173,6 +195,10 @@ export async function updateMessage(
   text: string,
   blocks?: unknown[]
 ): Promise<void> {
+  if (dryRun) {
+    logger.system(`[DRY RUN] updateMessage ${channel}:${ts} — ${text.slice(0, 120)}`);
+    return;
+  }
   const client = getSlackClient();
 
   await client.chat.update({

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -20,6 +20,7 @@ import {
   fetchSlackThread,
   getBotId,
   addReaction,
+  setSlackDryRun,
 } from './client.js';
 import { Task } from '../../tasks/task.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
@@ -34,6 +35,7 @@ import { findTaskByThread } from '../../tasks/persistence.js';
 export interface SlackConfig {
   slackBotToken: string;
   slackSigningSecret: string;
+  dryRun?: boolean;
 }
 
 let app: AppType | null = null;
@@ -55,6 +57,12 @@ export async function mountSlackApp(
   });
 
   logger.plain('Slack webhook: POST /webhooks/slack');
+
+  // Enable dry-run mode (receive events, suppress outgoing messages)
+  if (config.dryRun) {
+    setSlackDryRun(true);
+    logger.plain('Slack dry-run mode: outgoing messages suppressed');
+  }
 
   // Initialize Slack client for outgoing messages
   await initSlackClient(config.slackBotToken);
@@ -94,7 +102,7 @@ export async function mountSlackApp(
     const isThreadReply = event.thread_ts && event.thread_ts !== event.ts;
     if (
       event.type === 'message' &&
-      !event.subtype &&
+      (!event.subtype || ['file_share', 'thread_broadcast'].includes(event.subtype)) &&
       (isThreadReply || isDm)
     ) {
       // In channels, @mentions are handled by app_mention handler, so skip them here
@@ -277,8 +285,6 @@ async function handleSlackEvent(event: {
 
   const thread = await fetchSlackThread(event.channel, threadId, event.ts);
 
-  logger.system(`Processing #${thread.channel.name} (thread: ${threadId})`);
-
   // const triageResult = await triageSlackMessage(thread);
   // switch (triageResult.action) {
   //   case 'new_task': {
@@ -313,6 +319,7 @@ async function handleSlackEvent(event: {
   // }
   const taskId = await findTaskByThread(threadId);
   if (taskId) {
+    logger.system(`Processing #${thread.channel.name} (thread: ${threadId})`);
     const task = await Task.get(taskId);
 
     // Check if thread is muted
@@ -335,6 +342,8 @@ async function handleSlackEvent(event: {
     await task.append(thread);
     await task.sendMessage(AGENT_PROMPTS.existingTask);
   } else if (event.type === 'app_mention' || event.channel.startsWith('D')) {
+    logger.system(`Processing #${thread.channel.name} (thread: ${threadId})`);
+
     // Bot was @mentioned, or this is a DM — start a new task
     const task = await Task.create();
     await task.append(thread);

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,7 @@ async function main(): Promise<void> {
       await mountSlackApp(app, {
         slackBotToken: config.slackBotToken,
         slackSigningSecret: config.slackSigningSecret,
+        dryRun: process.env.SLACK_DRY_RUN === 'true',
       });
     } else {
       logger.plain('Slack App not configured — running in CLI-only mode');


### PR DESCRIPTION
## Summary
- **Dry-run mode**: `SLACK_DRY_RUN=true` suppresses all outgoing Slack messages (posts, reactions, updates) while still receiving and processing events — useful for local debugging with real webhook traffic
- **File uploads fix**: Messages with `file_share` subtype were silently dropped by the event filter, preventing the bot from seeing any file attachments
- **Thread broadcasts**: `thread_broadcast` subtype now also accepted
- **Log cleanup**: "Processing" log only emitted when the message will actually be handled (existing task or new @mention/DM), removing noise from unrelated thread replies

## Test plan
- [x] Verified with real Slack file upload — events now received and files downloaded
- [x] Test dry-run mode: set `SLACK_DRY_RUN=true`, send messages, confirm `[DRY RUN]` logs appear and no Slack replies are sent
- [x] Test thread broadcast replies are received

🤖 Generated with [Claude Code](https://claude.com/claude-code)