### PR TITLE
Add Slack user lookup, targeted messaging, and improved logging

### DIFF
--- a/docs/plans/v20-slack-user-lookup-targeted-messaging.md
+++ b/docs/plans/v20-slack-user-lookup-targeted-messaging.md
@@ -1,0 +1,258 @@
+# Plan: Slack User Lookup & Targeted Messaging
+
+## Context
+
+The PM agent currently can only post messages to the originating Slack thread (or broadcasts to all linked threads). There's no way to:
+1. Find a Slack user by name (only by ID)
+2. Send a message to a specific user via DM or to a different channel
+3. Link those new conversations back to the current task
+
+This limits Archie's ability to coordinate across people — e.g., "ping John about this" requires knowing John's user ID and having a tool to DM him.
+
+The goal is to give PM the ability to find users, message them (or any channel), and have those conversations automatically linked to the task so replies flow back.
+
+## Changes
+
+### 1. `src/connectors/slack/client.ts` — Slack API layer
+
+**Add user listing with cache:**
+
+```typescript
+interface SlackUserInfo {
+  id: string;
+  name: string;          // @handle
+  realName: string;      // Full name
+  displayName: string;   // Display name (may differ from realName)
+}
+
+let userCache: SlackUserInfo[] = [];
+let userCacheTimestamp = 0;
+const USER_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+
+export async function listWorkspaceUsers(): Promise<SlackUserInfo[]> {
+  if (userCache.length > 0 && Date.now() - userCacheTimestamp < USER_CACHE_TTL) {
+    return userCache;
+  }
+  // Paginated users.list call, filter out bots and deactivated
+  // Store in userCache, update timestamp
+  return userCache;
+}
+
+export async function findUsersByName(query: string): Promise<SlackUserInfo[]> {
+  const users = await listWorkspaceUsers();
+  const q = query.toLowerCase();
+  // Match against name, realName, displayName — case-insensitive substring
+  return users.filter(u =>
+    u.name.toLowerCase().includes(q) ||
+    u.realName.toLowerCase().includes(q) ||
+    u.displayName.toLowerCase().includes(q)
+  );
+}
+```
+
+**Add DM channel opening:**
+
+```typescript
+export async function openDMChannel(userId: string): Promise<string> {
+  const client = getSlackClient();
+  const result = await client.conversations.open({ users: userId });
+  return result.channel!.id!;
+}
+```
+
+**Add top-level message posting (creates a new thread):**
+
+```typescript
+export async function postNewMessage(channel: string, text: string): Promise<string | undefined> {
+  // Same as postToThread but WITHOUT thread_ts — creates top-level message
+  // Returns the message ts (which becomes the thread_id for replies)
+  if (dryRun) { ... }
+  const client = getSlackClient();
+  const slackText = slackifyMarkdown(restoreMentions(text));
+  const result = await client.chat.postMessage({ channel, text: slackText, mrkdwn: true });
+  return result.ts;
+}
+```
+
+### 2. `src/tasks/task.ts` — Task posting logic
+
+**Update `postToUser` signature and behavior:**
+
+```typescript
+interface PostTarget {
+  channel?: string;        // existing channel key (e.g., "slack:C123:456.789")
+  new_dm?: string;         // user ID — open DM, post, link
+  new_thread?: string;     // channel ID — post top-level, link
+}
+
+async postToUser(
+  message: string,
+  agentName?: string,
+  target?: PostTarget
+): Promise<string | null> {  // returns new channel key when creating, null otherwise
+```
+
+Logic:
+- **`target.new_dm`**: Call `openDMChannel(userId)` to get the DM channel ID (e.g., `D1234` — always the same for a given user) → scan `metadata.channels` for an existing slack channel with matching `channel_id` → if found, post to that existing thread and return its channel key → if not found, `postNewMessage(dmChannelId, message)` → register new entry `slack:{dmChannelId}:{ts}` with name `DM with {realName}` → return new channel key. No metadata changes needed — the DM channel ID itself is the unique identifier for a user's DM.
+- **`target.new_thread`**: Call `postNewMessage(channelId, message)` → get `ts` → register `slack:{channelId}:{ts}` → return channel key
+- **`target.channel`**: Look up the channel in `metadata.channels` → post to that specific thread only → return null
+- **No target**: Look up `default_channel` → post to that thread only → return null
+
+The key behavioral change: **no more broadcasting to all threads**. Without a target, post to `default_channel` only.
+
+**Update `postInteractiveToUser` to match:** Same logic — post to `default_channel` only instead of broadcasting to all threads. This applies to approval buttons (edit mode, research budget, subtask budget).
+
+**Add helper to register a new channel:**
+
+```typescript
+private registerSlackChannel(channelId: string, threadTs: string, channelName: string): string {
+  const key = `slack:${channelId}:${threadTs}`;
+  this.metadata.channels[key] = {
+    type: 'slack',
+    thread_id: threadTs,
+    channel_id: channelId,
+    channel_name: channelName,
+    last_processed_ts: threadTs,
+    url: buildThreadUrl(channelId, threadTs) ?? undefined,
+  };
+  this.debouncedSave();
+  return key;
+}
+```
+
+**Find existing channel by channel_id** (used for DM reuse):
+
+```typescript
+private findChannelBySlackId(slackChannelId: string): { key: string; channel: SlackChannel } | null {
+  for (const [key, ch] of Object.entries(this.metadata.channels)) {
+    if (ch.type === 'slack' && ch.channel_id === slackChannelId) return { key, channel: ch };
+  }
+  return null;
+}
+```
+
+**DM reuse** — `new_dm` calls `openDMChannel(userId)` to get the DM channel ID, then uses `findChannelBySlackId` to check if we already have a thread in that DM. If so, posts there. No type changes needed.
+
+### 3. `src/agents/tools.ts` — Tool definitions
+
+**New tool: `createFindSlackUserTool`**
+
+```typescript
+function createFindSlackUserTool(agent: Agent, task: Task) {
+  return tool(
+    'find_slack_user',
+    'Search for a Slack user by name. Returns matching users with their IDs. Use this to find user IDs before sending DMs.',
+    {
+      query: z.string().describe('Name or part of name to search for'),
+    },
+    async (args) => {
+      const matches = await findUsersByName(args.query);
+      if (matches.length === 0) return ok('No users found matching that query.');
+      const list = matches.slice(0, 10).map(u =>
+        `- ${u.realName} (@${u.name}) — ID: ${u.id}`
+      ).join('\n');
+      return ok(`Found ${matches.length} user(s):\n${list}`);
+    },
+  );
+}
+```
+
+**Update `createPostToUserTool`**
+
+Add optional target parameter with a zod union/object:
+
+```typescript
+function createPostToUserTool(agent: Agent, task: Task) {
+  return tool(
+    'post_to_user',
+    'Send a message to the user. Without target, posts to the default channel. ' +
+    'Use target.channel to post to a specific linked thread. ' +
+    'Use target.new_dm with a user ID to start a DM conversation (links it to this task). ' +
+    'Use target.new_thread with a channel ID to start a new thread in a channel (links it to this task). ' +
+    'When creating new threads, returns the channel key for future use.',
+    {
+      message: z.string().describe('The message to send'),
+      target: z.object({
+        channel: z.string().optional().describe('Channel key of an existing linked thread (e.g., "slack:C123:456.789")'),
+        new_dm: z.string().optional().describe('User ID to start a new DM conversation with'),
+        new_thread: z.string().optional().describe('Channel ID to start a new thread in'),
+      }).optional().describe('Where to post. Omit to post to the default channel.'),
+    },
+    async (args) => {
+      const agentName = agent.def.id as AgentName;
+      logger.agentToSlack(agentName, args.message);
+      task.touch();
+      const newChannelKey = await task.postToUser(args.message, agentName, args.target);
+      if (newChannelKey) {
+        return ok(`Message posted. New channel linked: ${newChannelKey} (saved in task metadata for future use)`);
+      }
+      return ok(`Message posted.`);
+    },
+  );
+}
+```
+
+**Register in `createPMAgentMcpServer` (line 884):**
+
+Add `createFindSlackUserTool(agent, task)` to the tools array.
+
+### 4. `prompts/pm-agent.md` — PM prompt update
+
+In the "Action Tools" section, update `post_to_user` description and add `find_slack_user`:
+
+```markdown
+- `post_to_user`: Send a message to the user. By default posts to the originating channel. Optionally target a specific channel:
+  - `target.channel`: Post to a specific linked thread (use the channel key)
+  - `target.new_dm`: Start a new DM with a user (pass their user ID). Links the DM thread to this task so replies flow back. Returns the channel key.
+  - `target.new_thread`: Start a new thread in a channel (pass channel ID). Links it to this task. Returns the channel key.
+- `find_slack_user`: Search for a Slack user by name. Returns matching users with IDs. Use before sending DMs.
+```
+
+Add a section on cross-channel communication:
+```markdown
+### Cross-Channel Communication
+
+You can reach people beyond the originating thread:
+1. Use `find_slack_user` to look up a user's ID by name
+2. Use `post_to_user` with `target.new_dm` to start a DM — this links the conversation to the current task
+3. Use the returned channel key with `target.channel` for follow-up messages to the same thread
+
+Replies from the DM will automatically route back to this task.
+```
+
+### 5. Slack manifest — No changes
+
+All required scopes already present: `users:read`, `im:write`, `chat:write`.
+
+### 6. Event handling — No changes
+
+`findTaskByThread()` already scans all channels for matching `thread_id`. New linked threads will be found automatically.
+
+## Edge Cases
+
+1. **DM reuse**: Handled inside `postToUser` — `openDMChannel` returns the same channel ID for a given user, so we match on `channel_id` to find existing DM threads.
+2. **Bot not in channel**: `chat.postMessage` to a channel the bot isn't a member of will fail. Let the error propagate to the agent via `err()`.
+3. **Dry-run mode**: `postNewMessage` and `openDMChannel` should respect the existing `dryRun` flag.
+4. **Default channel is null**: CLI-originated tasks have `default_channel: null`. Posting without target falls back to event emission only (existing behavior).
+5. **User cache staleness**: 10-minute TTL is reasonable. New hires won't appear for up to 10 minutes.
+
+### 7. `src/agents/__tests__/tool-contract.test.ts` — Update test
+
+The test hardcodes expected PM tool names in `SPAWN_PM_TOOLS` array (line 97). Add:
+```typescript
+'mcp__pm-agent-tools__find_slack_user',
+```
+
+The `makeTask()` mock (line 64) has `postToUser: vi.fn()` — no signature change needed since extra args are optional.
+
+## Verification
+
+1. **Type check**: `npm run typecheck` passes
+2. **Unit tests**: `npm run test` passes (tool-contract test updated)
+3. **Manual test flow**:
+   - Start a task via Slack
+   - PM calls `find_slack_user("somename")` — verify results
+   - PM calls `post_to_user("hello", { new_dm: "U..." })` — verify DM arrives, channel key returned
+   - Reply to the DM — verify it routes to the same task
+   - PM calls `post_to_user("follow-up", { channel: "slack:D..." })` — verify it goes to the same DM thread
+   - PM calls `post_to_user("update")` without target — verify it goes to default channel only (not DM)

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -92,11 +92,24 @@ Use as many of these as needed during your turn:
 
 - `assign_task_owner`: Designate a specific agent as the task owner
 - `send_message_to_agent`: Send instructions or questions to an agent
