### PR TITLE
Fix CLI SSE disconnect flicker when switching views

### DIFF
--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -134,12 +134,14 @@ export function connectSSE(opts: SSEOptions): () => void {
       if (err.name === 'AbortError') return;
     }
 
+    // If aborted, this was an intentional teardown — don't fire onDisconnect
+    // or attempt to reconnect (the new connection handles its own state)
+    if (aborted) return;
+
     opts.onDisconnect?.();
 
     // Reconnect after delay
-    if (!aborted) {
-      setTimeout(connect, 3000);
-    }
+    setTimeout(connect, 3000);
   };
 
   connect();


### PR DESCRIPTION
## Summary

- Old SSE connection's read loop could outlive the abort signal when switching between list and detail views
- This caused `onDisconnect` to fire after a new connection was already established, showing a false "disconnected" status
- Now skips `onDisconnect` and reconnect when the teardown was intentional (`aborted=true`)

## Test plan

- [x] Open CLI, navigate between task list and detail views repeatedly
- [x] Verify status bar stays "connected" without flickering to "disconnected"
- [x] Verify SSE events still stream correctly in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)