### PR TITLE
Add agent reminders for self-scheduled task reactivation

### DIFF
--- a/docs/plans/v21-agent-reminders.md
+++ b/docs/plans/v21-agent-reminders.md
@@ -1,0 +1,83 @@
+# Agent Reminders — Implementation Plan
+
+## Context
+
+Archie is purely reactive. We want agents to set their own reminders — "remind me at X to do Y" — like an employee. No cron, no new task states, no new persistence files. The agent decides when and why.
+
+## Core Idea
+
+Three PM tools + a lightweight in-memory scheduler. No task lifecycle changes. Reminder data lives in task metadata.
+
+- **`parse_datetime(expression)`** — natural language → ISO 8601 (powered by chrono-node)
+- **`set_reminder(datetime, reason)`** — set/replace the next reminder. `datetime` is ISO 8601.
+- **`cancel_reminder()`** — clear a pending reminder before it fires (e.g., issue resolved early)
+
+The agent says `parse_datetime("next Monday at 9am")` → gets back `2026-04-20T09:00:00+03:00` → passes it to `set_reminder`. No date math by the LLM.
+
+## Metadata
+
+New optional nested field on `TaskMetadata`:
+
+```
+reminder?: { trigger_at: string; reason: string }
+```
+
+`undefined` when no reminder is pending. Persisted via existing `task.debouncedSave()`.
+
+## Timezone
+
+Slack's `users.info` API returns `tz` (e.g. `"Europe/Moscow"`). Extend `getUserInfo()` in `src/connectors/slack/client.ts` to return `tz`. Resolve the timezone from the Slack user who triggered the task. Store it on task metadata so `parse_datetime` can use it as the reference timezone for chrono-node. "9am" means 9am in that user's local time.
+
+## `parse_datetime` Tool
+
+Uses `chrono-node` to parse natural language date expressions:
+- `"in 2 hours"`, `"tomorrow at 10am"`, `"next Monday at 9am"`, `"April 20 at 14:00"`
+
+Returns the ISO 8601 string. Uses current time + task's timezone as chrono reference. The agent calls this before `set_reminder` to get the exact ISO value.
+
+## Scheduler Module
+
+New file: `src/system/reminder-scheduler.ts`
+
+- In-memory `Map<taskId, { trigger_at, reason }>` — the runtime index
+- **On startup**: grep metadata files for `"trigger_at"`, build the map
+- **5-minute `setInterval`** iterates the map, fires due entries
+- **Firing sequence**:
+  1. Remove from in-memory map
+  2. Clear `metadata.reminder` + flush save (agent must see clean state when it wakes)
+  3. Reactivate task: `task.sendMessage(reminderPrompt)` — the prompt includes the reason, so the agent knows why it was woken even though metadata is cleared
+  
+  If crash between steps 2 and 3 — reminder is lost. This is a very small window and acceptable. The task still exists; a Slack message or user action can wake it.
+
+- **On tool call**: tools update both `task.metadata.reminder` and the in-memory map
+
+## Tools Registration
+
+Three new tools in `createPMAgentMcpServer()`, following existing factory pattern.
+
+`parse_datetime`: resolve natural language → ISO using chrono-node with task's timezone
+
+`set_reminder`: validate ISO is future (max 30 days), update map + metadata, log to knowledge.log, post to Slack
+
+`cancel_reminder`: remove from map, clear metadata field. For when the agent decides a pending reminder is no longer needed before it fires.
+
+## Context Injection
+
+In `spawn.ts` (~line 165), add to PM context:
+- **Pending reminder** (if set): `Pending reminder: 2026-04-20T09:00:00+03:00 — Follow up if no reply`
+
+## Other Small Changes
+
+- `src/agents/prompts.ts` — new prompt for reminder wake-ups
+- `src/types/task.ts` — add optional `reminder` and `timezone` to `TaskMetadata`
+- `src/index.ts` — call `initReminderScheduler()` after recovery
+- `src/connectors/slack/client.ts` — extend `getUserInfo()` to return `tz`
+- `package.json` — add `chrono-node` dependency
+
+## Edge Cases
+
+- **Task completed/stopped when reminder fires**: `sendMessage()` → `activate()` brings it back
+- **Slack message before reminder fires**: task wakes normally, PM sees pending reminder in context, decides what to do
+- **Archie restarts**: scheduler rebuilds map from metadata, overdue reminders fire on first tick
+- **Agent sets reminder on active task**: fine — fires later, task gets a message
+- **chrono-node can't parse expression**: tool returns an error, agent retries with different wording

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@octokit/webhooks": "^14.2.0",
         "@slack/bolt": "^4.6.0",
         "@slack/web-api": "^7.0.0",