-- `post_to_user`: Send updates to the user
+- `post_to_user`: Send a message to the user. By default posts to the originating channel. Optionally specify a target:
+  - `target.channel`: Post to a specific linked thread (use the channel key from metadata)
+  - `target.new_dm`: Start a new DM with a user (pass their Slack user ID). Links the DM thread to this task so replies flow back. Returns the channel key.
+  - `target.new_thread`: Start a new thread in a channel (pass Slack channel ID). Links it to this task. Returns the channel key.
+- `find_slack_user`: Search for a Slack user by name. Returns matching users with IDs. Use before sending DMs.
 
 ### Thread Management Tools
 
 - `mute_thread`: Unsubscribe from the Slack thread until someone @mentions you again. Use when asked to disengage.
+
+### Cross-Channel Communication
+
+You can reach people beyond the originating thread:
+1. Use `find_slack_user` to look up a user's ID by name
+2. Use `post_to_user` with `target.new_dm` to start a DM — this links the conversation to the current task
+3. Use the returned channel key with `target.channel` for follow-up messages to the same thread
+
+Replies from linked DMs and channels will automatically route back to this task.
 
 ### Turn-Ending Tools
 

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -96,7 +96,8 @@ Use as many of these as needed during your turn:
   - `target.channel`: Post to a specific linked thread (use the channel key from metadata)
   - `target.new_dm`: Start a new DM with a user (pass their Slack user ID). Links the DM thread to this task so replies flow back. Returns the channel key.
   - `target.new_thread`: Start a new thread in a channel (pass Slack channel ID). Links it to this task. Returns the channel key.
