### PR TITLE
Add subtask spawning for parallel investigation

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -73,6 +73,10 @@ One PM agent instance is spawned per task. It is the orchestrator: it receives a
 | `request_edit_mode` | Request user approval for code changes |
 | `get_agents_status` | Check which agents are spawned and active |
 | `web_research` | Spawn a multi-agent research pipeline |
+| `spawn_subtask` | Spawn an independent subtask for parallel investigation |
+| `send_message_to_subtask` | Send a follow-up message to a running subtask |
+| `get_subtasks_status` | Check status of all spawned subtasks |
+| `cancel_subtask` | Cancel a running subtask |
 | `Skill` | Load domain-specific PM skills from plugins |
 | `Read`, `Glob`, `Grep` | Read files in the shared task folder |
 
@@ -100,6 +104,10 @@ Repo agents are specialized for a single repository. They investigate code, make
 |---|---|---|---|
 | `send_message_to_agent` | `repo-agent-tools` | Always | Report findings or coordinate with peers |
 | `log_finding` | `repo-agent-tools` | Always | Write to shared knowledge log |
+| `spawn_subtask` | `repo-agent-tools` | Always | Spawn an independent subtask |
+| `send_message_to_subtask` | `repo-agent-tools` | Always | Send follow-up to a subtask |
+| `get_subtasks_status` | `repo-agent-tools` | Always | Check subtask statuses |
+| `cancel_subtask` | `repo-agent-tools` | Always | Cancel a running subtask |
 | `web_research` | `research-tools` | Always | Spawn a research pipeline |
 | `fetch` | `repo-tools` | Always | Fetch latest refs from origin |
 | `switch_branch` | `repo-tools` | Always | Switch branches with auto-stash/pop |
@@ -141,6 +149,10 @@ Plugin agents are lightweight, read-only agents for domains that don't need git,
 |---|---|
 | `send_message_to_agent` | Report findings or coordinate with peers |
 | `log_finding` | Write to shared knowledge log |
+| `spawn_subtask` | Spawn an independent subtask |
+| `send_message_to_subtask` | Send follow-up to a subtask |
+| `get_subtasks_status` | Check subtask statuses |
+| `cancel_subtask` | Cancel a running subtask |
 | `web_research` | Spawn a research pipeline |
 | `Read`, `Glob`, `Grep` | Explore files in workspace |
 | `Skill` | Load domain-specific agent skills |
@@ -177,6 +189,20 @@ Broadcast-style logging to the shared `knowledge.log` file. Non-blocking -- the 
 **Finding types**: `discovery`, `decision`, `completion`, `blocker`
 
 **Behavior**: Appends a timestamped entry to `<task>/shared/knowledge.log` with the agent name and finding type. All agents and the PM read this file at the start of each turn to understand task context.
+
+### Subtask Communication
+
+Any agent can spawn independent subtasks via `spawn_subtask`. Subtasks are full tasks with their own PM and specialist agents, running in fresh context with separate repo clones.
+
+**How it works**:
+1. Agent calls `spawn_subtask(goal)` → creates a new Task with a `ParentChannel` as its default channel
+2. The subtask PM thinks it's serving a regular user — its `post_to_user` messages route back to the parent task's originating agent via `deliverMessage()` (same pattern as Slack/CLI: log to knowledge.log + emit event + send standard prompt)
+3. Parent-to-subtask messages use source `'user'` so the subtask PM sees them as normal user messages
+4. Subtasks are fire-and-forget: they run independently and are not terminated when the parent stops. Results arriving on a stopped parent reactivate it.
+
+**Budget**: 10 subtasks per task (shared across all agents), extendable by 10 via user approval. Subtask tools are hidden from subtask agents to prevent recursion.
+
+**Source**: `deliverMessage()` in `src/tasks/task.ts`, `appendCrossTaskMessage()` in `src/tasks/persistence.ts`
 
 ## Thread Owner Pattern
 

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -309,8 +309,9 @@ function scheduleIdleCheck(task: Task): void {
 }
 ```
 
-`checkAllAgentsInactive()` returns `true` only if `spawned.size > 0` and every
-spawned agent's session has `active === false`.
+`checkAllAgentsInactive()` returns `true` only if `spawned.size > 0`, every
+spawned agent's session has `active === false`, and no active subtasks exist
+(checked via `task.metadata.subtask_ids` against `activeTasks`).
 
 ### Progressive recovery
 
@@ -332,12 +333,15 @@ agent's queue and marks the agent active. If the process is dead, it sets
 
 **Source**: `src/tasks/recovery.ts` -- `recoverActiveTasks()`
 
-Called once during server startup after the HTTP server is ready.
+Called once during server startup after the HTTP server is ready. Tasks with
+`parent_task_id` (subtasks) are skipped — they cannot run independently and
+are not recovered.
 
 ```
 recoverActiveTasks()
   --> findTasksByStatus('in_progress')   // grep across sessions/task-*/shared/metadata.json
   --> for each task:
+      --> skip if task.parent_task_id    // subtasks are not recovered
       --> Task.get(task_id)              // build Task from disk metadata
       --> recoverTaskAgents(task)
           --> for each session where active === true:
@@ -349,6 +353,21 @@ recoverActiveTasks()
 During graceful shutdown, `isShuttingDown` is set to `true` via `src/system/shutdown.ts`.
 This causes `task.updateAgentState()` to skip deactivation writes, preserving the
 `active: true` state in metadata so that recovery on restart correctly re-spawns those agents.
