### PR TITLE
Pull repos to latest on startup and before shared clones

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -31,7 +31,7 @@ import { WORKDIR } from '../system/workdir.js';
 import {
   createRecoverableInputGenerator,
 } from './message-queue.js';
-import { setupSharedClone, cloneExists, isWorktree, migrateWorktreeToClone, fetchOrigin, type CloneCheckout } from '../connectors/github/repo-clone.js';
+import { setupSharedClone, cloneExists, isWorktree, migrateWorktreeToClone, type CloneCheckout } from '../connectors/github/repo-clone.js';
 import { configureGitIdentity } from '../connectors/github/client.js';
 import { loadPrompt } from '../utils/prompt-loader.js';
 import { processAgentEventForLogging, logger } from '../system/logger.js';

--- a/src/connectors/github/repo-clone.ts
+++ b/src/connectors/github/repo-clone.ts
@@ -118,6 +118,15 @@ export async function setupSharedClone(
     resultBranch = defaultBranch;
   }
 
+  // Update the base repo's local branch to match remote before cloning from it
+  // (git clone --shared clones from local branches, not remote tracking refs)
+  try {
+    await gitExec(baseRepoPath, `checkout "${cloneBranch}"`);
+    await gitExec(baseRepoPath, `reset --hard "origin/${cloneBranch}"`);
+  } catch {
+    // Non-fatal — clone will use whatever state the base repo has
+  }
+
   // Clone and initialize submodules (before remote change, so submodules resolve from local base repo)
   await execAsync(`git clone --shared --branch ${cloneBranch} "${baseRepoPath}" "${clonePath}"`);
   await gitExec(clonePath, 'submodule update --init --recursive').catch(() => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ async function main(): Promise<void> {
     await cloneRepos(repoDefs.map((d) => ({
       key: d.repo!.repoKey,
       githubRepo: d.repo!.githubRepo,
+      baseBranch: d.repo!.baseBranch,
     })));
 
     // Log loaded plugins and agents

--- a/src/system/workdir.ts
+++ b/src/system/workdir.ts
@@ -90,12 +90,12 @@ export async function bootstrapWorkdir(): Promise<void> {
  * @param repos - Array of { key, githubRepo } from loaded plugin configs
  */
 export async function cloneRepos(
-  repos: Array<{ key: string; githubRepo: string }>
+  repos: Array<{ key: string; githubRepo: string; baseBranch?: string }>
 ): Promise<void> {
-  for (const { key, githubRepo } of repos) {
+  for (const { key, githubRepo, baseBranch } of repos) {
     const repoPath = join(REPOS_DIR, key);
     const repoUrl = githubRepoToUrl(githubRepo);
-    await cloneOrFetch(repoUrl, repoPath, key);
+    await cloneOrFetch(repoUrl, repoPath, key, baseBranch);
   }
 }
 
@@ -180,20 +180,23 @@ async function checkoutBranch(repoDir: string, branch: string, label: string): P
 }
 
 /**
- * Clone if missing, git fetch --all if exists.
- * Used for source repos (large, just need refs up to date for shared clones).
+ * Clone if missing, fetch and pull default branch if exists.
  */
-async function cloneOrFetch(url: string, targetDir: string, label: string): Promise<void> {
+async function cloneOrFetch(url: string, targetDir: string, label: string, baseBranch?: string): Promise<void> {
   if (existsSync(join(targetDir, '.git'))) {
-    logger.system(`Fetching latest for ${label}...`);
+    logger.system(`Pulling latest for ${label}...`);
     try {
       await execAsync('git remote prune origin', { cwd: targetDir });
       await execAsync('git fetch --all', { cwd: targetDir });
+      const branch = baseBranch || 'main';
+      await execAsync(`git checkout "${branch}"`, { cwd: targetDir });
+      await execAsync(`git reset --hard "origin/${branch}"`, { cwd: targetDir });
     } catch (error) {
-      logger.warn('workdir', `Failed to fetch ${label}, using existing refs: ${error}`);
+      logger.warn('workdir', `Failed to pull ${label}, using existing state: ${error}`);
     }
   } else {
+    const branchFlag = baseBranch ? ` -b "${baseBranch}"` : '';
     logger.system(`Cloning ${label} from ${url}...`);
-    await execAsync(`git clone "${url}" "${targetDir}"`);
+    await execAsync(`git clone${branchFlag} "${url}" "${targetDir}"`);
   }
 }


### PR DESCRIPTION
## Summary
- **Startup**: `cloneOrFetch` now checks out the configured `baseBranch` and resets to `origin/baseBranch` instead of only fetching refs. Fresh clones also use the branch flag.
- **New shared clones**: `setupSharedClone` resets the base repo's local branch to match remote before `git clone --shared`, ensuring new task clones always get latest code even if the server has been running for hours.
- Removed unused `fetchOrigin` import from `spawn.ts`

## Test plan
- [x] Start server, verify repos are pulled to latest on startup
- [x] Create a new task hours after startup, verify shared clone has latest commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)