+        "chrono-node": "^2.9.0",
         "dotenv": "^16.3.0",
         "gray-matter": "^4.0.3",
         "ink": "^5.2.1",
@@ -3615,6 +3616,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chrono-node": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.9.0.tgz",
+      "integrity": "sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/cli-boxes": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@octokit/webhooks": "^14.2.0",
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.0.0",
+    "chrono-node": "^2.9.0",
     "dotenv": "^16.3.0",
     "gray-matter": "^4.0.3",
     "ink": "^5.2.1",

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -21,6 +21,8 @@ Your turn must end with one of:
 
 Read knowledge.log to see where you left off, then take action.`,
 
+  reminder: (reason: string) => `Your scheduled reminder has fired. Reason: ${reason}\n\nCheck knowledge.log for the latest context and decide what to do next.`,
+
   reinforceAgent: `RECOVERY: You went idle without reporting back.
 
 Your turn must end with:

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -176,12 +176,18 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     const channelInfo = Object.entries(metadata.channels)
       .map(([id, ch]) => ch.type === 'slack' ? `#${ch.channel_name || ch.channel_id}` : id)
       .join(', ') || 'CLI (no Slack channel)';
+    const contextLines = [
+      `Task: ${taskId}`,
+      `Status: ${metadata.status}`,
+      `Channel(s): ${channelInfo}`,
+      `Task Owner: ${metadata.task_owner || 'Not assigned'}`,
+      `Participants: ${metadata.participants.join(', ') || 'None yet'}`,
+    ];
+    if (metadata.reminder) {
+      contextLines.push(`Reminder: ${metadata.reminder.trigger_at} — ${metadata.reminder.reason}`);
+    }
     const context = `
-Task: ${taskId}
-Status: ${metadata.status}
-Channel(s): ${channelInfo}
-Task Owner: ${metadata.task_owner || 'Not assigned'}
-Participants: ${metadata.participants.join(', ') || 'None yet'}
+${contextLines.join('\n')}
 
 Working directory (cwd): ${pmWorkspace} [READ-WRITE]
 

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -23,6 +23,8 @@ import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../
 import { appendAgentFinding } from '../tasks/persistence.js';
 import { logger } from '../system/logger.js';
 import { findSlackUsers, findSlackChannels } from '../connectors/slack/client.js';
+import { scheduleReminder, cancelReminder } from '../system/reminder-scheduler.js';
+import * as chrono from 'chrono-node';
 
 // Re-export branch state helpers for consumers that import from tools.ts
 export { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR };
@@ -794,6 +796,80 @@ function createListBranchesTool(agent: Agent, task: Task) {
   );
 }
 
+// ---- Reminder tools ----
+
+function createParseDatetimeTool(agent: Agent, task: Task) {
+  return tool(
+    'parse_datetime',
+    'Parse a natural language date/time expression into an ISO 8601 timestamp. Call this before set_reminder to get the correct datetime value. You must provide the timezone of the person the reminder relates to.',
+    {
+      expression: z.string().describe('Natural language date/time, e.g. "in 2 hours", "tomorrow at 10am", "next Monday at 9am"'),
+      timezone: z.string().describe('IANA timezone, e.g. "Europe/Moscow", "America/New_York", "UTC"'),
+    },
+    async (args) => {
+      const tz = args.timezone;
+      const refDate = new Date();
+      const results = chrono.parse(args.expression, { instant: refDate, timezone: tz });
+      if (results.length === 0) {
+        return { content: [{ type: 'text' as const, text: `Could not parse "${args.expression}". Try a different format like "in 2 hours", "tomorrow at 10am", or "next Monday at 9am".` }] };
+      }
+      const parsed = results[0].start.date();
+      return { content: [{ type: 'text' as const, text: parsed.toISOString() }] };
+    },
+  );
+}
+
+function createSetReminderTool(agent: Agent, task: Task) {
+  return tool(
+    'set_reminder',
+    'Set a reminder to be woken up at the specified time. The task will be reactivated and you will receive a prompt with the reason. Only one reminder can be pending — calling this replaces any existing reminder. Use parse_datetime first to get the correct ISO 8601 value.',
+    {
+      datetime: z.string().describe('ISO 8601 datetime, e.g. "2026-04-15T10:00:00Z"'),
+      reason: z.string().describe('What to do when woken — this will be shown to you'),
+    },
+    async (args) => {
+      const triggerAt = new Date(args.datetime);
+      if (isNaN(triggerAt.getTime())) {
+        return { content: [{ type: 'text' as const, text: 'Invalid datetime. Use parse_datetime to get a valid ISO 8601 value.' }] };
+      }
+      if (triggerAt <= new Date()) {
+        return { content: [{ type: 'text' as const, text: 'Datetime must be in the future.' }] };
+      }
+      const maxFuture = new Date(Date.now() + 30 * 24 * 60 * 60_000);
+      if (triggerAt > maxFuture) {
+        return { content: [{ type: 'text' as const, text: 'Datetime must be within 30 days.' }] };
+      }
+
+      const agentName = agent.def.id as AgentName;
+      scheduleReminder(task, triggerAt, args.reason);
+      logger.agentAction(agentName, 'Setting reminder', `${triggerAt.toISOString()}: ${args.reason}`);
+
+      return { content: [{ type: 'text' as const, text: `Reminder set for ${args.datetime}. Reason: ${args.reason}` }] };
+    },
+  );
+}
+
+function createCancelReminderTool(agent: Agent, task: Task) {
+  return tool(
+    'cancel_reminder',
+    'Cancel the pending reminder for this task. Use when the reason for the reminder is no longer relevant.',
+    {},
+    async () => {
+      if (!task.metadata.reminder) {
+        return { content: [{ type: 'text' as const, text: 'No pending reminder to cancel.' }] };
+      }
+
+      const agentName = agent.def.id as AgentName;
+      cancelReminder(task);
+
+      await appendAgentFinding(task.taskId, agentName, 'Cancelled scheduled reminder', 'decision');
+      logger.agentAction(agentName, 'Cancelled reminder', '');
+
+      return { content: [{ type: 'text' as const, text: 'Reminder cancelled.' }] };
+    },
+  );
+}
+
 // ---- MCP Server creation ----
 
 /**
@@ -813,6 +889,9 @@ export function createPMAgentMcpServer(agent: Agent, task: Task) {
       createRequestEditModeTool(agent, task),
       createGetAgentsStatusTool(agent, task),
       createMuteThreadTool(agent, task),
+      createParseDatetimeTool(agent, task),
+      createSetReminderTool(agent, task),
+      createCancelReminderTool(agent, task),
     ],
   });
 }

--- a/src/cli/components/TaskDetail.tsx
+++ b/src/cli/components/TaskDetail.tsx
@@ -21,6 +21,13 @@ function formatMessageParts(from: string, to: string, destination?: string): { l
   return { label, mention };
 }
 
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('en-US', {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
+  });
+}
+
 interface AgentStatus {
   agent: string;
   active: boolean;
@@ -66,6 +73,7 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
   const [focusedApprovalLine, setFocusedApprovalLine] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string>('');
+  const [reminder, setReminder] = useState<{ trigger_at: string; reason: string } | null>(null);
   const prevOnEvent = useRef<SystemEvent | null>(null);
   const prevOnConnect = useRef<boolean | undefined>(undefined);
   const scrollRef = useRef<ScrollViewRef>(null);
@@ -115,6 +123,21 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
             node: <Text>{event.data.approve ? '✅' : '❌'} Approval {event.data.approve ? 'granted' : 'denied'}: {event.data.type as string}</Text>,
           });
           break;
+        case 'reminder:set':
+          logLines.push({
+            node: <Text color="magenta">⏰ Reminder set for {formatDateTime(event.data.trigger_at as string)} — {event.data.reason as string}</Text>,
+          });
+          break;
+        case 'reminder:cancelled':
+          logLines.push({
+            node: <Text dimColor>⏰ Reminder cancelled</Text>,
+          });
+          break;
+        case 'reminder:fired':
+          logLines.push({
+            node: <Text color="magenta">⏰ Reminder fired — {event.data.reason as string}</Text>,
+          });
+          break;
         default:
           break;
       }
@@ -143,6 +166,7 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
         fetchTaskEvents(taskId),
       ]);
       setStatus(detail.metadata?.status || '');
+      setReminder(detail.metadata?.reminder ?? null);
       setAgents(detail.agents || []);
       setEvents(eventsResult.events);
       setEventCursor(eventsResult.total);
@@ -189,6 +213,14 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
       if (onEvent.type === 'task:resumed') setStatus('in_progress');
       if (onEvent.type === 'task:completed') setStatus('completed');
       if (onEvent.type === 'task:stopped') setStatus('stopped');
+
+      // Update reminder from reminder events
+      if (onEvent.type === 'reminder:set') {
+        setReminder({ trigger_at: onEvent.data.trigger_at as string, reason: onEvent.data.reason as string });
+      }
+      if (onEvent.type === 'reminder:cancelled' || onEvent.type === 'reminder:fired') {
+        setReminder(null);
+      }
 
       // Auto-scroll to bottom when new events arrive (if user hasn't scrolled up)
       if (autoScroll.current) {
@@ -312,10 +344,15 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
     <Box flexDirection="column" height={termHeight}>
       {/* Header */}
       <Box paddingX={1}>
-        <Text bold>Task: {taskId}</Text>
-        <Text dimColor>  status: </Text>
-        <Text color={status === 'in_progress' ? 'yellow' : status === 'completed' ? 'green' : 'red'}>
-          {status}
+        <Text wrap="truncate-end">
+          <Text bold>Task: {taskId}</Text>
+          <Text dimColor>  status: </Text>
+          <Text color={status === 'in_progress' ? 'yellow' : status === 'completed' ? 'green' : 'red'}>
+            {status}
+          </Text>
+          {reminder && (
+            <Text color="magenta">  ⏰ {formatDateTime(reminder.trigger_at)}</Text>
+          )}
         </Text>
       </Box>
 

--- a/src/cli/components/TaskList.tsx
+++ b/src/cli/components/TaskList.tsx
@@ -3,6 +3,13 @@ import { Box, Text, useInput, useStdout } from 'ink';
 import Spinner from 'ink-spinner';
 import { fetchTasks } from '../api.js';
 
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('en-US', {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
+  });
+}
+
 interface TaskSummary {
   task_id: string;
   status: string;
@@ -11,6 +18,7 @@ interface TaskSummary {
   created_at: string;
   updated_at: string;
   channel_name: string | null;
+  reminder: { trigger_at: string; reason: string } | null;
   agents?: { agentId: string; active: boolean }[];
 }
 
@@ -163,15 +171,18 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
           : 'cli';
 
         return (
-          <Box key={task.task_id} paddingX={1} gap={1}>
-            <Text color={selected ? 'cyan' : undefined} bold={selected}>
-              {selected ? '>' : ' '}
-            </Text>
-            <StatusIcon status={task.status} />
-            <Text color={selected ? 'cyan' : undefined} bold={selected}>
-              {task.task_id}
+          <Box key={task.task_id} paddingX={1}>
+            <Text wrap="truncate-end">
+              <Text color={selected ? 'cyan' : undefined} bold={selected}>
+                {selected ? '> ' : '  '}
+              </Text>
+              <StatusIcon status={task.status} />
+              <Text color={selected ? 'cyan' : undefined} bold={selected}>
+                {' '}{task.task_id}
+              </Text>
               <Text dimColor>  {channel}</Text>
               {activeAgents > 0 && <Text color="green">  {activeAgents} active</Text>}
+              {task.reminder && <Text color="magenta">  ⏰ {formatDateTime(task.reminder.trigger_at)} — {task.reminder.reason.length > 50 ? task.reminder.reason.slice(0, 50) + '…' : task.reminder.reason}</Text>}
             </Text>
           </Box>
         );

--- a/src/connectors/api/routes.ts
+++ b/src/connectors/api/routes.ts
@@ -102,6 +102,7 @@ export function mountApiRoutes(app: Application): void {
           created_at: metadata.created_at,
           updated_at: metadata.updated_at,
           channel_name,
+          reminder: metadata.reminder ?? null,
           agents: activeTask ? activeTask.getAgentStatus() : [],
         });
       }

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -649,7 +649,7 @@ export async function fetchNewMessages(
 /**
  * Get user info
  */
-export async function getUserInfo(userId: string): Promise<{ name: string; realName: string }> {
+export async function getUserInfo(userId: string): Promise<{ name: string; realName: string; tz?: string }> {
   const client = getSlackClient();
 
   const result = await client.users.info({ user: userId });
@@ -657,6 +657,7 @@ export async function getUserInfo(userId: string): Promise<{ name: string; realN
   return {
     name: result.user?.name || userId,
     realName: result.user?.real_name || userId,
+    tz: (result.user as Record<string, unknown>)?.tz as string | undefined,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { initRegistry, getAllAgentDefs } from './agents/registry.js';
 import { configureGitIdentity } from './connectors/github/client.js';
 import { recoverActiveTasks } from './tasks/recovery.js';
 import { initEventPersistence } from './tasks/persistence.js';
+import { initReminderScheduler } from './system/reminder-scheduler.js';
 
 /**
  * Application configuration
@@ -177,6 +178,7 @@ async function main(): Promise<void> {
     logger.plain(`Archie server is running on port ${config.port}\n`);
 
     await recoverActiveTasks();
+    await initReminderScheduler();
 
     // Graceful shutdown
     const shutdown = async (signal: string) => {

--- a/src/system/event-bus.ts
+++ b/src/system/event-bus.ts
@@ -11,7 +11,8 @@ export type EventType =
   | 'task:created' | 'task:resumed' | 'task:stopped' | 'task:completed'
   | 'agent:active' | 'agent:inactive'
   | 'message' | 'agent:log'
-  | 'approval:requested' | 'approval:resolved';
+  | 'approval:requested' | 'approval:resolved'
+  | 'reminder:set' | 'reminder:cancelled' | 'reminder:fired';
 
 export interface SystemEvent {
   type: EventType;

--- a/src/system/reminder-scheduler.ts
+++ b/src/system/reminder-scheduler.ts
@@ -1,0 +1,149 @@
+/**
+ * Reminder Scheduler
+ *
+ * In-memory index of pending reminders, backed by task metadata on disk.
+ * A 5-minute interval checks for due reminders and reactivates tasks.
+ */
+
+import { execSync } from 'child_process';
+import { writeFile } from 'fs/promises';
+import { Task } from '../tasks/task.js';
+import { SESSIONS_DIR } from './workdir.js';
+import { loadMetadata, getMetadataPath } from '../tasks/persistence.js';
+import { AGENT_PROMPTS } from '../agents/prompts.js';
+import { emitEvent } from './event-bus.js';
+import { logger } from './logger.js';
+
+// ---- In-memory index ----
+
+interface PendingReminder {
+  trigger_at: Date;
+  reason: string;
+}
+
+const pendingReminders = new Map<string, PendingReminder>();
+let schedulerTimer: ReturnType<typeof setInterval> | undefined;
+
+// ---- Public API ----
+
+/**
+ * Initialize the reminder scheduler.
+ * Scans task metadata on disk to rebuild the in-memory index, then starts the interval.
+ */
+export async function initReminderScheduler(): Promise<void> {
+  await rebuildFromDisk();
+
+  const count = pendingReminders.size;
+  if (count > 0) {
+    logger.system(`Reminder scheduler: loaded ${count} pending reminder(s)`);
+  }
+
+  // Check every 5 minutes
+  schedulerTimer = setInterval(() => {
+    checkDueReminders().catch((err) =>
+      logger.error('reminder-scheduler', 'Error checking due reminders', err),
+    );
+  }, 60_000);
+
+  // Also run immediately to fire any overdue reminders from downtime
+  checkDueReminders().catch((err) =>
+    logger.error('reminder-scheduler', 'Error on initial reminder check', err),
+  );
+}
+
+/**
+ * Register a reminder for a task. Replaces any existing reminder.
+ * Updates both in-memory map and task metadata.
+ */
+export function scheduleReminder(task: Task, triggerAt: Date, reason: string): void {
+  pendingReminders.set(task.taskId, { trigger_at: triggerAt, reason });
+  task.metadata.reminder = { trigger_at: triggerAt.toISOString(), reason };
+  task.debouncedSave();
+  emitEvent('reminder:set', task.taskId, { trigger_at: triggerAt.toISOString(), reason });
+}
+
+/**
+ * Cancel a pending reminder for a task.
+ * Clears both in-memory map and task metadata.
+ */
+export function cancelReminder(task: Task): void {
+  pendingReminders.delete(task.taskId);
+  task.metadata.reminder = undefined;
+  task.debouncedSave();
+  emitEvent('reminder:cancelled', task.taskId);
+}
+
+/**
+ * Get the pending reminder for a task (if any). Read-only.
+ */
+export function getReminder(taskId: string): PendingReminder | undefined {
+  return pendingReminders.get(taskId);
+}
+
+// ---- Internal ----
+
+/**
+ * Scan all task metadata files to rebuild the in-memory index.
+ */
+async function rebuildFromDisk(): Promise<void> {
+  try {
+    const grepResult = execSync(
+      `grep -l '"trigger_at"' ${SESSIONS_DIR}/task-*/shared/metadata.json 2>/dev/null || true`,
+      { encoding: 'utf-8' },
+    ).trim();
+
+    if (!grepResult) return;
+
+    for (const filePath of grepResult.split('\n')) {
+      const taskIdMatch = filePath.match(/task-[a-z0-9-]+/i);
+      if (!taskIdMatch) continue;
+      const taskId = taskIdMatch[0];
+
+      const metadata = await loadMetadata(taskId);
+      if (metadata?.reminder?.trigger_at) {
+        pendingReminders.set(metadata.task_id, {
+          trigger_at: new Date(metadata.reminder.trigger_at),
+          reason: metadata.reminder.reason,
+        });
+      }
+    }
+  } catch (err) {
+    logger.error('reminder-scheduler', 'Failed to rebuild reminders from disk', err);
+  }
+}
+
+/**
+ * Check for due reminders and fire them.
+ */
+async function checkDueReminders(): Promise<void> {
+  const now = new Date();
+
+  for (const [taskId, reminder] of pendingReminders) {
+    if (reminder.trigger_at > now) continue;
+
+    // 1. Remove from in-memory map
+    pendingReminders.delete(taskId);
+
+    try {
+      // 2. Clear metadata.reminder + flush save (agent sees clean state)
+      const metadata = await loadMetadata(taskId);
+      if (!metadata) {
+        logger.warn('reminder-scheduler', `Task ${taskId} not found on disk, skipping reminder`);
+        continue;
+      }
+
+      metadata.reminder = undefined;
+      await writeFile(getMetadataPath(taskId), JSON.stringify(metadata, null, 2));
+
+      // 3. Reactivate task
+      emitEvent('reminder:fired', taskId, { reason: reminder.reason });
+      logger.system(`Reminder fired for ${taskId}: ${reminder.reason}`);
+      const task = await Task.get(taskId);
+      await task.sendMessage(
+        AGENT_PROMPTS.reminder(reminder.reason),
+      );
+    } catch (err) {
+      logger.error('reminder-scheduler', `Failed to fire reminder for ${taskId}`, err);
+    }
+  }
+}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -109,6 +109,10 @@ export interface TaskMetadata {
   research_budget_extra?: number;    // Additional research budget granted via Slack approval (+5 per approval)
   research_request_count?: number;   // Persisted research request count (survives stop/reactivate)
   failure_counter?: number;          // Consecutive recovery attempts (Stage 3 idle detection)
+  reminder?: {                       // Pending self-scheduled reminder (set by agent via set_reminder tool)
+    trigger_at: string;              // ISO 8601 datetime when the task should be reactivated
+    reason: string;                  // Why — shown to agent when woken
+  };
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

- Agents can now set reminders to be woken at a future time via `set_reminder`, `cancel_reminder`, and `parse_datetime` (chrono-node) tools
- In-memory scheduler with 1-min interval rebuilds from task metadata on startup, enabling proactive follow-ups and recurring work without external cron
- CLI task list and detail views show pending reminders with real-time SSE updates
- Fixes CLI SSE disconnect flicker when switching between list and detail views

## Test plan

- [x] Create a task and ask the agent to set a reminder (e.g. "remind me in 2 minutes")
- [x] Verify reminder appears in CLI task list and detail header
- [x] Wait for reminder to fire, verify task reactivates and agent sees the reason
- [x] Test cancel_reminder clears the pending reminder
- [x] Test recurring reminders (agent sets a new reminder after each wake)
- [x] Restart server with a pending reminder, verify it fires after restart
- [x] Verify no SSE disconnect flicker when switching views in CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)