+
+### Graceful Agent Shutdown
+
+When a task stops or completes, agents are shut down via `stopAgents()`:
+
+- **Active agents** (mid-turn): `pendingClose = true` is set. The agent finishes its current turn, the SDK Stop hook fires `updateAgentState(false)`, which triggers `setTimeout(() => agent.close(), 0)` on the next tick. This lets the hook complete before the SDK process is killed.
+- **Idle agents** (waiting for input): `agent.close()` is called immediately, which stops the queue and calls `query.close()` to terminate the SDK subprocess.
+
+`Agent.close()` calls `queue.stop()` + `handle.query.close()`. The `query` reference is stored on `AgentHandle` when the SDK `query()` is created in `spawn.ts`.
+
+### Subtask Lifecycle
+
+Subtasks are fire-and-forget. When a parent task stops or completes, its subtasks are **not** terminated — they continue running independently. When a subtask finishes, its `post_to_user` routes the result back to the parent via `deliverMessage()`. If the parent is stopped, this reactivates it (same as a Slack message arriving on a stopped task).
+
+Subtask budget: 10 per task (shared across all agents), extendable by 10 via Slack approval. Tracked on `metadata.subtask_ids` (count) and `metadata.subtask_budget_extra`.
 
 ---
 

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -84,6 +84,9 @@ interface TaskMetadata {
   agent_sessions: Record<string, AgentSessionState | string>;  // per-agent session state
   repositories: Record<string, RepositoryInfo>; // per-repo metadata
   status: TaskStatus;                           // 'in_progress' | 'stopped' | 'completed'
+  parent_task_id?: string;                      // set on subtasks — ID of the parent task
+  subtask_ids?: string[];                       // set on parent — all subtask IDs ever created
+  subtask_budget_extra?: number;                // additional +10 per user approval
   edit_allowed?: boolean;                       // user approved edit mode
   research_budget_extra?: number;               // additional budget granted (+5 per approval)
   research_request_count?: number;              // persisted research call count
@@ -96,7 +99,7 @@ interface TaskMetadata {
 ### Channel (replaces legacy `slack_threads`)
 
 ```typescript
-type Channel = SlackChannel | GitHubChannel;
+type Channel = SlackChannel | GitHubChannel | ParentChannel;
 
 interface SlackChannel {
   type: 'slack';
@@ -110,6 +113,12 @@ interface GitHubChannel {
   type: 'github';
   repo: string;             // GitHub repo identifier
   pr_number: number;        // PR number
+}
+
+interface ParentChannel {
+  type: 'parent';
+  parent_task_id: string;   // ID of the parent task
+  parent_agent: string;     // agent that spawned this subtask (e.g. 'pm-agent')
 }
 ```
 
@@ -214,6 +223,8 @@ and omitted for Slack messages and GitHub events.
 | `slack:#<{channelId}:{channelName}>:{threadId}` | `appendSlackMessage()` | `[2025-01-15T10:30:00Z] [slack:#<C123:general>:1234.5678] [@<U456:Jane Doe>] Fix the login bug` |
 | `{agentName}` | `appendAgentFinding()` | `[2025-01-15T10:31:00Z] [pm-agent] [decision] Assigned backend-agent as task owner` |
 | `github:{repoKey}` | `appendGitHubEvent()` | `[2025-01-15T10:32:00Z] [github:backend] PR #42: reviewer approved` |
+| `subtask:{taskId}` | `appendCrossTaskMessage()` | `[2025-01-15T10:34:00Z] [subtask:task-20250115-1030-abc123] Investigation findings...` |
+| `user` | `appendCrossTaskMessage()` | `[2025-01-15T10:34:00Z] [user] Goal message from parent...` (on subtask's log) |
 | `system` | Various (edit mode, budget) | `[2025-01-15T10:33:00Z] [system] [decision] Edit mode approved by user` |
 
 ### Slack message format

--- a/docs/plans/v20-subtask-spawning.md
+++ b/docs/plans/v20-subtask-spawning.md
@@ -1,0 +1,382 @@
+# Plan: PM Subtask Spawning
+
+## Context
+
+PM currently operates within a single task session. When researching complex bugs or doing deep analysis, a single session may miss angles that parallel sessions would catch. This feature lets PM spawn independent subtasks — each with its own PM + specialist agents, fresh context, own repo clones — then collect findings and synthesize.
+
+**Key design principle**: Simplicity. Subtasks are full tasks with a special channel type that routes `post_to_user` back to the parent PM's message queue instead of Slack.
+
+## How It Works
+
+1. Parent PM calls `spawn_subtask(goal)` → creates a new Task with a **`parent` channel** instead of a Slack channel
+2. Subtask's PM thinks it's talking to a user via `post_to_user`, but messages route to parent PM's queue
+3. Parent PM can send messages to subtask via `send_message_to_subtask(id, message)` → queued to subtask's PM
+4. Subtask is **always read-only** — `request_edit_mode` returns an error
+5. Subtasks **cannot spawn further subtasks** — the `spawn_subtask` tool is not available to subtask PMs
+6. On startup recovery, subtasks (identified by `parent_task_id` in metadata) are **skipped**
+7. When parent task stops/completes, all active subtasks are terminated
+
+## Changes
+
+### 1. Add `parent_task_id` and `subtasks` to TaskMetadata
+
+**File**: [src/types/task.ts](src/types/task.ts)
+
+```typescript
+// Add to TaskMetadata:
+parent_task_id?: string;           // Set on subtasks — ID of the parent task
+subtask_ids?: string[];            // Set on parent — all subtask IDs ever created
+subtask_budget_extra?: number;     // Additional +10 per user approval
+```
+
+### 2. Add `parent` channel type
+
+**File**: [src/types/task.ts](src/types/task.ts)
+
+```typescript
+export type ChannelType = 'slack' | 'github' | 'parent';
+
+export interface ParentChannel extends ChannelBase {
+  type: 'parent';
+  parent_task_id: string;
+}
+
+export type Channel = SlackChannel | GitHubChannel | ParentChannel;
+```
+
+### 3. Route subtask `post_to_user` to parent PM
+
+**File**: [src/tasks/task.ts](src/tasks/task.ts) — `postToUser()` method
+
+Current logic: emit event → append to knowledge.log → post to Slack threads.
+
+Add: if default channel is `parent` type, use `deliverMessage()` (see step 3b) to route to parent PM instead of Slack. Otherwise, use existing Slack posting logic.
+
+```typescript
+async postToUser(message: string, agentName?: string): Promise<void> {
+  const sender = agentName || 'system';
+  emitEvent('message', this.taskId, { from: sender, to: 'user', message });
+  await appendMessageToUser(this.taskId, sender, message);
+
+  const defaultCh = this.metadata.default_channel 
+    ? this.metadata.channels[this.metadata.default_channel] 
+    : null;
+  if (defaultCh?.type === 'parent') {
+    // Route to parent task's PM — same as Slack/CLI: log + event + standard prompt
+    await deliverMessage(defaultCh.parent_task_id, message, `subtask:${this.taskId}`);
+  } else {
+    // Existing Slack posting logic
+    const slackRefs = this.getSlackThreadRefs();
+    if (slackRefs.length > 0) {
+      await Promise.all(slackRefs.map((ref) => removeReaction(ref.channel_id, ref.last_processed_ts, 'eyes')));
+      await postToThreads(slackRefs, message);
+    }
+  }
+}
+```
+
+### 3b. Add `appendCrossTaskMessage()` persistence helper + `deliverMessage()` routing helper
+
+These follow the exact same pattern as CLI and Slack message delivery:
+- **CLI**: `appendCliMessage()` (knowledge log + event) → `task.sendMessage(AGENT_PROMPTS.existingTask)`
+- **Slack**: `appendSlackMessage()` per message (knowledge log + event) → `task.sendMessage(AGENT_PROMPTS.existingTask)`
+
+Cross-task messages use the same two-step approach: log the message, then send a standard prompt so PM reads from knowledge log.
+
+**File**: [src/tasks/persistence.ts](src/tasks/persistence.ts)
+
+New function mirroring `appendCliMessage` / `appendSlackMessage`:
+
+```typescript
+/**
+ * Append a cross-task message to the knowledge log.
+ * Used for subtask↔parent communication in both directions.
+ * Same pattern as appendCliMessage/appendSlackMessage — logs + emits event.
+ */
+export async function appendCrossTaskMessage(
+  taskId: string,
+  source: string,
+  message: string,
+): Promise<void> {
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    source,
+    message,
+  };
+  await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
+  emitEvent('message', taskId, { from: source, to: 'pm-agent', message });
+}
+```
+
+Knowledge log entries:
+- **Subtask→parent**: `[2025-...] [subtask:task-20250411-1234-abc123] Findings from subtask...` — parent PM sees which subtask reported
+- **Parent→subtask**: `[2025-...] [user] Message from parent...` — subtask PM sees this as a normal user message (preserves the illusion that it's serving a regular user)
+
+**File**: [src/tasks/task.ts](src/tasks/task.ts)
+
+Module-level function (has direct access to `activeTasks` and `Task` — no circular import needed):
+
+```typescript
+/**
+ * Deliver a message to any task's agent. Follows the same pattern as
+ * Slack (appendSlackMessage + sendMessage) and CLI (appendCliMessage + sendMessage):
+ * 1. Log message to target task's knowledge log + emit event
+ * 2. Load/reactivate task + send standard prompt to agent (agent reads knowledge log)
+ */
+export async function deliverMessage(
+  taskId: string,
+  message: string,
+  source: string,
+): Promise<void> {
+  // 1. Log to target task's knowledge log + emit event
+  await appendCrossTaskMessage(taskId, source, message);
+
+  // 2. Load/reactivate task and send standard prompt to PM (same as Slack/CLI)
+  const task = activeTasks.get(taskId) ?? await Task.get(taskId);
+  await task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
+}
+```
+
+Usage:
+- **Subtask→parent** (`postToUser`): `deliverMessage(parentTaskId, message, `subtask:${this.taskId}`)` — parent PM sees subtask source
+- **Parent→subtask** (`send_message_to_subtask`): `deliverMessage(subtaskId, message, 'user')` — subtask PM sees it as a user message
+- **Initial subtask spawn** (`spawn_subtask`): `appendCrossTaskMessage` + `sendMessage(AGENT_PROMPTS.newTask)` (see step 5)
+
+All paths: append to knowledge log → emit event → load/reactivate task → standard prompt to PM. Identical to how Slack and CLI work.
+
+### 4. Block `request_edit_mode` and research budget extension for subtasks
+
+**File**: [src/agents/tools.ts](src/agents/tools.ts) — `createRequestEditModeTool`
+
+Add early return at top of handler:
+
+```typescript
+if (task.metadata.parent_task_id) {
+  return err('This tool is not available in the current task context.');
+}
+```
+
+**File**: [src/tasks/task.ts](src/tasks/task.ts) — `onResearchBudgetExceeded()`
+
+For subtasks, don't post approval buttons or stop the task. Instead, just let the research tool return an error so the agent naturally reports back to the parent:
+
+```typescript
+async onResearchBudgetExceeded(): Promise<void> {
+  // Subtasks: no approval flow, research tool will return error, agent reports back naturally
+  if (this.metadata.parent_task_id) return;
+  
+  // ... existing approval button flow for normal tasks ...
+}
+```
+
+The research MCP tool already checks `checkResearchBudget()` before executing — when it returns `{allowed: false}`, the tool returns an error message. The subtask PM will naturally report this limitation back via `post_to_user`, which routes to the parent PM. Subtasks keep the default research limit of 5.
+
+### 5. Create subtask tools (PM-only, parent tasks only)
+
+**File**: [src/agents/tools.ts](src/agents/tools.ts)
+
+Four new tools, only added to the PM MCP server when `task.metadata.parent_task_id` is undefined:
+
+#### `spawn_subtask(goal)`
+- Check subtask budget (10 base + extras, prompt user via Slack if exceeded)
+- Call `Task.create()`
+- Set subtask's `metadata.parent_task_id = task.taskId`
+- Set subtask's channel: `{ type: 'parent', parent_task_id: task.taskId }` as default channel
+- Append to parent's `metadata.subtask_ids[]`, call `task.debouncedSave()` on parent
+- Call `subtask.debouncedSave()` to persist parent_task_id and channel
+- `appendCrossTaskMessage(subtaskId, 'user', goal)` — log goal to subtask knowledge log (looks like a user message)
+- `subtask.sendMessage(AGENT_PROMPTS.newTask, 'pm-agent')` — start subtask PM (reads knowledge log)
+- Return subtask ID + note: "You will be notified when the subtask reports back. No need to poll — continue with other work."
+
+#### `send_message_to_subtask(subtask_id, message)`
+- Validate subtask_id is in `task.metadata.subtask_ids`
+- `deliverMessage(subtaskId, message, 'user')` — logs to subtask knowledge log as user message + events, sends standard prompt to subtask PM
+- Return confirmation + note: "Message delivered. You will be notified when the subtask responds."
+
+#### `get_subtasks_status()`
+- Iterate `task.metadata.subtask_ids`
+- For each: check if active, get status, get agent statuses
+- Return formatted list
+
+#### `cancel_subtask(subtask_id)`
+- Look up subtask, call `subtask.stop()`
+- Return confirmation
+
+### 6. Subtask budget with Slack approval
+
+**File**: [src/tasks/task.ts](src/tasks/task.ts)
+
+Add methods mirroring research budget pattern:
+
+```typescript
+checkSubtaskBudget(): { allowed: boolean; used: number; limit: number }
+onSubtaskBudgetExceeded(): Promise<void>  // posts approval buttons, stops task
+handleSubtaskBudgetApproval(): void       // extends limit by 10, resumes PM
+handleSubtaskBudgetDenial(): void         // logs denial, resumes PM
+```
+
+Budget: 10 base + `subtask_budget_extra` (incremented by 10 per approval).
+Count: `metadata.subtask_ids.length`.
+
+### 7. Wire approval buttons for subtask budget
+
+**File**: [src/connectors/slack/events.ts](src/connectors/slack/events.ts)
+
+Add action handlers for `approve_subtask_budget` and `deny_subtask_budget`, same pattern as research budget.
+
+**File**: [src/connectors/api/routes.ts](src/connectors/api/routes.ts) — `POST /tasks/:id/approve`
+
+Add `subtask_budget` case alongside existing `edit_mode` and `research_budget`:
+
+```typescript
+} else if (type === 'subtask_budget') {
+  if (approve) {
+    await task.handleSubtaskBudgetApproval();
+  } else {
+    await task.handleSubtaskBudgetDenial();
+  }
+}
+```
+
+### 8. Subtask-aware wall-clock timeout message
+
+**File**: [src/tasks/task.ts](src/tasks/task.ts) — `startTaskTimeout()`
+
+The timeout handler calls `this.postToUser(...)` which for subtasks routes to the parent PM. Adjust the message so the parent PM understands what happened:
+
+```typescript
+const timeoutMessage = this.metadata.parent_task_id
+  ? `Subtask timed out after ${Math.round(elapsed / 60_000)} minutes without completing. Partial findings (if any) are in the knowledge log.`
+  : `⏱️ Task timed out after ${Math.round(elapsed / 60_000)} minutes. Stopping task.`;
+await this.postToUser(timeoutMessage);
+```
+
+### 9. Terminate subtasks when parent stops
+
+**File**: [src/tasks/task.ts](src/tasks/task.ts) — `stop()` and `complete()` methods
+
+Before existing cleanup, add:
+
+```typescript
+// Stop all active subtasks
+if (this.metadata.subtask_ids?.length) {
+  for (const subtaskId of this.metadata.subtask_ids) {
+    const subtask = activeTasks.get(subtaskId);
+    if (subtask?.isActive) {
+      await subtask.stop();
+    }
+  }
+}
+```
+
+### 10. Skip subtasks during startup recovery
+
+**File**: [src/tasks/recovery.ts](src/tasks/recovery.ts) — `recoverActiveTasks()`
+
+Add filter:
+
+```typescript
+// Skip subtasks — they cannot run independently
+if (taskMeta.parent_task_id) {
+  logger.system(`Recovery: Skipping subtask ${taskMeta.task_id} (parent: ${taskMeta.parent_task_id})`);
+  continue;
+}
+```
+
+### 11. Register subtask tools conditionally in PM MCP server
+
+**File**: [src/agents/tools.ts](src/agents/tools.ts) — `createPMAgentMcpServer()`
+
+```typescript
+export function createPMAgentMcpServer(agent: Agent, task: Task) {
+  const tools = [
+    createSendMessageTool(agent, task),
+    createPostToUserTool(agent, task),
+    createAssignTaskOwnerTool(agent, task),
+    createReportCompletionTool(agent, task),
+    createRequestEditModeTool(agent, task),
+    createGetAgentsStatusTool(agent, task),
+    createMuteThreadTool(agent, task),
+  ];
+
+  // Subtask tools only for parent tasks (not subtasks themselves)
+  if (!task.metadata.parent_task_id) {
+    tools.push(
+      createSpawnSubtaskTool(agent, task),
+      createSendMessageToSubtaskTool(agent, task),
+      createGetSubtasksStatusTool(agent, task),
+      createCancelSubtaskTool(agent, task),
+    );
+  }
+
+  return createSdkMcpServer({
+    name: 'pm-agent-tools',
+    version: '1.0.0',
+    tools,
+  });
+}
+```
+
+### 12. Render parent channel in CLI task list and move `#` prefix to API
+
+**File**: [src/connectors/api/routes.ts](src/connectors/api/routes.ts) — `GET /api/tasks`
+
+Currently extracts `channel_name` only from Slack channels (lines 91-95). Add handling for all channel types and move the `#` prefix here (instead of CLI adding it):
+
+```typescript
+let channel_name: string | null = null;
+if (metadata.default_channel && metadata.channels[metadata.default_channel]) {
+  const ch = metadata.channels[metadata.default_channel];
+  if (ch.type === 'slack') {
+    channel_name = ch.channel_name.startsWith('DM with') ? ch.channel_name : `#${ch.channel_name}`;
+  } else if (ch.type === 'parent') {
+    channel_name = `subtask of ${ch.parent_task_id}`;
+  }
+}
+```
+
+**File**: [src/cli/components/TaskList.tsx](src/cli/components/TaskList.tsx) — channel display (lines 161-163)
+
+Remove the `#` prefix logic from CLI — API now returns display-ready channel names:
+
+```typescript
+const channel = task.channel_name || 'cli';
+```
+
+### 13. Add brief subtask guidance to PM prompt
+
+**File**: [prompts/pm-agent.md](prompts/pm-agent.md)
+
+Add a short section (keep it minimal — detailed patterns will come via skills later):
+
+```markdown
+## Subtasks
+
+You can spawn independent subtasks to investigate in parallel. Each subtask gets its own agents and fresh context. Use this carefully — only when parallel investigation genuinely helps (e.g., exploring multiple hypotheses for a bug, researching different angles of a complex question). Subtasks report findings back to you automatically. Do not poll — continue with other work while subtasks run.
+```
+
+## Files to Modify
+
+1. [src/types/task.ts](src/types/task.ts) — Add `ParentChannel`, extend `TaskMetadata`
+2. [src/tasks/persistence.ts](src/tasks/persistence.ts) — Add `appendCrossTaskMessage()` (knowledge log + event for cross-task messages)
+3. [src/tasks/task.ts](src/tasks/task.ts) — Add `deliverMessage()`, route `postToUser` to parent, subtask budget methods, subtask-aware timeout, terminate subtasks on stop/complete, skip research budget approval for subtasks
+4. [src/agents/tools.ts](src/agents/tools.ts) — 4 new subtask tools, block edit mode for subtasks, conditional PM tool registration
+5. [src/tasks/recovery.ts](src/tasks/recovery.ts) — Skip subtasks in startup recovery
+6. [src/connectors/slack/events.ts](src/connectors/slack/events.ts) — Subtask budget approval buttons
+7. [src/connectors/api/routes.ts](src/connectors/api/routes.ts) — Render parent channel in task list, add `subtask_budget` approval type, move `#` prefix from CLI
+8. [src/cli/components/TaskList.tsx](src/cli/components/TaskList.tsx) — Simplify channel display (API now returns display-ready names)
+9. [prompts/pm-agent.md](prompts/pm-agent.md) — Brief subtask tool guidance
+
+## Verification
+
+1. **Typecheck**: `npm run typecheck` — ensure no type errors
+2. **Manual test**: Create a task via Slack, have PM spawn a subtask, verify:
+   - Subtask PM receives the goal message
+   - Subtask's `post_to_user` delivers to parent PM's queue
+   - Parent PM can send messages to subtask
+   - `get_subtasks_status` shows correct state
+   - `request_edit_mode` in subtask returns error
+   - Subtask cannot spawn further subtasks (tool not available)
+   - Parent completion terminates subtasks
+   - Server restart skips subtask recovery
+   - Budget of 10 enforced, approval extends by 10

--- a/prompts/agent-core.md
+++ b/prompts/agent-core.md
@@ -32,6 +32,17 @@ Key principle: Unless explicitly assigned as Task Owner, you are a Participant.
 - **send_message_to_agent**: Send a message to another agent for coordination, questions, work requests, or reporting findings
 - **log_finding**: Write to the shared knowledge log (visible to all agents and pm-agent) to record discoveries, decisions, completions, or blockers
 
+### Subtasks
+
+You can spawn independent subtasks for parallel investigation. Each subtask gets its own agents and fresh context. Use this carefully — only when parallel investigation genuinely helps. Subtasks report findings back to you automatically. Do not poll — continue with other work or STOP and wait.
+
+- `spawn_subtask(goal)`: Start an independent subtask with the given goal
+- `send_message_to_subtask(subtask_id, message)`: Send a follow-up to a running subtask
+- `get_subtasks_status()`: Check status of all subtasks
+- `cancel_subtask(subtask_id)`: Stop a running subtask
+
+After spawning subtasks, STOP and wait for their results — do not report completion until subtask findings arrive.
+
 ## Coordination Strategies
 
 When work spans multiple areas, you must determine the appropriate coordination strategy:
@@ -54,10 +65,11 @@ The key question for determining strategy: "Can both pieces of work proceed inde
 You must STOP and wait for further instructions in these situations:
 
 1. After sending a sequential coordination request to another agent
-2. After completing your work as a Participant (report to requesting agent, then stop)
-3. After completing your own work in parallel coordination as Task Owner, if you haven't received all Participant completion reports yet (STOP and wait for Participant messages — do not poll logs or ping)
-4. After completing your work as Task Owner AND receiving completion from all Participants (report to pm-agent, then stop)
-5. When you need confirmation, clarification, or approval
+2. After spawning subtasks — wait for their results before reporting back
+3. After completing your work as a Participant (report to requesting agent, then stop)
+4. After completing your own work in parallel coordination as Task Owner, if you haven't received all Participant completion reports yet (STOP and wait for Participant messages — do not poll logs or ping)
+5. After completing your work as Task Owner AND receiving completion from all Participants (report to pm-agent, then stop)
+6. When you need confirmation, clarification, or approval
 
 Do not send multiple messages for the same piece of work. Do not continue working after reporting completion.
 

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -28,9 +28,11 @@ At the start of each turn, read `knowledge.log` once to understand the current c
 
 The key to managing your turns is understanding who you're waiting for after your actions:
 
-- **Waiting for USER**: You must explicitly pause the system using a turn-ending tool (`report_completion` or `request_edit_mode`), then STOP immediately. The user needs to respond before work continues.
+- **Waiting for USER input**: You must explicitly pause the system using a turn-ending tool (`report_completion` or `request_edit_mode`), then STOP immediately. The user needs to respond before work continues.
 
 - **Waiting for AGENT**: Your turn ends naturally when you delegate work via `send_message_to_agent`. Do NOT call turn-ending tools. The agent will respond and that will trigger your next turn.
+
+- **Waiting for SUBTASK**: Your turn ends naturally after spawning subtasks — same as waiting for an agent. The subtask will report back and trigger your next turn. Do NOT call turn-ending tools.
 
 - **Neither**: You have more actions to take. Continue working, then re-evaluate.
 
@@ -71,7 +73,7 @@ When assigning work to an agent via `send_message_to_agent`, ALWAYS start your m
 
 ### 6. Task Completion Philosophy
 
-Calling `report_completion` doesn't abandon work - it means "I've responded to my requester and am now waiting for their next input." Tasks automatically reopen when users respond or new events arrive.
+Calling `report_completion` means "I need the user to respond before work can continue." It pauses the entire system. Only use it when you are genuinely waiting for user input — not when you are waiting for agents or subtasks to report back. Tasks automatically reopen when users respond or new events arrive.
 
 **When to include a message with report_completion** (user-facing milestones):
 
@@ -97,6 +99,15 @@ Use as many of these as needed during your turn:
 ### Thread Management Tools
 
 - `mute_thread`: Unsubscribe from the Slack thread until someone @mentions you again. Use when asked to disengage.
+
+### Subtasks
+
+You can spawn independent subtasks to investigate in parallel. Each subtask gets its own agents and fresh context. Use this carefully — only when parallel investigation genuinely helps (e.g., exploring multiple hypotheses for a bug, researching different angles of a complex question). Subtasks report findings back to you automatically. Do not poll — continue with other work while subtasks run.
+
+- `spawn_subtask(goal)`: Start an independent subtask with the given goal
+- `send_message_to_subtask(subtask_id, message)`: Send a follow-up to a running subtask
+- `get_subtasks_status()`: Check status of all subtasks
+- `cancel_subtask(subtask_id)`: Stop a running subtask
 
 ### Turn-Ending Tools
 
@@ -157,15 +168,15 @@ For EACH tool you're considering, systematically check:
 - List out EVERY required parameter for this tool
 - For each parameter, note: "Have this: [value]" or "Missing: [what's needed]"
 - Do I have ALL the information needed to call this tool? (yes/no)
-- After calling this tool, who would I be waiting for? (USER / AGENT / neither)
+- After calling this tool, who would I be waiting for? (USER / AGENT / SUBTASK / neither)
 
 **7. Rule Compliance Checks**
 Go through EACH of these rules explicitly, even if marked N/A:
 
 - Re-reading knowledge.log during this turn? [Should be NO]
 - Taking actions AFTER send_message_to_agent? [Should be NO - turn ends naturally, or N/A if not using send_message_to_agent]
-- Calling turn-ending tool when waiting for USER? [Should be YES, or N/A if not waiting for USER]
-- Calling turn-ending tool when waiting for AGENT? [Should be NO, or N/A if not waiting for AGENT]
+- Calling turn-ending tool when waiting for USER input? [Should be YES, or N/A if not waiting for USER]
+- Calling turn-ending tool when waiting for AGENT or SUBTASK? [Should be NO, or N/A]
 - Using post_to_user to explain BEFORE request_edit_mode? [Should be YES if requesting edit mode, or N/A]
 - Starting delegation message with protocol language? [Should be YES if delegating, or N/A]
 
@@ -226,7 +237,7 @@ Here's the format your analysis should follow:
     - [param2]: Have this: [value] / Missing: [what's needed]
       [list ALL parameters]
   - Have all info? [yes/no]
-  - After this, waiting for: [USER/AGENT/neither]
+  - After this, waiting for: [USER/AGENT/SUBTASK/neither]
     [Repeat for each tool being considered]
 
 **Rule Compliance Checks:**
@@ -240,10 +251,10 @@ Here's the format your analysis should follow:
 
 **Waiting-For Logic:**
 
-- After [action 1]: waiting for [USER/AGENT/neither]
-- After [action 2]: waiting for [USER/AGENT/neither]
-- After [action 3]: waiting for [USER/AGENT/neither]
-- Final: After all actions, waiting for [USER/AGENT/neither]
+- After [action 1]: waiting for [USER/AGENT/SUBTASK/neither]
+- After [action 2]: waiting for [USER/AGENT/SUBTASK/neither]
+- After [action 3]: waiting for [USER/AGENT/SUBTASK/neither]
+- Final: After all actions, waiting for [USER/AGENT/SUBTASK/neither]
 
 **Final Action Plan:**
 

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -17,6 +17,7 @@ export class Agent {
   readonly queue: MessageQueue;
   handle?: AgentHandle;
   session: AgentSessionState;
+  pendingClose: boolean = false;
 
   constructor(def: AgentDef) {
     this.def = def;
@@ -36,6 +37,17 @@ export class Agent {
    */
   get isRunning(): boolean {
     return this.handle?.isRunning ?? false;
+  }
+
+  /**
+   * Forcefully terminate the agent's SDK process.
+   * Kills the subprocess immediately — use for subtask cleanup.
+   */
+  close(): void {
+    this.queue.stop();
+    if (this.handle?.query) {
+      this.handle.query.close();
+    }
   }
 
   /**

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -12,6 +12,7 @@ import { join } from 'path';
 import { mkdir, symlink, readdir, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { query } from '@anthropic-ai/claude-agent-sdk';
+import type { AgentHandle } from '../types/agent.js';
 import type { Agent } from './agent.js';
 import type { Task } from '../tasks/task.js';
 import {
@@ -492,7 +493,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
   const existingSessionId = agent.session.session_id;
   const recoverable = createRecoverableInputGenerator(agent.queue);
 
-  const handle = {
+  const handle: AgentHandle = {
     running: Promise.resolve() as Promise<void>,
     isRunning: true,
   };
@@ -508,6 +509,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
             prompt: recoverable.generator() as any,
             options: buildQueryOptions(sessionId),
           });
+          handle.query = agentQuery;
 
           for await (const event of agentQuery) {
             if (event.type === 'system' && event.subtype === 'init') {

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -14,13 +14,14 @@ import { promisify } from 'util';
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { AgentName, FindingType } from '../types/task.js';
-import type { Task } from '../tasks/task.js';
+import { type Task, activeTasks, deliverMessage } from '../tasks/task.js';
+import { appendAgentFinding, appendCrossTaskMessage } from '../tasks/persistence.js';
+import { AGENT_PROMPTS } from './prompts.js';
 import type { Agent } from './agent.js';
 import { getAgentIds } from './registry.js';
 import { getGitHubClient } from '../connectors/github/client.js';
 import { gitExec } from '../connectors/github/repo-clone.js';
 import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
-import { appendAgentFinding } from '../tasks/persistence.js';
 import { logger } from '../system/logger.js';
 
 // Re-export branch state helpers for consumers that import from tools.ts
@@ -173,6 +174,10 @@ function createRequestEditModeTool(agent: Agent, task: Task) {
       reason: z.string().describe('Brief summary of what changes need to be made'),
     },
     async (args) => {
+      if (task.metadata.parent_task_id) {
+        return err('This tool is not available in the current task context.');
+      }
+
       const agentName = agent.def.id as AgentName;
       logger.agentAction(agentName, 'Requesting edit mode', args.reason);
       task.touch();
@@ -739,24 +744,169 @@ function createListBranchesTool(agent: Agent, task: Task) {
   );
 }
 
+// ---- Subtask tools (PM-only, parent tasks only) ----
+
+function createSpawnSubtaskTool(agent: Agent, task: Task) {
+  return tool(
+    'spawn_subtask',
+    'Spawn an independent subtask for parallel investigation. The subtask gets its own PM and specialist agents with fresh context. You will be notified when the subtask reports back — no need to poll, continue with other work.',
+    {
+      goal: z.string().describe('Clear goal/question for the subtask to investigate'),
+    },
+    async (args) => {
+      const agentName = agent.def.id as AgentName;
+      logger.agentAction(agentName, 'Spawning subtask', args.goal);
+      task.touch();
+
+      // Check subtask budget
+      const budget = task.checkSubtaskBudget();
+      if (!budget.allowed) {
+        await task.onSubtaskBudgetExceeded();
+        return err(`Subtask budget exceeded (${budget.used}/${budget.limit}). Approval requested.`);
+      }
+
+      // Create the subtask
+      const { Task: TaskClass } = await import('../tasks/task.js');
+      const subtask = await TaskClass.create();
+
+      // Set subtask metadata
+      subtask.metadata.parent_task_id = task.taskId;
+      const channelId = `parent:${task.taskId}`;
+      subtask.metadata.channels[channelId] = {
+        type: 'parent',
+        parent_task_id: task.taskId,
+        parent_agent: agent.def.id,
+      };
+      subtask.metadata.default_channel = channelId;
+      subtask.debouncedSave();
+
+      // Track on parent
+      task.metadata.subtask_ids ??= [];
+      task.metadata.subtask_ids.push(subtask.taskId);
+      task.debouncedSave();
+
+      // Log goal to subtask knowledge log (looks like a user message) and start subtask PM
+      await appendCrossTaskMessage(subtask.taskId, 'user', args.goal);
+      await subtask.sendMessage(AGENT_PROMPTS.newTask, 'pm-agent');
+
+      await appendAgentFinding(task.taskId, agentName, `Spawned subtask ${subtask.taskId}: ${args.goal}`, 'decision');
+      logger.system(`Task ${task.taskId}: spawned subtask ${subtask.taskId}`);
+
+      return ok(`Subtask ${subtask.taskId} spawned. You will be notified when it reports back. No need to poll — continue with other work.`);
+    },
+  );
+}
+
+function createSendMessageToSubtaskTool(agent: Agent, task: Task) {
+  return tool(
+    'send_message_to_subtask',
+    'Send a follow-up message to a running subtask. You will be notified when the subtask responds.',
+    {
+      subtask_id: z.string().describe('The subtask ID to send the message to'),
+      message: z.string().describe('The message content'),
+    },
+    async (args) => {
+      const agentName = agent.def.id as AgentName;
+      task.touch();
+
+      if (!task.metadata.subtask_ids?.includes(args.subtask_id)) {
+        return err(`Unknown subtask: ${args.subtask_id}`);
+      }
+
+      await deliverMessage(args.subtask_id, args.message, 'user');
+      logger.agentMessage(agentName, `subtask:${args.subtask_id}`, args.message, { truncate: 100 });
+
+      return ok(`Message delivered to ${args.subtask_id}. You will be notified when the subtask responds.`);
+    },
+  );
+}
+
+function createGetSubtasksStatusTool(agent: Agent, task: Task) {
+  return tool(
+    'get_subtasks_status',
+    'Get the status of all subtasks spawned by this task.',
+    {},
+    async () => {
+      const subtaskIds = task.metadata.subtask_ids ?? [];
+      if (subtaskIds.length === 0) {
+        return ok('No subtasks spawned yet.');
+      }
+
+      const lines: string[] = [];
+      for (const subtaskId of subtaskIds) {
+        const subtask = activeTasks.get(subtaskId);
+        if (subtask?.isActive) {
+          const agents = subtask.getAgentStatus();
+          const activeAgents = agents.filter((a) => a.active).map((a) => a.agent);
+          lines.push(`- ${subtaskId}: active (agents: ${activeAgents.join(', ') || 'none active'})`);
+        } else {
+          lines.push(`- ${subtaskId}: inactive`);
+        }
+      }
+
+      return ok(`Subtasks (${subtaskIds.length}):\n${lines.join('\n')}`);
+    },
+  );
+}
+
+function createCancelSubtaskTool(agent: Agent, task: Task) {
+  return tool(
+    'cancel_subtask',
+    'Cancel a running subtask.',
+    {
+      subtask_id: z.string().describe('The subtask ID to cancel'),
+    },
+    async (args) => {
+      const agentName = agent.def.id as AgentName;
+      task.touch();
+
+      if (!task.metadata.subtask_ids?.includes(args.subtask_id)) {
+        return err(`Unknown subtask: ${args.subtask_id}`);
+      }
+
+      const subtask = activeTasks.get(args.subtask_id);
+      if (subtask?.isActive) {
+        await subtask.stop();
+        logger.agentAction(agentName, 'Cancelled subtask', args.subtask_id);
+        return ok(`Subtask ${args.subtask_id} cancelled.`);
+      }
+
+      return ok(`Subtask ${args.subtask_id} is already inactive.`);
+    },
+  );
+}
+
 // ---- MCP Server creation ----
 
 /**
  * Create the MCP server with PM agent tools.
  */
 export function createPMAgentMcpServer(agent: Agent, task: Task) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tools: any[] = [
+    createSendMessageTool(agent, task),
+    createPostToUserTool(agent, task),
+    createAssignTaskOwnerTool(agent, task),
+    createReportCompletionTool(agent, task),
+    createRequestEditModeTool(agent, task),
+    createGetAgentsStatusTool(agent, task),
+    createMuteThreadTool(agent, task),
+  ];
+
+  // Subtask tools only for parent tasks (not subtasks themselves)
+  if (!task.metadata.parent_task_id) {
+    tools.push(
+      createSpawnSubtaskTool(agent, task),
+      createSendMessageToSubtaskTool(agent, task),
+      createGetSubtasksStatusTool(agent, task),
+      createCancelSubtaskTool(agent, task),
+    );
+  }
+
   return createSdkMcpServer({
     name: 'pm-agent-tools',
     version: '1.0.0',
-    tools: [
-      createSendMessageTool(agent, task),
-      createPostToUserTool(agent, task),
-      createAssignTaskOwnerTool(agent, task),
-      createReportCompletionTool(agent, task),
-      createRequestEditModeTool(agent, task),
-      createGetAgentsStatusTool(agent, task),
-      createMuteThreadTool(agent, task),
-    ],
+    tools,
   });
 }
 
@@ -797,12 +947,25 @@ export function createRepoToolsMcpServer(agent: Agent, task: Task) {
  * Create the MCP server with base agent tools (repo + plugin agents).
  */
 export function createBaseAgentMcpServer(agent: Agent, task: Task) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tools: any[] = [
+    createSendMessageTool(agent, task),
+    createLogFindingTool(agent, task),
+  ];
+
+  // Subtask tools available to all agents (shared budget per task)
+  if (!task.metadata.parent_task_id) {
+    tools.push(
+      createSpawnSubtaskTool(agent, task),
+      createSendMessageToSubtaskTool(agent, task),
+      createGetSubtasksStatusTool(agent, task),
+      createCancelSubtaskTool(agent, task),
+    );
+  }
+
   return createSdkMcpServer({
     name: 'repo-agent-tools',
     version: '1.0.0',
-    tools: [
-      createSendMessageTool(agent, task),
-      createLogFindingTool(agent, task),
-    ],
+    tools,
   });
 }

--- a/src/cli/components/TaskList.tsx
+++ b/src/cli/components/TaskList.tsx
@@ -158,9 +158,7 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
         const globalIndex = scrollTop + i;
         const selected = globalIndex === cursor;
         const activeAgents = task.agents?.filter((a) => a.active).length ?? 0;
-        const channel = task.channel_name
-          ? (task.channel_name.startsWith('DM with') ? task.channel_name : `#${task.channel_name}`)
-          : 'cli';
+        const channel = task.channel_name || 'cli';
 
         return (
           <Box key={task.task_id} paddingX={1} gap={1}>

--- a/src/connectors/api/routes.ts
+++ b/src/connectors/api/routes.ts
@@ -87,11 +87,15 @@ export function mountApiRoutes(app: Application): void {
 
         const activeTask = activeTasks.get(dir);
 
-        // Extract channel name from default channel
+        // Extract display-ready channel name from default channel
         let channel_name: string | null = null;
         if (metadata.default_channel && metadata.channels[metadata.default_channel]) {
           const ch = metadata.channels[metadata.default_channel];
-          if (ch.type === 'slack') channel_name = ch.channel_name;
+          if (ch.type === 'slack') {
+            channel_name = ch.channel_name.startsWith('DM with') ? ch.channel_name : `#${ch.channel_name}`;
+          } else if (ch.type === 'parent') {
+            channel_name = `subtask of ${ch.parent_task_id}`;
+          }
         }
 
         tasks.push({
@@ -233,6 +237,12 @@ export function mountApiRoutes(app: Application): void {
           await task.handleResearchBudgetApproval();
         } else {
           await task.handleResearchBudgetDenial();
+        }
+      } else if (type === 'subtask_budget') {
+        if (approve) {
+          await task.handleSubtaskBudgetApproval();
+        } else {
+          await task.handleSubtaskBudgetDenial();
         }
       } else {
         res.status(400).json({ error: `Unknown approval type: ${type}` });

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -241,6 +241,60 @@ export async function mountSlackApp(
       logger.error('Server', 'Error handling research budget denial', error);
     }
   });
+
+  // Handle subtask budget approval button
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app!.action('approve_subtask_budget', async ({ action, ack, body }: any) => {
+    await ack();
+
+    const taskId = action.value;
+    const userId = body.user?.id || 'unknown';
+
+    logger.server(`Subtask budget approved by ${userId} for task ${taskId}`);
+
+    try {
+      if (body.channel?.id && body.message?.ts) {
+        await updateMessage(
+          body.channel.id,
+          body.message.ts,
+          `✅ *Subtask budget extended* by <@${userId}> (+10 subtasks)`,
+          []
+        );
+      }
+
+      const task = await Task.get(taskId);
+      await task.handleSubtaskBudgetApproval();
+    } catch (error) {
+      logger.error('Server', 'Error handling subtask budget approval', error);
+    }
+  });
+
+  // Handle subtask budget denial button
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app!.action('deny_subtask_budget', async ({ action, ack, body }: any) => {
+    await ack();
+
+    const taskId = action.value;
+    const userId = body.user?.id || 'unknown';
+
+    logger.server(`Subtask budget denied by ${userId} for task ${taskId}`);
+
+    try {
+      if (body.channel?.id && body.message?.ts) {
+        await updateMessage(
+          body.channel.id,
+          body.message.ts,
+          `❌ *Additional subtasks denied* by <@${userId}>`,
+          []
+        );
+      }
+
+      const task = await Task.get(taskId);
+      await task.handleSubtaskBudgetDenial();
+    } catch (error) {
+      logger.error('Server', 'Error handling subtask budget denial', error);
+    }
+  });
 }
 
 

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -295,6 +295,27 @@ export async function appendCliMessage(
 }
 
 /**
+ * Append a cross-task message to the knowledge log.
+ * Used for subtask↔parent communication in both directions.
+ * Same pattern as appendCliMessage/appendSlackMessage — logs + emits event.
+ */
+export async function appendCrossTaskMessage(
+  taskId: string,
+  source: string,
+  message: string,
+  target: string = 'pm-agent',
+): Promise<void> {
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    source,
+    message,
+  };
+
+  await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
+  emitEvent('message', taskId, { from: source, to: target, message });
+}
+
+/**
  * Read the knowledge log
  */
 export async function readKnowledgeLog(taskId: string): Promise<string> {

--- a/src/tasks/recovery.ts
+++ b/src/tasks/recovery.ts
@@ -11,7 +11,7 @@ import { findTasksByStatus } from './persistence.js';
 import { logger } from '../system/logger.js';
 import { getIsShuttingDown } from '../system/shutdown.js';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
-import type { Task } from './task.js';
+import { type Task, activeTasks } from './task.js';
 import type { AgentName } from '../types/index.js';
 
 // ============================================================================
@@ -36,6 +36,12 @@ export async function recoverActiveTasks(): Promise<void> {
   const { Task: TaskClass } = await import('./task.js');
 
   for (const taskMeta of tasks) {
+    // Skip subtasks — they cannot run independently
+    if (taskMeta.parent_task_id) {
+      logger.system(`Recovery: Skipping subtask ${taskMeta.task_id} (parent: ${taskMeta.parent_task_id})`);
+      continue;
+    }
+
     try {
       const task = await TaskClass.get(taskMeta.task_id);
       await recoverTaskAgents(task);
@@ -87,12 +93,22 @@ export function scheduleIdleCheck(task: Task): void {
 
 /**
  * Check if all spawned agents are inactive.
+ * Also considers active subtasks — if any subtask is still running,
+ * the task is waiting for results and is not truly idle.
  */
 function checkAllAgentsInactive(task: Task): boolean {
   if (task.agentProcesses.size === 0) return false;
 
   for (const [, agent] of task.agentProcesses) {
     if (agent.session.active) return false;
+  }
+
+  // If any subtask is still active, we're waiting for it — not idle
+  if (task.metadata.subtask_ids?.length) {
+    for (const subtaskId of task.metadata.subtask_ids) {
+      const subtask = activeTasks.get(subtaskId);
+      if (subtask?.isActive) return false;
+    }
   }
   return true;
 }

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -27,6 +27,7 @@ import {
   getMetadataPath,
   appendAgentFinding,
   appendAgentMessage,
+  appendCrossTaskMessage,
   appendMessageToUser,
   appendSlackMessage,
   downloadMessageFiles,
@@ -242,13 +243,22 @@ export class Task {
     emitEvent('message', this.taskId, { from: sender, to: 'user', message });
     await appendMessageToUser(this.taskId, sender, message);
 
-    const slackRefs = this.getSlackThreadRefs();
-    if (slackRefs.length > 0) {
-      // Remove eyes acknowledgment before posting the reply
-      await Promise.all(
-        slackRefs.map((ref) => removeReaction(ref.channel_id, ref.last_processed_ts, 'eyes')),
-      );
-      await postToThreads(slackRefs, message);
+    const defaultCh = this.metadata.default_channel
+      ? this.metadata.channels[this.metadata.default_channel]
+      : null;
+    if (defaultCh?.type === 'parent') {
+      // Route to parent task's originating agent — same as Slack/CLI: log + event + standard prompt
+      await deliverMessage(defaultCh.parent_task_id, message, `subtask:${this.taskId}`, defaultCh.parent_agent as AgentName);
+    } else {
+      // Post to Slack threads
+      const slackRefs = this.getSlackThreadRefs();
+      if (slackRefs.length > 0) {
+        // Remove eyes acknowledgment before posting the reply
+        await Promise.all(
+          slackRefs.map((ref) => removeReaction(ref.channel_id, ref.last_processed_ts, 'eyes')),
+        );
+        await postToThreads(slackRefs, message);
+      }
     }
   }
 
@@ -257,7 +267,7 @@ export class Task {
    * Always emits an approval:requested event (so CLI sees it).
    * If Slack channels exist, also posts interactive message there.
    */
-  async postInteractiveToUser(text: string, blocks: unknown[], approvalType: 'edit_mode' | 'research_budget'): Promise<void> {
+  async postInteractiveToUser(text: string, blocks: unknown[], approvalType: 'edit_mode' | 'research_budget' | 'subtask_budget'): Promise<void> {
     emitEvent('approval:requested', this.taskId, { text, approvalType });
 
     const slackRefs = this.getSlackThreadRefs();
@@ -293,11 +303,7 @@ export class Task {
     this.isActive = false;
     activeTasks.delete(this.taskId);
     this.clearTaskTimeout();
-
-    // Stop all queues — agent:inactive emitted by Stop hook / crash handler
-    for (const a of this.agentProcesses.values()) {
-      a.queue.stop();
-    }
+    this.stopAgents();
 
     // Clean up clones to free disk space (only when not in edit mode)
     if (this.metadata.edit_allowed !== true) {
@@ -324,10 +330,7 @@ export class Task {
     activeTasks.delete(this.taskId);
     this.clearTaskTimeout();
 
-    // Stop all queues — agent:inactive emitted by Stop hook / crash handler
-    for (const a of this.agentProcesses.values()) {
-      a.queue.stop();
-    }
+    this.stopAgents();
 
     // Clean up clones to free disk space (only when not in edit mode).
     // RW clones (edit_allowed) are kept — they have branches, commits, PRs.
@@ -340,6 +343,22 @@ export class Task {
 
     logger.system(`Task ${this.taskId} completed`);
     emitEvent('task:completed', this.taskId);
+  }
+
+  /**
+   * Stop all agents gracefully.
+   * Active agents (mid-turn) get pendingClose — they finish their turn,
+   * the Stop hook fires, and close() runs on the next tick.
+   * Idle agents (waiting for input) get closed immediately.
+   */
+  private stopAgents(): void {
+    for (const a of this.agentProcesses.values()) {
+      if (a.session.active) {
+        a.pendingClose = true;
+      } else {
+        a.close();
+      }
+    }
   }
 
   /**
@@ -468,6 +487,9 @@ export class Task {
       `Research budget exceeded for task ${this.taskId} (${this.budgets.researchRequestCount}/${this.budgets.researchRequestLimit})`,
     );
 
+    // Subtasks: no approval flow, research tool will return error, agent reports back naturally
+    if (this.metadata.parent_task_id) return;
+
     const blocks = [
       {
         type: 'section',
@@ -537,6 +559,72 @@ export class Task {
     await this.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
   }
 
+  // ---- Subtask budget methods ----
+
+  checkSubtaskBudget(): { allowed: boolean; used: number; limit: number } {
+    const used = this.metadata.subtask_ids?.length ?? 0;
+    const limit = 10 + (this.metadata.subtask_budget_extra ?? 0);
+    return { allowed: used < limit, used, limit };
+  }
+
+  async onSubtaskBudgetExceeded(): Promise<void> {
+    const { used, limit } = this.checkSubtaskBudget();
+    logger.warn('budget', `Subtask budget exceeded for task ${this.taskId} (${used}/${limit})`);
+
+    const blocks = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Subtask budget reached* (${used}/${limit} subtasks). Approve additional subtasks?`,
+        },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Approve (+10)' },
+            action_id: 'approve_subtask_budget',
+            value: this.taskId,
+            style: 'primary',
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Deny' },
+            action_id: 'deny_subtask_budget',
+            value: this.taskId,
+            style: 'danger',
+          },
+        ],
+      },
+    ];
+    await this.postInteractiveToUser(
+      `Subtask budget reached (${used}/${limit} subtasks)`,
+      blocks,
+      'subtask_budget',
+    ).catch((err: unknown) => logger.error('budget', 'Failed to post subtask budget approval request', err));
+
+    await this.stop();
+  }
+
+  async handleSubtaskBudgetApproval(): Promise<void> {
+    this.metadata.subtask_budget_extra = (this.metadata.subtask_budget_extra ?? 0) + 10;
+    this.debouncedSave();
+    await appendAgentFinding(
+      this.taskId,
+      'system',
+      `Subtask budget extended by user (+10 subtasks, total extra: ${this.metadata.subtask_budget_extra})`,
+      'decision',
+    );
+    await this.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
+  }
+
+  async handleSubtaskBudgetDenial(): Promise<void> {
+    await appendAgentFinding(this.taskId, 'system', 'Additional subtasks denied by user', 'decision');
+    await this.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
+  }
+
   // ---- Internal methods ----
 
   /**
@@ -553,6 +641,12 @@ export class Task {
 
     if (agent) {
       agent.updateSession(active, sessionId);
+
+      // If agent was marked for deferred close (task completed/stopped),
+      // close the SDK process on next tick so the Stop hook can finish cleanly.
+      if (!active && agent.pendingClose) {
+        setTimeout(() => agent.close(), 0);
+      }
     }
 
     emitEvent(active ? 'agent:active' : 'agent:inactive', this.taskId, {}, name);
@@ -604,9 +698,11 @@ export class Task {
           'budget',
           `Task ${this.taskId} exceeded wall-clock timeout (${Math.round(elapsed / 60_000)}min)`,
         );
-        await this.postToUser(
-          `⏱️ Task timed out after ${Math.round(elapsed / 60_000)} minutes. Stopping task.`,
-        ).catch((err: unknown) => logger.error('budget', 'Failed to post timeout message', err));
+        const timeoutMessage = this.metadata.parent_task_id
+          ? `Subtask timed out after ${Math.round(elapsed / 60_000)} minutes without completing. Partial findings (if any) are in the knowledge log.`
+          : `⏱️ Task timed out after ${Math.round(elapsed / 60_000)} minutes. Stopping task.`;
+        await this.postToUser(timeoutMessage)
+          .catch((err: unknown) => logger.error('budget', 'Failed to post timeout message', err));
         await this.stop();
       }
     }, 60_000);
@@ -642,6 +738,26 @@ export class Task {
     }, 500);
   }
 
+}
+
+// ---- Cross-task message delivery ----
+
+/**
+ * Deliver a message to any task's agent. Follows the same pattern as
+ * Slack (appendSlackMessage + sendMessage) and CLI (appendCliMessage + sendMessage):
+ * 1. Log message to target task's knowledge log + emit event
+ * 2. Load/reactivate task + send standard prompt to agent (agent reads knowledge log)
+ */
+export async function deliverMessage(
+  taskId: string,
+  message: string,
+  source: string,
+  targetAgent: AgentName = 'pm-agent',
+): Promise<void> {
+  await appendCrossTaskMessage(taskId, source, message, targetAgent);
+
+  const task = activeTasks.get(taskId) ?? await Task.get(taskId);
+  await task.sendMessage(AGENT_PROMPTS.existingTask, targetAgent);
 }
 
 // ---- Module-level accessor functions (backward compat) ----

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -54,6 +54,8 @@ export interface AgentHandle {
   running: Promise<void>;
   /** Whether the agent is still processing messages */
   isRunning: boolean;
+  /** Reference to the SDK Query for forceful termination via close() */
+  query?: { close(): void };
 }
 
 /**

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -37,7 +37,7 @@ export interface SlackThread {
 
 // ---- Channel types (replace slack_threads) ----
 
-export type ChannelType = 'slack' | 'github';
+export type ChannelType = 'slack' | 'github' | 'parent';
 
 export interface ChannelBase {
   type: ChannelType;
@@ -61,7 +61,14 @@ export interface GitHubChannel extends ChannelBase {
   pr_number: number;
 }
 
-export type Channel = SlackChannel | GitHubChannel;
+/** Parent channel — routes subtask messages back to parent task's originating agent */
+export interface ParentChannel extends ChannelBase {
+  type: 'parent';
+  parent_task_id: string;
+  parent_agent: string;  // Agent that spawned this subtask (e.g. 'pm-agent', 'backend-agent')
+}
+
+export type Channel = SlackChannel | GitHubChannel | ParentChannel;
 
 /** Per-branch state — tracks PR lifecycle and stash */
 export interface BranchState {
@@ -105,6 +112,9 @@ export interface TaskMetadata {
   agent_sessions: Record<string, AgentSessionState | string>; // union handles legacy string values on disk
   repositories: Record<string, RepositoryInfo>;
   status: TaskStatus;
+  parent_task_id?: string;           // Set on subtasks — ID of the parent task
+  subtask_ids?: string[];            // Set on parent — all subtask IDs ever created
+  subtask_budget_extra?: number;     // Additional +10 per user approval
   edit_allowed?: boolean;     // Has user approved edit mode for this task?
   research_budget_extra?: number;    // Additional research budget granted via Slack approval (+5 per approval)
   research_request_count?: number;   // Persisted research request count (survives stop/reactivate)


### PR DESCRIPTION
## Summary

- Agents can spawn independent subtasks for parallel investigation (e.g., exploring multiple bug hypotheses, parallel data analysis)
- Subtasks are fire-and-forget: they run with their own PM + specialist agents in fresh context, report back via a `ParentChannel` that routes to the originating agent
- If the parent task is stopped, subtask results reactivate it on arrival
- Graceful agent shutdown via `pendingClose` — agents finish their current turn before SDK process is terminated

## Changes

- **Types**: `ParentChannel`, `parent_task_id`, `subtask_ids`, `subtask_budget_extra` on `TaskMetadata`; `AgentHandle.query` for SDK process reference
- **Tools**: 4 new tools (`spawn_subtask`, `send_message_to_subtask`, `get_subtasks_status`, `cancel_subtask`) available to all agent tracks, hidden from subtask agents to prevent recursion
- **Message routing**: `deliverMessage()` + `appendCrossTaskMessage()` follow the same Slack/CLI pattern (knowledge log + event + standard prompt)
- **Subtask PM illusion**: parent-to-subtask messages use source `'user'`, subtask PM thinks it's serving a regular user
- **Budget**: 10 subtasks per task (shared across agents), extendable by 10 via Slack/CLI approval
- **Recovery**: startup recovery skips subtasks; idle detection considers active subtasks
- **Agent shutdown**: `pendingClose` flag lets active agents finish their turn, then `close()` runs on next tick via `setTimeout`
- **Prompts**: PM and agent-core prompts updated with subtask guidance and "waiting for SUBTASK" turn flow
- **CLI/API**: parent channel rendered as "subtask of {taskId}", `#` prefix moved from CLI to API
- **Docs**: architecture docs updated (agents, orchestration, persistence)

## Test plan

- [x] Typecheck passes
- [x] PM spawns subtask, subtask reports back, PM receives findings
- [x] Non-PM agent (copywriter) spawns subtask, subtask reports back to correct agent
- [x] Full round-trip: PM → Agent → Subtask → Agent → PM
- [x] `request_edit_mode` returns error in subtask context
- [x] Subtask tools hidden from subtask PMs (no recursion)
- [x] Parent completion doesn't kill subtasks — they finish independently
- [x] Server restart skips subtask recovery
- [x] Graceful shutdown: no "Stream closed" errors on report_completion
- [x] Knowledge log and events correctly show subtask source and target agent
- [x] CLI task list renders subtask channel correctly
- [ ] Subtask budget enforcement (10 limit + approval extension)
- [ ] Health check Stage 5 (subtask round-trip) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)