### PR TITLE
Fix Docker container name conflict across worktrees

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,9 @@
+# Assign a unique PORT per worktree to avoid Docker port conflicts
+[post-create]
+env-port = """
+if [ -f .env ] && grep -q '^PORT=' .env; then
+    sed -i.bak 's/^PORT=.*/PORT={{ branch | hash_port }}/' .env && rm -f .env.bak
+else
+    echo 'PORT={{ branch | hash_port }}' >> .env
+fi
+"""

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,5 +1,6 @@
-# Assign a unique PORT per worktree to avoid Docker port conflicts
+# Copy .env from base worktree, then assign a unique PORT
 [post-create]
+env-copy = "cp {{ base_worktree_path }}/.env .env 2>/dev/null || true"
 env-port = """
 if [ -f .env ] && grep -q '^PORT=' .env; then
     sed -i.bak 's/^PORT=.*/PORT={{ branch | hash_port }}/' .env && rm -f .env.bak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: archie-hq
     restart: unless-stopped
     ports:
       - "${PORT:-3000}:${PORT:-3000}"


### PR DESCRIPTION
## Summary
- Remove hardcoded `container_name: archie-hq` from `docker-compose.yml` — Docker Compose now derives unique container names from the project directory, preventing name collisions across worktrees
- Add Worktrunk `post-create` hook (`.config/wt.toml`) that assigns a unique `PORT` (10000–19999) per worktree using `hash_port`, preventing Docker port binding conflicts

## Test plan
- [x] Run `docker compose up` from two different worktrees simultaneously
- [x] Verify each gets a unique container name (e.g., `archie-hq-archie-1` vs `archie-hqfix-container-setup-archie-1`)
- [ ] Create a new worktree with `wt switch --create test-port` and verify `.env` gets a unique PORT
- [ ] Confirm `docker compose logs -f archie` still works (service name unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)