### PR TITLE
Fix sandbox-blocked SDK tool results for large MCP outputs

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -137,12 +137,17 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   task.updateAgentState(def.id, true);
 
   // ---- SDK config/tmp dirs (agent reads tool-results from here) ----
+  // Only create for new tasks. Old tasks recovering won't have <taskId>/claude/
+  // on disk — skip to avoid breaking their sandbox config during transition.
 
   const claudeBaseDir = join(getTaskPath(taskId), 'claude', def.key);
-  const claudeConfigDir = join(claudeBaseDir, 'session');
-  const claudeTmpDir = join(claudeBaseDir, 'tmp');
-  await mkdir(claudeConfigDir, { recursive: true });
-  await mkdir(claudeTmpDir, { recursive: true });
+  const hasClaudeDirs = existsSync(claudeBaseDir);
+  if (!agent.session.session_id) {
+    // Fresh spawn — create dirs
+    await mkdir(join(claudeBaseDir, 'session'), { recursive: true });
+    await mkdir(join(claudeBaseDir, 'tmp'), { recursive: true });
+  }
+  const useClaudeDirs = hasClaudeDirs || !agent.session.session_id;
 
   // ---- Build track-specific config ----
 
@@ -211,7 +216,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       cwd: pmWorkspace,
       denyReadPaths: [WORKDIR],
       allowReadPaths: [
-        pmWorkspace, sharedPath, claudeBaseDir,
+        pmWorkspace, sharedPath, ...(useClaudeDirs ? [claudeBaseDir] : []),
         ...(def.pluginPath ? [def.pluginPath] : []),
         ...(def.pluginDataPath ? [def.pluginDataPath] : []),
       ],
@@ -374,7 +379,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       sandboxOpts = {
         cwd,
         denyReadPaths: [WORKDIR],
-        allowReadPaths: [repoWorkspace, repoPath, claudeBaseDir, ...readOnlyPaths],
+        allowReadPaths: [repoWorkspace, repoPath, ...(useClaudeDirs ? [claudeBaseDir] : []), ...readOnlyPaths],
         allowWritePaths: [repoWorkspace, repoPath],
         denyWritePaths: [...readOnlyPaths, ...denyWriteProtected],
       };
@@ -382,7 +387,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       sandboxOpts = {
         cwd,
         denyReadPaths: [WORKDIR],
-        allowReadPaths: [repoWorkspace, repoPath, claudeBaseDir, ...readOnlyPaths],
+        allowReadPaths: [repoWorkspace, repoPath, ...(useClaudeDirs ? [claudeBaseDir] : []), ...readOnlyPaths],
         allowWritePaths: [repoWorkspace],
         denyWritePaths: [repoPath, ...readOnlyPaths],
       };
@@ -433,7 +438,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       cwd: agentWorkspace,
       denyReadPaths: [WORKDIR],
       allowReadPaths: [
-        agentWorkspace, sharedPath, claudeBaseDir,
+        agentWorkspace, sharedPath, ...(useClaudeDirs ? [claudeBaseDir] : []),
         ...(def.pluginPath ? [def.pluginPath] : []),
         ...(def.pluginDataPath ? [def.pluginDataPath] : []),
       ],
@@ -464,8 +469,10 @@ Shared folder: ${sharedPath} [READ-ONLY]
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
       PATH: process.env.PATH,
       CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
-      CLAUDE_CONFIG_DIR: claudeConfigDir,
-      CLAUDE_CODE_TMPDIR: claudeTmpDir,
+      ...(useClaudeDirs ? {
+        CLAUDE_CONFIG_DIR: join(claudeBaseDir, 'session'),
+        CLAUDE_CODE_TMPDIR: join(claudeBaseDir, 'tmp'),
+      } : {}),
     },
     resume: sessionId,
     maxTurns: 100,

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -136,6 +136,14 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   // false idle detection — recovery fires at 3s, MCP connections can take longer
   task.updateAgentState(def.id, true);
 
+  // ---- SDK config/tmp dirs (agent reads tool-results from here) ----
+
+  const claudeBaseDir = join(getTaskPath(taskId), 'claude', def.key);
+  const claudeConfigDir = join(claudeBaseDir, 'session');
+  const claudeTmpDir = join(claudeBaseDir, 'tmp');
+  await mkdir(claudeConfigDir, { recursive: true });
+  await mkdir(claudeTmpDir, { recursive: true });
+
   // ---- Build track-specific config ----
 
   let systemPrompt: string;
@@ -203,7 +211,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       cwd: pmWorkspace,
       denyReadPaths: [WORKDIR],
       allowReadPaths: [
-        pmWorkspace, sharedPath,
+        pmWorkspace, sharedPath, claudeBaseDir,
         ...(def.pluginPath ? [def.pluginPath] : []),
         ...(def.pluginDataPath ? [def.pluginDataPath] : []),
       ],
@@ -366,7 +374,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       sandboxOpts = {
         cwd,
         denyReadPaths: [WORKDIR],
-        allowReadPaths: [repoWorkspace, repoPath, ...readOnlyPaths],
+        allowReadPaths: [repoWorkspace, repoPath, claudeBaseDir, ...readOnlyPaths],
         allowWritePaths: [repoWorkspace, repoPath],
         denyWritePaths: [...readOnlyPaths, ...denyWriteProtected],
       };
@@ -374,7 +382,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       sandboxOpts = {
         cwd,
         denyReadPaths: [WORKDIR],
-        allowReadPaths: [repoWorkspace, repoPath, ...readOnlyPaths],
+        allowReadPaths: [repoWorkspace, repoPath, claudeBaseDir, ...readOnlyPaths],
         allowWritePaths: [repoWorkspace],
         denyWritePaths: [repoPath, ...readOnlyPaths],
       };
@@ -425,7 +433,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       cwd: agentWorkspace,
       denyReadPaths: [WORKDIR],
       allowReadPaths: [
-        agentWorkspace, sharedPath,
+        agentWorkspace, sharedPath, claudeBaseDir,
         ...(def.pluginPath ? [def.pluginPath] : []),
         ...(def.pluginDataPath ? [def.pluginDataPath] : []),
       ],
@@ -456,6 +464,8 @@ Shared folder: ${sharedPath} [READ-ONLY]
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
       PATH: process.env.PATH,
       CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+      CLAUDE_CONFIG_DIR: claudeConfigDir,
+      CLAUDE_CODE_TMPDIR: claudeTmpDir,
     },
     resume: sessionId,
     maxTurns: 100,


### PR DESCRIPTION
## Summary
- Redirect SDK's `CLAUDE_CONFIG_DIR` and `CLAUDE_CODE_TMPDIR` into the task tree (`<taskId>/claude/<agentKey>/`) so large tool-result files land in a sandbox-accessible location
- Add the redirected dir to `allowReadPaths` in all agent tracks (PM, repo, plugin)
- Gate the redirection on fresh spawns only — legacy tasks recovering without the `claude/` dir on disk continue working as before

## Context
When MCP tools (e.g. `n8n-context-grabber`) return large outputs (~117KB+), the SDK saves them to `~/.claude/projects/.../tool-results/`. The agent then tries to read the file back, but the sandbox denies access to `~/.claude`, causing a retry loop.

## Test plan
- [x] Verified `CLAUDE_CONFIG_DIR` redirects tool-results into the task tree
- [x] Verified agent can read the saved tool-results file
- [x] Verify legacy task recovery still works (no `claude/` dir → old behavior)
- [x] Verify new task with large MCP output reads tool-results successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)