-- `find_slack_user`: Search for a Slack user by name. Returns matching users with IDs. Use before sending DMs.
+- `find_slack_user`: Search for a Slack user by name or ID. Returns matching users with IDs. Use before sending DMs.
+- `find_slack_channel`: Search for a Slack channel by name or ID. Returns matching channels with IDs. Use before posting to new threads.
 
 ### Thread Management Tools
 
@@ -104,9 +105,9 @@ Use as many of these as needed during your turn:
 
 ### Cross-Channel Communication
 
-You can reach people beyond the originating thread:
-1. Use `find_slack_user` to look up a user's ID by name
-2. Use `post_to_user` with `target.new_dm` to start a DM — this links the conversation to the current task
+You can reach people and channels beyond the originating thread:
+1. Use `find_slack_user` to look up a user's ID, or `find_slack_channel` to look up a channel's ID
+2. Use `post_to_user` with `target.new_dm` to start a DM, or `target.new_thread` to post in a channel — both link the conversation to the current task
 3. Use the returned channel key with `target.channel` for follow-up messages to the same thread
 
 Replies from linked DMs and channels will automatically route back to this task.

--- a/slack-manifest.yaml
+++ b/slack-manifest.yaml
@@ -13,6 +13,7 @@ oauth_config:
       - chat:write
       - channels:history
       - channels:read
+      - groups:read
       - im:history
       - im:read
       - im:write

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -46,6 +46,10 @@ vi.mock('../registry.js', () => ({
   getAgentIds: vi.fn().mockReturnValue(['backend-agent', 'mobile-agent']),
 }));
 
+vi.mock('../../connectors/slack/client.js', () => ({
+  findSlackUsers: vi.fn().mockResolvedValue([]),
+}));
+
 // ---- Helpers ----
 
 function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
@@ -97,6 +101,7 @@ function getRegisteredToolNames(server: ReturnType<typeof createRepoToolsMcpServ
 const SPAWN_PM_TOOLS = [
   'mcp__pm-agent-tools__send_message_to_agent',
   'mcp__pm-agent-tools__post_to_user',
+  'mcp__pm-agent-tools__find_slack_user',
   'mcp__pm-agent-tools__assign_task_owner',
   'mcp__pm-agent-tools__report_completion',
   'mcp__pm-agent-tools__request_edit_mode',

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -48,6 +48,7 @@ vi.mock('../registry.js', () => ({
 
 vi.mock('../../connectors/slack/client.js', () => ({
   findSlackUsers: vi.fn().mockResolvedValue([]),
+  findSlackChannels: vi.fn().mockResolvedValue([]),
 }));
 
 // ---- Helpers ----
@@ -102,6 +103,7 @@ const SPAWN_PM_TOOLS = [
   'mcp__pm-agent-tools__send_message_to_agent',
   'mcp__pm-agent-tools__post_to_user',
   'mcp__pm-agent-tools__find_slack_user',
+  'mcp__pm-agent-tools__find_slack_channel',
   'mcp__pm-agent-tools__assign_task_owner',
   'mcp__pm-agent-tools__report_completion',
   'mcp__pm-agent-tools__request_edit_mode',

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -22,7 +22,7 @@ import { gitExec } from '../connectors/github/repo-clone.js';
 import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
 import { appendAgentFinding } from '../tasks/persistence.js';
 import { logger } from '../system/logger.js';
-import { findSlackUsers } from '../connectors/slack/client.js';
+import { findSlackUsers, findSlackChannels } from '../connectors/slack/client.js';
 
 // Re-export branch state helpers for consumers that import from tools.ts
 export { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR };
@@ -168,6 +168,28 @@ function createFindSlackUserTool(_agent: Agent, _task: Task) {
         return `- ${parts.join('\n')}`;
       }).join('\n');
       return ok(`Found ${matches.length} user(s):\n${list}`);
+    },
+  );
+}
+
+function createFindSlackChannelTool(_agent: Agent, _task: Task) {
+  return tool(
+    'find_slack_channel',
+    'Find a Slack channel by name or ID. Returns matching channels with their details. Use this to find channel IDs before posting to new threads.',
+    {
+      query: z.string().describe('Channel ID (e.g., "C1234567"), or channel name/part of name to search for (with or without #)'),
+    },
+    async (args) => {
+      const matches = await findSlackChannels(args.query);
+      if (matches.length === 0) return ok('No channels found matching that query.');
+      const list = matches.slice(0, 10).map(ch => {
+        const parts = [`#${ch.name} — ID: ${ch.id} (${ch.memberCount} members)`];
+        if (ch.topic) parts.push(`  Topic: ${ch.topic}`);
+        if (ch.purpose) parts.push(`  Purpose: ${ch.purpose}`);
+        if (ch.isPrivate) parts.push(`  Private channel`);
+        return `- ${parts.join('\n')}`;
+      }).join('\n');
+      return ok(`Found ${matches.length} channel(s):\n${list}`);
     },
   );
 }
@@ -785,6 +807,7 @@ export function createPMAgentMcpServer(agent: Agent, task: Task) {
       createSendMessageTool(agent, task),
       createPostToUserTool(agent, task),
       createFindSlackUserTool(agent, task),
+      createFindSlackChannelTool(agent, task),
       createAssignTaskOwnerTool(agent, task),
       createReportCompletionTool(agent, task),
       createRequestEditModeTool(agent, task),

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -22,6 +22,7 @@ import { gitExec } from '../connectors/github/repo-clone.js';
 import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
 import { appendAgentFinding } from '../tasks/persistence.js';
 import { logger } from '../system/logger.js';
+import { findSlackUsers } from '../connectors/slack/client.js';
 
 // Re-export branch state helpers for consumers that import from tools.ts
 export { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR };
@@ -124,16 +125,49 @@ function createLogFindingTool(agent: Agent, task: Task) {
 function createPostToUserTool(agent: Agent, task: Task) {
   return tool(
     'post_to_user',
-    'Send a message to the user. Routes to the originating channel (Slack thread, CLI, etc.). Write naturally, like a human PM.',
+    'Send a message to the user. Without target, posts to the default channel. ' +
+    'Use target.channel to post to a specific linked thread. ' +
+    'Use target.new_dm with a user ID to start a DM conversation (links it to this task). ' +
+    'Use target.new_thread with a channel ID to start a new thread in a channel (links it to this task). ' +
+    'When creating new DMs/threads, returns the channel key for future use.',
     {
-      message: z.string().describe('The message to send to the user'),
+      message: z.string().describe('The message to send'),
+      target: z.object({
+        channel: z.string().optional().describe('Channel key of an existing linked thread (e.g., "slack:C123:456.789")'),
+        new_dm: z.string().optional().describe('User ID to start a new DM conversation with'),
+        new_thread: z.string().optional().describe('Channel ID to start a new thread in'),
+      }).optional().describe('Where to post. Omit to post to the default channel.'),
     },
     async (args) => {
       const agentName = agent.def.id as AgentName;
-      logger.agentToSlack(agentName, args.message);
       task.touch();
-      await task.postToUser(args.message, agentName);
-      return { content: [{ type: 'text' as const, text: `Posted to user: ${args.message}` }] };
+      const newChannelKey = await task.postToUser(args.message, agentName, args.target);
+      if (newChannelKey) {
+        return ok(`Message posted. New channel linked: ${newChannelKey} (saved in task metadata for future use)`);
+      }
+      return ok('Message posted.');
+    },
+  );
+}
+
+function createFindSlackUserTool(_agent: Agent, _task: Task) {
+  return tool(
+    'find_slack_user',
+    'Find a Slack user by name or ID. Returns matching users with their details. Use this to find user IDs before sending DMs.',
+    {
+      query: z.string().describe('User ID (e.g., "U1234567") or name/part of name to search for'),
+    },
+    async (args) => {
+      const matches = await findSlackUsers(args.query);
+      if (matches.length === 0) return ok('No users found matching that query.');
+      const list = matches.slice(0, 10).map(u => {
+        const parts = [`${u.realName} (@${u.name}) — ID: ${u.id}`];
+        if (u.title) parts.push(`  Title: ${u.title}`);
+        if (u.timezone) parts.push(`  Timezone: ${u.timezone}`);
+        if (u.displayName && u.displayName !== u.realName) parts.push(`  Display name: ${u.displayName}`);
+        return `- ${parts.join('\n')}`;
+      }).join('\n');
+      return ok(`Found ${matches.length} user(s):\n${list}`);
     },
   );
 }
@@ -222,7 +256,6 @@ function createReportCompletionTool(agent: Agent, task: Task) {
     async (args) => {
       const agentName = agent.def.id as AgentName;
       if (args.message) {
-        logger.agentToSlack(agentName, args.message);
         await task.postToUser(args.message, agentName);
       }
       logger.agentAction(agentName, 'Reporting completion', '');
@@ -751,6 +784,7 @@ export function createPMAgentMcpServer(agent: Agent, task: Task) {
     tools: [
       createSendMessageTool(agent, task),
       createPostToUserTool(agent, task),
+      createFindSlackUserTool(agent, task),
       createAssignTaskOwnerTool(agent, task),
       createReportCompletionTool(agent, task),
       createRequestEditModeTool(agent, task),

--- a/src/cli/components/TaskDetail.tsx
+++ b/src/cli/components/TaskDetail.tsx
@@ -5,6 +5,22 @@ import { ScrollView, type ScrollViewRef } from 'ink-scroll-view';
 import { fetchTaskDetail, fetchTaskEvents, sendMessage, sendApproval } from '../api.js';
 import { MessageInput } from './MessageInput.js';
 
+/**
+ * Format message for CLI display using from, to, and destination fields.
+ *
+ * Patterns:
+ *   [cli] @pm-agent message                      — CLI input
+ *   [Egor in #bot-test] @pm-agent message         — Slack incoming
+ *   [pm-agent in #bot-test] message               — agent posting to a channel
+ *   [pm-agent in cli] message                     — agent posting to CLI
+ *   [pm-agent] @backend-agent message             — agent messaging another agent
+ */
+function formatMessageParts(from: string, to: string, destination?: string): { label: string; mention: string } {
+  const label = destination ? `${from} in ${destination}` : from;
+  const mention = from !== to && to !== 'user' ? ` @${to}` : '';
+  return { label, mention };
+}
+
 interface AgentStatus {
   agent: string;
   active: boolean;
@@ -69,7 +85,7 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
       switch (event.type) {
         case 'message':
           logLines.push({
-            node: <><Text dimColor>[{event.data.from as string}]</Text> <Text color="cyan">@{event.data.to as string}</Text> {event.data.message as string}</>,
+            node: (() => { const p = formatMessageParts(event.data.from as string, event.data.to as string, event.data.destination as string | undefined); return <><Text dimColor>[{p.label}]</Text>{p.mention ? <Text color="cyan">{p.mention}</Text> : null} {event.data.message as string}</>; })(),
           });
           break;
         case 'agent:log':

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -935,6 +935,86 @@ export async function findSlackUsers(query: string): Promise<SlackUserInfo[]> {
 }
 
 // ============================================================================
+// Channel Lookup
+// ============================================================================
+
+export interface SlackChannelInfo {
+  id: string;
+  name: string;
+  topic: string;
+  purpose: string;
+  memberCount: number;
+  isPrivate: boolean;
+  isArchived: boolean;
+}
+
+let channelCache: SlackChannelInfo[] = [];
+let channelCacheTimestamp = 0;
+
+/**
+ * List all workspace channels the bot can see (cached, refreshed every 10 minutes).
+ * Filters out archived channels.
+ */
+export async function listWorkspaceChannels(): Promise<SlackChannelInfo[]> {
+  if (channelCache.length > 0 && Date.now() - channelCacheTimestamp < USER_CACHE_TTL) {
+    return channelCache;
+  }
+
+  const client = getSlackClient();
+  const channels: SlackChannelInfo[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const result = await client.conversations.list({
+      cursor,
+      limit: 200,
+      exclude_archived: true,
+      types: 'public_channel,private_channel',
+    });
+    for (const ch of result.channels ?? []) {
+      channels.push({
+        id: ch.id!,
+        name: ch.name ?? ch.id!,
+        topic: (ch.topic as { value?: string })?.value ?? '',
+        purpose: (ch.purpose as { value?: string })?.value ?? '',
+        memberCount: ch.num_members ?? 0,
+        isPrivate: ch.is_private ?? false,
+        isArchived: ch.is_archived ?? false,
+      });
+    }
+    cursor = result.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  channelCache = channels;
+  channelCacheTimestamp = Date.now();
+  logger.slack(`Cached ${channels.length} workspace channels`);
+  return channels;
+}
+
+/**
+ * Find Slack channels by ID or name.
+ * - If query looks like a Slack channel ID (starts with C), returns exact match
+ * - Otherwise, case-insensitive substring match against name, topic, purpose
+ */
+export async function findSlackChannels(query: string): Promise<SlackChannelInfo[]> {
+  const channels = await listWorkspaceChannels();
+
+  // Exact ID match
+  if (/^C[A-Z0-9]+$/.test(query)) {
+    const ch = channels.find(c => c.id === query);
+    return ch ? [ch] : [];
+  }
+
+  // Name search (strip leading # if present)
+  const q = query.replace(/^#/, '').toLowerCase();
+  return channels.filter(c =>
+    c.name.toLowerCase().includes(q) ||
+    c.topic.toLowerCase().includes(q) ||
+    c.purpose.toLowerCase().includes(q)
+  );
+}
+
+// ============================================================================
 // DM & Channel Messaging
 // ============================================================================
 

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -834,3 +834,139 @@ export async function fetchSlackThread(
     currentMessageTs,
   };
 }
+
+// ============================================================================
+// Channel Formatting
+// ============================================================================
+
+/**
+ * Format a Slack channel reference for logs (includes IDs).
+ * e.g., "slack:#<C123:bot-test>:threadTs"
+ */
+export function formatSlackChannelRef(channelId: string, channelName: string, threadId: string): string {
+  return `slack:#<${channelId}:${channelName}>:${threadId}`;
+}
+
+/**
+ * Format a Slack channel for human-readable display.
+ * e.g., "#bot-test"
+ */
+export function formatSlackChannelDisplay(channelName: string): string {
+  return `#${channelName}`;
+}
+
+// ============================================================================
+// User Lookup
+// ============================================================================
+
+export interface SlackUserInfo {
+  id: string;
+  name: string;          // @handle
+  realName: string;      // Full name
+  displayName: string;   // Display name (may differ from realName)
+  title: string;         // Job title (e.g., "Senior Engineer")
+  timezone: string;      // Timezone label (e.g., "Eastern Time (US & Canada)")
+  isAdmin: boolean;      // Workspace admin
+  isOwner: boolean;      // Workspace owner
+}
+
+let userCache: SlackUserInfo[] = [];
+let userCacheTimestamp = 0;
+const USER_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * List all workspace users (cached, refreshed every 10 minutes).
+ * Filters out bots and deactivated accounts.
+ */
+export async function listWorkspaceUsers(): Promise<SlackUserInfo[]> {
+  if (userCache.length > 0 && Date.now() - userCacheTimestamp < USER_CACHE_TTL) {
+    return userCache;
+  }
+
+  const client = getSlackClient();
+  const users: SlackUserInfo[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const result = await client.users.list({ cursor, limit: 200 });
+    for (const member of result.members ?? []) {
+      if (member.deleted || member.is_bot || member.id === 'USLACKBOT') continue;
+      users.push({
+        id: member.id!,
+        name: member.name ?? member.id!,
+        realName: member.real_name ?? member.name ?? member.id!,
+        displayName: member.profile?.display_name || member.real_name || member.name || member.id!,
+        title: member.profile?.title ?? '',
+        timezone: member.tz_label ?? member.tz ?? '',
+        isAdmin: member.is_admin ?? false,
+        isOwner: member.is_owner ?? false,
+      });
+    }
+    cursor = result.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  userCache = users;
+  userCacheTimestamp = Date.now();
+  logger.slack(`Cached ${users.length} workspace users`);
+  return users;
+}
+
+/**
+ * Find Slack users by ID or name.
+ * - If query looks like a Slack user ID (starts with U), returns exact match
+ * - Otherwise, case-insensitive substring match against name, realName, displayName
+ */
+export async function findSlackUsers(query: string): Promise<SlackUserInfo[]> {
+  const users = await listWorkspaceUsers();
+
+  // Exact ID match
+  if (/^U[A-Z0-9]+$/.test(query)) {
+    const user = users.find(u => u.id === query);
+    return user ? [user] : [];
+  }
+
+  // Name search
+  const q = query.toLowerCase();
+  return users.filter(u =>
+    u.name.toLowerCase().includes(q) ||
+    u.realName.toLowerCase().includes(q) ||
+    u.displayName.toLowerCase().includes(q)
+  );
+}
+
+// ============================================================================
+// DM & Channel Messaging
+// ============================================================================
+
+/**
+ * Open (or get existing) DM channel with a user.
+ * Returns the DM channel ID (e.g., "D1234567").
+ */
+export async function openDMChannel(userId: string): Promise<string> {
+  if (dryRun) {
+    logger.system(`[DRY RUN] openDMChannel for user ${userId}`);
+    return `D_DRYRUN_${userId}`;
+  }
+  const client = getSlackClient();
+  const result = await client.conversations.open({ users: userId });
+  return result.channel!.id!;
+}
+
+/**
+ * Post a top-level message to a channel (not in a thread).
+ * Creates a new thread — the returned ts becomes the thread_id for replies.
+ */
+export async function postNewMessage(channel: string, text: string): Promise<string | undefined> {
+  if (dryRun) {
+    logger.system(`[DRY RUN] postNewMessage ${channel} — ${text.slice(0, 120)}`);
+    return undefined;
+  }
+  const client = getSlackClient();
+  const slackText = slackifyMarkdown(restoreMentions(text));
+  const result = await client.chat.postMessage({
+    channel,
+    text: slackText,
+    mrkdwn: true,
+  });
+  return result.ts;
+}

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -20,6 +20,7 @@ import {
   fetchSlackThread,
   getBotId,
   addReaction,
+  removeReaction,
   setSlackDryRun,
 } from './client.js';
 import { Task } from '../../tasks/task.js';
@@ -278,8 +279,18 @@ async function handleSlackEvent(event: {
 }): Promise<void> {
   const threadId = event.thread_ts || event.ts;
 
-  // Instant acknowledgment — react before any LLM processing
+  // Instant acknowledgment — react before any LLM processing.
+  // Remove eyes from the previous message first (only one message should have eyes at a time).
   if (event.type === 'app_mention' || event.channel.startsWith('D')) {
+    const prevTaskId = await findTaskByThread(threadId);
+    if (prevTaskId) {
+      const prevTask = await Task.get(prevTaskId);
+      const chKey = `slack:${event.channel}:${threadId}`;
+      const prevCh = prevTask.metadata.channels[chKey];
+      if (prevCh?.type === 'slack' && prevCh.last_processed_ts !== event.ts) {
+        removeReaction(event.channel, prevCh.last_processed_ts, 'eyes');
+      }
+    }
     addReaction(event.channel, event.ts, 'eyes');
   }
 

--- a/src/system/logger.ts
+++ b/src/system/logger.ts
@@ -264,9 +264,10 @@ export class Logger {
   /**
    * Log an agent posting to Slack
    */
-  agentToSlack(agentName: string, message: string, opts?: { editMode?: boolean }): void {
+  agentToSlack(agentName: string, message: string, opts?: { editMode?: boolean; destination?: string }): void {
     const label = formatAgentLabel(agentName, opts?.editMode);
-    console.log(`${label} ${c.dim('→')} ${c.cyan('[Slack]')}: ${message}`);
+    const dest = opts?.destination ? `[${opts.destination}]` : '[Slack]';
+    console.log(`${label} ${c.dim('→')} ${c.cyan(dest)}: ${message}`);
   }
 
   /**

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -15,6 +15,7 @@ import { activeTasks } from './task.js';
 import { SESSIONS_DIR } from '../system/workdir.js';
 import { emitEvent, onEvent } from '../system/event-bus.js';
 import { logger } from '../system/logger.js';
+import { formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
 
 /**
  * Generate a unique task ID with human-readable date format
@@ -183,7 +184,7 @@ export async function appendSlackMessage(
   files?: SlackFile[]
 ): Promise<void> {
   // Build message with optional file attachments
-  let fullMessage = `[@<${userInfo.id}:${userInfo.realName}>] ${message}`;
+  let fullMessage = message;
 
   if (files && files.length > 0) {
     const fileInfo = files.map(f => {
@@ -195,12 +196,12 @@ export async function appendSlackMessage(
 
   const entry: LogEntry = {
     timestamp: new Date().toISOString(),
-    source: `slack:#<${channelInfo.id}:${channelInfo.name}>:${threadId}`,
+    source: `@<${userInfo.id}:${userInfo.realName}> in ${formatSlackChannelRef(channelInfo.id, channelInfo.name, threadId)}`,
     message: fullMessage,
   };
 
   await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
-  emitEvent('message', taskId, { from: userInfo.realName, to: 'pm-agent', message });
+  emitEvent('message', taskId, { from: userInfo.realName, to: 'pm-agent', destination: formatSlackChannelDisplay(channelInfo.name), message });
 }
 
 /**
@@ -230,11 +231,13 @@ export async function appendMessageToUser(
   taskId: string,
   agentName: string,
   message: string,
+  destination?: string,
 ): Promise<void> {
+  const source = destination ? `${agentName} in ${destination}` : agentName;
   const entry: LogEntry = {
     timestamp: new Date().toISOString(),
-    source: agentName,
-    message: `@user ${message}`,
+    source,
+    message,
   };
   await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
 }
@@ -291,7 +294,7 @@ export async function appendCliMessage(
   };
 
   await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
-  emitEvent('message', taskId, { from: 'user', to: 'pm-agent', message });
+  emitEvent('message', taskId, { from: 'cli', to: 'pm-agent', message });
 }
 
 /**

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -10,6 +10,18 @@ import type { AgentName, SlackChannel, SlackThread, TaskMetadata } from '../type
 import type { AgentDef } from '../types/agent.js';
 
 /**
+ * Target for postToUser — controls where the message is delivered.
+ */
+export interface PostTarget {
+  /** Post to an existing linked thread (channel key, e.g., "slack:C123:456.789") */
+  channel?: string;
+  /** Start a new DM with a user (Slack user ID). Reuses existing DM thread if one is linked. */
+  new_dm?: string;
+  /** Start a new thread in a channel (Slack channel ID). */
+  new_thread?: string;
+}
+
+/**
  * Resource budgets for a task (Defense 4 — per-task limits)
  */
 export interface TaskBudgets {
@@ -40,7 +52,7 @@ import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
 import { scanAgentDefs } from '../agents/registry.js';
 import { refreshPlugins } from '../system/workdir.js';
-import { postToThreads, postInteractiveToThreads, removeReaction, buildThreadUrl } from '../connectors/slack/client.js';
+import { postToThread, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, postNewMessage, getChannelInfo, getUserInfo, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { logger } from '../system/logger.js';
 import { emitEvent } from '../system/event-bus.js';
@@ -233,52 +245,164 @@ export class Task {
   }
 
   /**
-   * Post a message to the user via the default channel.
-   * Always emits an event (so CLI sees it via SSE). If the default channel
-   * is a Slack thread, also posts there.
+   * Post a message to the user.
+   *
+   * Targeting modes:
+   * - No target: post to default_channel only
+   * - target.channel: post to a specific already-linked thread
+   * - target.new_dm: open DM with user, post message, link thread (reuses existing DM if found)
+   * - target.new_thread: post top-level message in channel, link thread
+   *
+   * Returns the channel key when a new channel is created/reused, null otherwise.
    */
-  async postToUser(message: string, agentName?: string): Promise<void> {
+  async postToUser(message: string, agentName?: string, target?: PostTarget): Promise<string | null> {
     const sender = agentName || 'system';
-    emitEvent('message', this.taskId, { from: sender, to: 'user', message });
-    await appendMessageToUser(this.taskId, sender, message);
 
-    const slackRefs = this.getSlackThreadRefs();
-    if (slackRefs.length > 0) {
-      // Remove eyes acknowledgment before posting the reply
-      await Promise.all(
-        slackRefs.map((ref) => removeReaction(ref.channel_id, ref.last_processed_ts, 'eyes')),
-      );
-      await postToThreads(slackRefs, message);
+    // New DM — open DM channel, reuse existing thread or create new
+    if (target?.new_dm) {
+      const dmChannelId = await openDMChannel(target.new_dm);
+      const existing = this.findChannelBySlackId(dmChannelId);
+      if (existing) {
+        const dest = Task.formatSlackDest(existing.channel);
+        this.logOutgoingMessage(sender, message, dest.display, existing.channel);
+        await this.postToSlackRef(existing.channel, message);
+        return existing.key;
+      }
+      const userInfo = await getUserInfo(target.new_dm);
+      const channelName = `DM with ${userInfo.realName}`;
+      const ts = await postNewMessage(dmChannelId, message);
+      if (!ts) return null; // dry-run
+      const key = this.registerSlackChannel(dmChannelId, ts, channelName);
+      const ch = this.metadata.channels[key] as SlackChannel;
+      this.logOutgoingMessage(sender, message, Task.formatSlackDest(ch).display, ch);
+      return key;
     }
+
+    // New thread in a channel
+    if (target?.new_thread) {
+      const channelInfo = await getChannelInfo(target.new_thread);
+      const ts = await postNewMessage(target.new_thread, message);
+      if (!ts) return null; // dry-run
+      const key = this.registerSlackChannel(target.new_thread, ts, channelInfo.name);
+      const ch = this.metadata.channels[key] as SlackChannel;
+      this.logOutgoingMessage(sender, message, Task.formatSlackDest(ch).display, ch);
+      return key;
+    }
+
+    // Specific existing channel
+    if (target?.channel) {
+      const ch = this.metadata.channels[target.channel];
+      if (ch?.type === 'slack') {
+        const dest = Task.formatSlackDest(ch);
+        this.logOutgoingMessage(sender, message, dest.display, ch);
+        await this.postToSlackRef(ch, message);
+      }
+      return null;
+    }
+
+    // Default channel
+    const defaultCh = this.metadata.default_channel
+      ? this.metadata.channels[this.metadata.default_channel]
+      : null;
+    if (defaultCh?.type === 'slack') {
+      const dest = Task.formatSlackDest(defaultCh);
+      this.logOutgoingMessage(sender, message, dest.display, defaultCh);
+      await this.postToSlackRef(defaultCh, message);
+    } else {
+      // CLI or no channel
+      this.logOutgoingMessage(sender, message, 'cli');
+    }
+    return null;
   }
 
   /**
-   * Post an interactive message (with blocks) to the user.
-   * Always emits an approval:requested event (so CLI sees it).
-   * If Slack channels exist, also posts interactive message there.
+   * Emit event and append outgoing message to knowledge log with destination info.
+   */
+  /**
+   * Format a SlackChannel as a destination string for logs.
+   * For knowledge log: includes IDs (e.g., "slack:#<C123:bot-test>:threadTs")
+   * For CLI/server: human-readable (e.g., "#bot-test", "DM with Egor")
+   */
+  private static formatSlackDest(ch: SlackChannel): { log: string; display: string } {
+    return {
+      log: formatSlackChannelRef(ch.channel_id, ch.channel_name, ch.thread_id),
+      display: formatSlackChannelDisplay(ch.channel_name),
+    };
+  }
+
+  private logOutgoingMessage(sender: string, message: string, destination: string, slackChannel?: SlackChannel): void {
+    const display = destination;
+    const logDest = slackChannel ? Task.formatSlackDest(slackChannel).log : destination;
+    logger.agentToSlack(sender, message, { destination: display });
+    emitEvent('message', this.taskId, { from: sender, to: 'user', destination: display, message });
+    appendMessageToUser(this.taskId, sender, message, logDest);
+  }
+
+  /**
+   * Post an interactive message (with blocks) to the user via the default channel.
    */
   async postInteractiveToUser(text: string, blocks: unknown[], approvalType: 'edit_mode' | 'research_budget'): Promise<void> {
     emitEvent('approval:requested', this.taskId, { text, approvalType });
 
-    const slackRefs = this.getSlackThreadRefs();
-    if (slackRefs.length > 0) {
-      await postInteractiveToThreads(slackRefs, text, blocks);
+    const defaultCh = this.metadata.default_channel
+      ? this.metadata.channels[this.metadata.default_channel]
+      : null;
+    if (defaultCh?.type === 'slack') {
+      await postInteractiveToThreads([{
+        thread_id: defaultCh.thread_id,
+        channel_id: defaultCh.channel_id,
+        last_processed_ts: defaultCh.last_processed_ts,
+      }], text, blocks);
     } else {
       logger.slack(`POST (interactive): ${text}`);
     }
   }
 
   /**
-   * Extract SlackThreadRef[] from channels for posting via Slack client.
+   * Remove eyes reaction from the last processed message on all Slack channels.
+   * Called on task stop/complete to clean up acknowledgment indicators.
    */
-  private getSlackThreadRefs(): { thread_id: string; channel_id: string; last_processed_ts: string }[] {
-    return Object.values(this.metadata.channels)
-      .filter((ch): ch is SlackChannel => ch.type === 'slack')
-      .map((ch) => ({
-        thread_id: ch.thread_id,
-        channel_id: ch.channel_id,
-        last_processed_ts: ch.last_processed_ts,
-      }));
+  private removeEyesFromAllChannels(): void {
+    for (const ch of Object.values(this.metadata.channels)) {
+      if (ch.type === 'slack') {
+        removeReaction(ch.channel_id, ch.last_processed_ts, 'eyes');
+      }
+    }
+  }
+
+  /**
+   * Post to a single Slack thread ref.
+   */
+  private async postToSlackRef(ch: SlackChannel, message: string): Promise<void> {
+    await postToThread(ch.channel_id, ch.thread_id, message);
+  }
+
+  /**
+   * Find an existing channel entry by Slack channel ID.
+   * Used for DM reuse — conversations.open returns the same channel ID for a given user.
+   */
+  private findChannelBySlackId(slackChannelId: string): { key: string; channel: SlackChannel } | null {
+    for (const [key, ch] of Object.entries(this.metadata.channels)) {
+      if (ch.type === 'slack' && ch.channel_id === slackChannelId) return { key, channel: ch };
+    }
+    return null;
+  }
+
+  /**
+   * Register a new Slack channel/thread in the task metadata.
+   */
+  private registerSlackChannel(channelId: string, threadTs: string, channelName: string): string {
+    const key = `slack:${channelId}:${threadTs}`;
+    this.metadata.channels[key] = {
+      type: 'slack',
+      thread_id: threadTs,
+      channel_id: channelId,
+      channel_name: channelName,
+      last_processed_ts: threadTs,
+      url: buildThreadUrl(channelId, threadTs) ?? undefined,
+    };
+    this.debouncedSave();
+    return key;
   }
 
   /**
@@ -303,6 +427,8 @@ export class Task {
     if (this.metadata.edit_allowed !== true) {
       await this.cleanupClones();
     }
+
+    this.removeEyesFromAllChannels();
 
     this.metadata.status = 'stopped';
     await this.save(true);
@@ -334,6 +460,8 @@ export class Task {
     if (this.metadata.edit_allowed !== true) {
       await this.cleanupClones();
     }
+
+    this.removeEyesFromAllChannels();
 
     this.metadata.status = 'completed';
     await this.save(true);


### PR DESCRIPTION
## Summary

- **New `find_slack_user` PM tool** — search workspace users by name or ID, returns details (title, timezone, display name)
- **New `find_slack_channel` PM tool** — search channels by name or ID, returns details (topic, purpose, member count, privacy)
- **Updated `post_to_user` with targeting** — optional `target` parameter for posting to specific channels (`target.channel`), starting DMs (`target.new_dm`), or creating new threads (`target.new_thread`). New threads automatically link to the task so replies route back.
- **No more broadcast** — `postToUser` and `postInteractiveToUser` now post to default channel only instead of all linked threads
- **Consistent `[who in where]` logging** — CLI, knowledge log, and server log all use the same structure with appropriate detail level (IDs in knowledge log, human-readable in CLI)
- **Eyes reaction lifecycle** — eyes removed on task stop/complete and replaced per-message when new messages arrive
- **Added `groups:read` scope** to Slack manifest so private channels are discoverable
- **No other Slack manifest changes needed** — existing scopes cover all new functionality

## Test plan

- [x] Typecheck passes
- [x] All 22 tests pass
- [x] Manual test: find user by name, send DM, receive reply routed back to task
- [x] Manual test: cross-channel flow (Slack channel → DM → back to channel)
- [x] Manual test: CLI-originated task with DM targeting
- [x] Manual test: find channel by name and post new thread
- [x] Verify eyes removed on task completion in Slack
- [x] Verify consistent `[who in where]` format in CLI and knowledge log

🤖 Generated with [Claude Code](https://claude.com/claude-code)