### PR TITLE
Eliminate GitHub PR triage and fix repo-agent review tools

### DIFF
--- a/docs/plans/v22-github-triage-removal.md
+++ b/docs/plans/v22-github-triage-removal.md
@@ -1,0 +1,166 @@
+# Eliminate GitHub PR comment triage
+
+## Context
+
+The GitHub webhook → agent flow has two defects the user noticed: PR comments and merge status aren't reliably reaching the agent or `shared-knowledge.log`.
+
+Root causes:
+
+1. **PR merge/close events are dropped at the router.** [webhooks.ts:260](src/connectors/github/webhooks.ts#L260) returns `'noop'` for `pull_request` / `action === 'closed'`, so merged/closed PRs never reach the existing-task handler.
+2. **PR comments are gated by an LLM classifier.** `issue_comment` events are routed to `processGitHubTriage` which calls `triageGitHubComment` (Haiku). Any comment the classifier deems "conversational" ("Thanks", "LGTM", etc.) is silently dropped — not logged, not sent to the agent.
+
+Decision: remove GitHub triage entirely. Every relevant PR event for a known task routes directly to the existing-task handler, which appends to the knowledge log and pings the agent. Slack triage stays untouched. Preserve `last_processed_comment_id` bookkeeping (user wants it for future PR-tracking work) and make it actually load-bearing with a dedup guard.
+
+## Critical files
+
+- [src/connectors/github/webhooks.ts](src/connectors/github/webhooks.ts) — routing + context formatting
+- [src/connectors/github/events.ts](src/connectors/github/events.ts) — webhook dispatch + handlers
+- [src/system/triage.ts](src/system/triage.ts) — remove GitHub-specific triage code
+- [src/agents/prompts.ts](src/agents/prompts.ts) — stale doc comment
+- [prompts/triage-agent.md](prompts/triage-agent.md) — drop the "or GitHub PR comments" phrase
+
+## Implementation
+
+All code changes land in one commit (types change across files; intermediate states don't typecheck). Docs under `docs/architecture/` are a follow-up.
+
+### 1. Route changes — [webhooks.ts](src/connectors/github/webhooks.ts)
+
+In `determineRouteAction` ([L242-L277](src/connectors/github/webhooks.ts#L242-L277)):
+
+- `issue_comment` + `action === 'created'` → `'existing_task'` (was `'triage_comment'`)
+- `pull_request` + `action === 'closed'` → `'existing_task'` (was `'noop'`)
+- Other arms unchanged
+
+Type/union cleanup:
+
+- Drop `'triage'` variant from `GitHubRouteResult` ([L229-L232](src/connectors/github/webhooks.ts#L229-L232)). Final shape: `{ action: 'discard'; reason } | { action: 'direct'; handler: 'merge_check' | 'existing_task'; taskId }`. `discard` stays: the dispatcher at [events.ts:93-95](src/connectors/github/events.ts#L93-L95) logs `route.reason` (own-bot events, unknown branch pattern, missing task, noop action) — useful for webhook debugging.
+- Drop `'triage_comment'` from `InternalRouteAction` ([L237](src/connectors/github/webhooks.ts#L237)).
+- Remove the `case 'triage_comment'` arm from the switch at [L330-L346](src/connectors/github/webhooks.ts#L330-L346).
+- Update the docstring at [L288-L294](src/connectors/github/webhooks.ts#L288-L294) to drop the "If event needs triage" bullet.
+
+### 1a. Align GitHub event shape with Slack/CLI — [persistence.ts](src/tasks/persistence.ts) and [webhooks.ts](src/connectors/github/webhooks.ts)
+
+Slack and CLI both use a structured event shape — author goes into `from`, channel/context into `destination`, `message` is the clean body:
+
+- Slack: `{ from: "Egor", to: "pm-agent", destination: "#bot-test", message: "hello" }` ([persistence.ts:204](src/tasks/persistence.ts#L204))
+- CLI: `{ from: "cli", to: "pm-agent", message: "hello" }` ([persistence.ts:297](src/tasks/persistence.ts#L297))
+
+Which the CLI renders as `[Egor in #bot-test] @pm-agent hello` via `formatMessageParts` ([TaskDetail.tsx:18-22](src/cli/components/TaskDetail.tsx#L18-L22)).
+
+GitHub events currently jam the author into the message body (`"PR #42: alice commented: fix bug"`) and set `from: "github:backend"` — the structured shape loses author information, and the CLI can't render `[alice in PR #42]` cleanly.
+
+**Change:**
+
+1. `GitHubEventContext` already has `user`, `prNumber`, `body` — use them directly.
+
+2. Replace `formatGitHubEventMessage(context): string` with `formatGitHubEvent(context): { from: string; destination: string; message: string }` at [webhooks.ts:154](src/connectors/github/webhooks.ts#L154). Examples:
+   - `pull_request_review` approved: `{ from: alice, destination: "PR #42", message: "approved" }`
+   - `pull_request_review` changes_requested: `{ from: alice, destination: "PR #42", message: "requested changes: <body>" }`
+   - `pull_request_review` commented: `{ from: alice, destination: "PR #42", message: "commented: <body>" }` (or just `<body>` — see note)
+   - `pull_request_review_comment`: `{ from: alice, destination: "PR #42", message: "commented on code: <body>" }`
+   - `pull_request` closed/merged: `{ from: alice, destination: "PR #42", message: "merged" }` or `"closed"`
+   - `issue_comment`: `{ from: alice, destination: "PR #42", message: <body> }`
+   - `push`: `{ from: alice, destination: "branch:<name>", message: "pushed" }`
+   - `workflow_run`: `{ from: "ci", destination: "branch:<name>", message: "workflow <conclusion>" }`
+
+   Author comes from `context.user`; destination prefers `PR #N` for PR-scoped events and `branch:<name>` for push/CI. Message body is the pure comment/action, no `"user X by"` prefix.
+
+3. Update `appendGitHubEvent` at [persistence.ts:268-281](src/tasks/persistence.ts#L268-L281) to accept the structured payload and emit it with repo context in `destination`:
+
+   ```ts
+   export async function appendGitHubEvent(
+     taskId: string,
+     repoKey: string,
+     event: { from: string; destination: string; message: string }
+   ): Promise<void>
+   ```
+
+   Inside: the knowledge-log line becomes `source: github:${repoKey}/${event.destination}`, `message: ${event.from}: ${event.message}` (or similar — mirrors the Slack log-entry shape at [L199-L201](src/tasks/persistence.ts#L199-L201) which puts the author in `source`). Emitted SSE shape: `{ from: event.from, to: 'pm-agent', destination: ${repoKey}/${event.destination}, message: event.message }` — now consumable by `formatMessageParts` unchanged.
+
+4. Only caller of `appendGitHubEvent` is [events.ts](src/connectors/github/events.ts) (plus the soon-deleted processGitHubTriage backfill loop). Update that call site in the new `handleExistingTaskDirect`.
+
+**Result in CLI:** PR comments render as `[alice in backend/PR #42] @pm-agent fix the bug` instead of the current `[github:backend] @pm-agent PR #42: alice commented: fix the bug`. Matches Slack's `[Egor in #bot-test] @pm-agent hello`.
+
+**Knowledge-log format change:** the on-disk format of GitHub entries changes (`source` goes from `github:backend` to `github:backend/PR #42` and the author is separated from the message body). Historical entries stay readable — the format is still `[timestamp] [source] message`. No parser elsewhere consumes the exact GitHub line format (grepped — only `appendGitHubEvent` writes it).
+
+### 2. Handler consolidation — [events.ts](src/connectors/github/events.ts)
+
+Imports:
+
+- Drop `triageGitHubComment, type GitHubComment` ([L28](src/connectors/github/events.ts#L28)).
+- Drop `createGitHubClient` ([L20](src/connectors/github/events.ts#L20)) — only `processGitHubTriage` used it.
+- Keep `findBranchStateByPR` — it moves into `handleExistingTaskDirect`.
+
+Dispatch switch ([L95-L108](src/connectors/github/events.ts#L95-L108)): remove the `else if (route.action === 'triage')` branch. Final shape: `discard` logged and dropped → `direct` routes to `handleMergeCheckDirect` or `handleExistingTaskDirect`.
+
+Delete:
+
+- `processGitHubTriage` ([L131-L210](src/connectors/github/events.ts#L131-L210))
+- `handleGitHubCommentDirect` ([L215-L230](src/connectors/github/events.ts#L215-L230))
+
+Expand `handleExistingTaskDirect` ([L115-L126](src/connectors/github/events.ts#L115-L126)) to one function with an `issue_comment` branch that also updates bookkeeping. Shape:
+
+1. Resolve `repoKey` via `getAgentDefByGithubRepo(context.githubRepo)`; fallback `'unknown'`.
+2. Load `task = await Task.get(taskId)`.
+3. If `context.eventType === 'issue_comment'` and both `context.prNumber` and `context.commentId` are set:
+   - `repoInfo = task.metadata.repositories[repoKey]`
+   - `branchMatch = repoInfo ? findBranchStateByPR(repoInfo, context.prNumber) : undefined`
+   - `lastProcessedId = branchMatch?.state.last_processed_comment_id ?? repoInfo?.last_processed_comment_id ?? 0`
+   - **Dedup guard:** `if (context.commentId <= lastProcessedId) return;` — makes bookkeeping load-bearing against webhook retries.
+   - Update both locations:
+     - `if (branchMatch) branchMatch.state.last_processed_comment_id = context.commentId;`
+     - `if (repoInfo) repoInfo.last_processed_comment_id = context.commentId;`
+   - `task.debouncedSave();`
+4. `await appendGitHubEvent(taskId, repoKey, formatGitHubEvent(context));` — passes the structured `{ from, destination, message }` payload.
+5. `await task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');`
+
+Explicit choice: drop the old `getPRComments` backfill loop. It existed to replay comments triage had dropped; with triage gone there is nothing to replay. Removes network I/O per comment and lets `createGitHubClient` drop out of this file.
+
+### 3. Strip GitHub code — [triage.ts](src/system/triage.ts)
+
+Delete the GitHub block ([L164-L240](src/system/triage.ts#L164-L240)):
+
+- `GitHubComment` interface
+- `GitHubCommentTriageResult` interface
+- `GitHubCommentTriageSchema`
+- `triageGitHubComment` function
+- The `// GitHub PR Comment Triage` header comment block
+
+Keep everything above L164 (Slack schema, `runTriage`, `buildTriageInput`, `triageSlackMessage`). Do not inline `runTriage` into Slack — out of scope.
+
+### 4. Stale doc comment — [prompts.ts](src/agents/prompts.ts)
+
+At [L4-L7](src/agents/prompts.ts#L4-L7), remove the `processGitHubTriage` reference. Replace `"event-handler (handleSlackEvent/processGitHubTriage)"` with `"event-handler (handleSlackEvent, GitHub webhook dispatch)"`.
+
+### 5. Triage prompt — [prompts/triage-agent.md](prompts/triage-agent.md)
+
+At [L3](prompts/triage-agent.md#L3), drop the "or GitHub PR comments" phrase. Rest of the file is Slack-only rules; safe because after step 3 this prompt is only loaded for Slack triage.
+
+## Non-goals
+
+- Slack triage: untouched (though currently commented out at [src/connectors/slack/events.ts:299-330](src/connectors/slack/events.ts#L299-L330), it stays intact per user directive).
+- Unknown `pull_request_review` states ([webhooks.ts:250](src/connectors/github/webhooks.ts#L250)) still drop to noop — separate fix.
+- `docs/architecture/github-integration.md`, `orchestration.md`, `agents.md` — will update in a separate follow-up commit.
+- Historical plans under `docs/plans/` — not back-patched by convention.
+
+## Reuse / existing utilities
+
+- `findBranchStateByPR` ([src/tasks/persistence.ts](src/tasks/persistence.ts)) — already used by the old bookkeeping path.
+- `appendGitHubEvent` ([src/tasks/persistence.ts:268](src/tasks/persistence.ts#L268)) — signature changes to accept `{ from, destination, message }`.
+- `formatGitHubEventMessage` ([webhooks.ts:154](src/connectors/github/webhooks.ts#L154)) — renamed/rewritten to `formatGitHubEvent(context): { from, destination, message }`. All existing arms rewritten to the structured shape, plus new `issue_comment` arm.
+- `formatMessageParts` ([TaskDetail.tsx:18](src/cli/components/TaskDetail.tsx#L18)) — unchanged; now consumes GitHub events correctly without special-casing.
+- `Task.get` / `task.sendMessage` / `task.debouncedSave` — existing task API, unchanged.
+- `AGENT_PROMPTS.existingTask` ([src/agents/prompts.ts](src/agents/prompts.ts)) — existing message.
+
+## Verification
+
+1. **Typecheck:** `npm run typecheck` — must pass. The dropped `'triage'` variant on `GitHubRouteResult` provides the compiler safety net: any missed call site fails the build.
+2. **Unit tests:** `npm test` — no test files reference the removed symbols (`triageGitHubComment`, `GitHubComment`, `GitHubRouteResult`, `processGitHubTriage`, `handleGitHubCommentDirect`). `findBranchStateByPR` coverage in [src/agents/__tests__/pr-tools.test.ts:362-389](src/agents/__tests__/pr-tools.test.ts#L362-L389) unaffected.
+3. **Manual end-to-end** against a test task with an active PR, watching the CLI task detail view and `shared-knowledge.log`:
+   - Post a PR comment ("Thanks!") → CLI renders `[alice in backend/PR #N] @pm-agent Thanks!`; log has matching entry; PM agent wakes.
+   - Post a substantive PR comment → same shape.
+   - Merge the PR → CLI renders `[alice in backend/PR #N] @pm-agent merged`; log entry present (previously dropped at routing).
+   - Close without merging → `[alice in backend/PR #N] @pm-agent closed`.
+   - Approve the PR → `[alice in backend/PR #N] @pm-agent approved`.
+   - Redeliver the same `issue_comment` webhook → confirm the comment logs only once (dedup guard).
+4. **Observability:** tail the app log — confirm no more `"Running triage-agent for github-pr-*"` lines after the change.

--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -104,12 +104,22 @@ When you have Edit tools available, you also have access to:
 
 ### Tools
 
+Read:
+- `list_prs(state?, base?, sort?, limit?)` — list PRs with filters
+- `get_pr(pr_number)` — full PR details: title, description, diff, branches
+- `get_pr_status(pr_number)` — mergeability state + approval state
+- `get_pr_reviews(pr_number)` — review-level summary (approvals, change requests, review bodies)
+- `get_pr_comments(pr_number)` — top-level PR conversation comments with `comment_id`
+- `get_review_threads(pr_number)` — every review thread with its `thread_id` (GraphQL node id) plus each comment's `comment_id`, resolved/outdated flags, file, line
+
+Write:
 - `push_branch()` — push your current branch to origin (always use this, never `git push`)
 - `create_pull_request(title, body)` — open a PR from your current branch
-- `update_pr(pr_number, title?, body?)` — edit PR title and/or description
-- `add_pr_comment(pr_number, comment)` — add a general PR comment
-- `add_review_comment(pr_number, path, line, comment)` — comment on a specific line
-- `resolve_review_thread(pr_number, thread_id)` — mark thread resolved
+- `update_pr(pr_number, title?, body?, base?)` — edit PR title, description, and/or retarget base branch
+- `add_pr_comment(pr_number, comment)` — add a general PR conversation comment
+- `add_review_comment(pr_number, path, line, comment)` — start a NEW review thread on a line
+- `reply_to_review_comment(pr_number, comment_id, comment)` — reply inside an EXISTING review thread
+- `resolve_review_thread(pr_number, thread_id)` — mark thread resolved (thread_id from `get_review_threads`)
 - `request_re_review(pr_number)` — notify reviewers after fixes
 - `merge_pull_request(pr_number)` — merge the PR (checks mergeability first, returns status if not ready)
 - `close_pull_request(pr_number)` — close PR without merging
@@ -124,11 +134,19 @@ When you have Edit tools available, you also have access to:
 
 ### Handling Reviews
 
-1. `get_pr_reviews(pr_number)` to read feedback
+1. `get_pr_reviews(pr_number)` for review-level verdicts (approvals, change requests); `get_review_threads(pr_number)` for inline comments with their `thread_id` and `comment_id`
 2. Make fixes, commit, `push_branch()`
-3. `resolve_review_thread` for each addressed thread
+3. For each thread you addressed: `reply_to_review_comment(pr_number, comment_id, "<what changed>")` then `resolve_review_thread(pr_number, thread_id)`
 4. `request_re_review(pr_number)`
-5. `add_pr_comment` explaining what changed
+5. `add_pr_comment` with a high-level summary if helpful
+
+### Replying to comments
+
+The knowledge log surfaces `[comment_id=N]` for review comments and issue comments. Use that id directly:
+- Review comment (inline on code) → `reply_to_review_comment(pr_number, comment_id, "...")`
+- Top-level PR comment → `add_pr_comment(pr_number, "@user ...")` (GitHub has no threaded replies on conversation comments)
+
+If you don't have the id from the log (e.g. working on an arbitrary PR), call `get_review_threads` or `get_pr_comments` first.
 
 ### Handling Conflicts (after PR is open)
 

--- a/prompts/triage-agent.md
+++ b/prompts/triage-agent.md
@@ -1,6 +1,6 @@
 You are the Triage Agent, a lightweight classifier for a multi-agent engineering system.
 
-Your job is to classify incoming events (Slack messages or GitHub PR comments) and determine the appropriate action.
+Your job is to classify incoming Slack messages and determine the appropriate action.
 
 ## Actions
 

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -63,9 +63,12 @@ const mockGitHubClient = {
   closePullRequest: vi.fn(),
   createPullRequest: vi.fn(),
   getPRReviews: vi.fn(),
+  getPRComments: vi.fn(),
+  getReviewThreads: vi.fn(),
   updatePR: vi.fn(),
   addPRComment: vi.fn(),
   addReviewComment: vi.fn(),
+  replyToReviewComment: vi.fn(),
   resolveReviewThread: vi.fn(),
   requestReReview: vi.fn(),
 };
@@ -279,8 +282,9 @@ describe('PM agent tools', () => {
 
     const prToolNames = [
       'push_branch', 'create_pull_request', 'get_pr_status', 'get_pr_reviews',
-      'update_pr', 'add_pr_comment', 'add_review_comment', 'resolve_review_thread',
-      'request_re_review', 'merge_pull_request', 'close_pull_request',
+      'get_pr_comments', 'get_review_threads',
+      'update_pr', 'add_pr_comment', 'add_review_comment', 'reply_to_review_comment',
+      'resolve_review_thread', 'request_re_review', 'merge_pull_request', 'close_pull_request',
     ];
 
     for (const prTool of prToolNames) {

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -109,6 +109,9 @@ const SPAWN_PM_TOOLS = [
   'mcp__pm-agent-tools__request_edit_mode',
   'mcp__pm-agent-tools__get_agents_status',
   'mcp__pm-agent-tools__mute_thread',
+  'mcp__pm-agent-tools__parse_datetime',
+  'mcp__pm-agent-tools__set_reminder',
+  'mcp__pm-agent-tools__cancel_reminder',
 ];
 
 const SPAWN_REPO_TOOLS = [
@@ -122,12 +125,15 @@ const SPAWN_REPO_TOOLS = [
   'mcp__repo-tools__get_pr',
   'mcp__repo-tools__get_pr_status',
   'mcp__repo-tools__get_pr_reviews',
+  'mcp__repo-tools__get_pr_comments',
+  'mcp__repo-tools__get_review_threads',
   // PR write
   'mcp__repo-tools__push_branch',
   'mcp__repo-tools__create_pull_request',
   'mcp__repo-tools__update_pr',
   'mcp__repo-tools__add_pr_comment',
   'mcp__repo-tools__add_review_comment',
+  'mcp__repo-tools__reply_to_review_comment',
   'mcp__repo-tools__resolve_review_thread',
   'mcp__repo-tools__request_re_review',
   'mcp__repo-tools__merge_pull_request',

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -3,7 +3,7 @@
  *
  * Shared prompt constants for spawn/recovery scenarios.
  * Used by task-runtime (sendMessage), task-recovery (triggerRecovery),
- * and event-handler (handleSlackEvent/processGitHubTriage).
+ * and event-handler (handleSlackEvent, GitHub webhook dispatch).
  */
 
 export const AGENT_PROMPTS = {

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -369,6 +369,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
             'mcp__repo-tools__update_pr',
             'mcp__repo-tools__add_pr_comment',
             'mcp__repo-tools__add_review_comment',
+            'mcp__repo-tools__reply_to_review_comment',
             'mcp__repo-tools__resolve_review_thread',
             'mcp__repo-tools__request_re_review',
             'mcp__repo-tools__merge_pull_request',

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -61,19 +61,37 @@ export interface PRStatus {
   approved: boolean;
 }
 
-export interface PRReviewComment {
-  path: string;
-  line: number;
-  body: string;
-  threadId: string;
-}
-
 export interface PRReview {
   id: string;
   user: string;
   state: 'approved' | 'changes_requested' | 'commented';
   body: string;
-  comments: PRReviewComment[];
+  submittedAt: string;
+}
+
+export interface ReviewThreadComment {
+  commentId: number;
+  author: string;
+  body: string;
+  createdAt: string;
+  url: string;
+}
+
+export interface ReviewThread {
+  threadId: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path: string;
+  line: number | null;
+  comments: ReviewThreadComment[];
+}
+
+export interface PRComment {
+  id: number;
+  author: string;
+  body: string;
+  createdAt: string;
+  url: string;
 }
 
 // ---- Tool creation helpers ----
@@ -279,18 +297,26 @@ function createReportCompletionTool(agent: Agent, task: Task) {
     },
     async (args) => {
       const agentName = agent.def.id as AgentName;
+      // Idempotency: if the task is already completing/completed, skip side-effects.
+      // Prevents duplicate Slack posts when the agent retries after a stream-closed error
+      // (the previous complete() tore down the agent mid-response, so the retry is spurious).
+      if (!task.isActive) {
+        return ok('Task already completed.');
+      }
       if (args.message) {
         await task.postToUser(args.message, agentName);
       }
       logger.agentAction(agentName, 'Reporting completion', '');
       task.touch();
-      await task.complete();
-      return {
-        content: [{
-          type: 'text' as const,
-          text: args.message ? 'Posted message to Slack and stopped task.' : 'Stopped task.',
-        }],
-      };
+      // Run complete() on next tick so this tool response streams back to the agent
+      // before the runtime tears it down. Without this, the response is lost and the
+      // agent's SDK reports "stream closed", causing a retry loop.
+      setImmediate(() => {
+        task.complete().catch((err) =>
+          logger.error('report_completion', 'Error completing task', err)
+        );
+      });
+      return ok(args.message ? 'Posted message to Slack and stopped task.' : 'Stopped task.');
     },
   );
 }
@@ -454,23 +480,70 @@ function createGetPRReviewsTool(agent: Agent, task: Task) {
   const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'get_pr_reviews',
-    'Get all reviews and comments on a pull request.',
+    'Get review-level summary for a PR (approvals, change requests, review bodies). For line-level comments, use get_review_threads.',
     { pr_number: z.number().describe('The PR number') },
     async (args) => {
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
       const reviews = await client.getPRReviews(githubRepo, args.pr_number);
       if (reviews.length === 0) {
-        return { content: [{ type: 'text' as const, text: `No reviews found for PR #${args.pr_number}` }] };
+        return ok(`No reviews found for PR #${args.pr_number}`);
       }
-      const reviewText = reviews.map((r) => {
-        let text = `- ${r.user} (${r.state}): ${r.body || '(no comment)'}`;
-        if (r.comments.length > 0) {
-          text += '\n  Comments:\n' + r.comments.map((c) => `    - ${c.path}:${c.line}: ${c.body}`).join('\n');
-        }
-        return text;
-      }).join('\n');
-      return { content: [{ type: 'text' as const, text: `Reviews for PR #${args.pr_number}:\n${reviewText}` }] };
+      const lines = reviews.map((r) =>
+        `- ${r.user} [${r.state}] @ ${r.submittedAt}: ${r.body || '(no body)'}`
+      );
+      return ok(`Reviews for PR #${args.pr_number}:\n${lines.join('\n')}`);
+    },
+  );
+}
+
+function createGetPRCommentsTool(agent: Agent, task: Task) {
+  const githubRepo = agent.def.repo!.githubRepo;
+  return tool(
+    'get_pr_comments',
+    'Get top-level PR conversation comments (the "Conversation" tab). Does not include line-level review comments — use get_review_threads for those.',
+    { pr_number: z.number().describe('The PR number') },
+    async (args) => {
+      const client = getGitHubClient();
+      if (!client) throw new Error('GitHub client not configured');
+      const comments = await client.getPRComments(githubRepo, args.pr_number);
+      if (comments.length === 0) {
+        return ok(`No conversation comments on PR #${args.pr_number}`);
+      }
+      const lines = comments.map((c) =>
+        `- [comment_id=${c.id}] ${c.author} @ ${c.createdAt}: ${c.body}`
+      );
+      return ok(`Comments on PR #${args.pr_number}:\n${lines.join('\n')}`);
+    },
+  );
+}
+
+function createGetReviewThreadsTool(agent: Agent, task: Task) {
+  const githubRepo = agent.def.repo!.githubRepo;
+  return tool(
+    'get_review_threads',
+    'Get every review thread on a PR with its thread_id (for resolve_review_thread) and each comment\'s comment_id (for reply_to_review_comment).',
+    { pr_number: z.number().describe('The PR number') },
+    async (args) => {
+      const client = getGitHubClient();
+      if (!client) throw new Error('GitHub client not configured');
+      const threads = await client.getReviewThreads(githubRepo, args.pr_number);
+      if (threads.length === 0) {
+        return ok(`No review threads on PR #${args.pr_number}`);
+      }
+      const chunks = threads.map((t) => {
+        const flags = [
+          t.isResolved ? 'RESOLVED' : 'UNRESOLVED',
+          t.isOutdated ? 'OUTDATED' : null,
+        ].filter(Boolean).join(', ');
+        const location = t.line !== null ? `${t.path}:${t.line}` : `${t.path} (outdated)`;
+        const header = `Thread ${t.threadId} — ${location} [${flags}]`;
+        const lines = t.comments.map((c) =>
+          `  [comment_id=${c.commentId}] ${c.author} @ ${c.createdAt}: ${c.body}`
+        );
+        return [header, ...lines].join('\n');
+      });
+      return ok(`Review threads on PR #${args.pr_number}:\n${chunks.join('\n\n')}`);
     },
   );
 }
@@ -536,16 +609,21 @@ function createUpdatePRTool(agent: Agent, task: Task) {
   const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'update_pr',
-    'Update the title and/or description of a pull request. Both fields are optional — include only what needs to change.',
+    'Update the title, description, and/or base branch of a pull request. All fields are optional — include only what needs to change.',
     {
       pr_number: z.number().describe('The PR number'),
       title: z.string().optional().describe('New PR title'),
       body: z.string().optional().describe('New PR description body'),
+      base: z.string().optional().describe('New base branch (retarget the PR, e.g. "main" → "release-1.2")'),
     },
     async (args) => {
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      await client.updatePR(githubRepo, args.pr_number, { title: args.title, body: args.body });
+      await client.updatePR(githubRepo, args.pr_number, {
+        title: args.title,
+        body: args.body,
+        base: args.base,
+      });
       return { content: [{ type: 'text' as const, text: `Updated PR #${args.pr_number}` }] };
     },
   );
@@ -573,7 +651,7 @@ function createAddReviewCommentTool(agent: Agent, task: Task) {
   const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'add_review_comment',
-    'Add a comment on a specific line of code in a PR.',
+    'Start a NEW review thread on a specific line of code. To reply inside an existing thread, use reply_to_review_comment instead.',
     {
       pr_number: z.number().describe('The PR number'),
       path: z.string().describe('File path relative to repo root'),
@@ -584,7 +662,26 @@ function createAddReviewCommentTool(agent: Agent, task: Task) {
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
       await client.addReviewComment(githubRepo, args.pr_number, args.path, args.line, args.comment);
-      return { content: [{ type: 'text' as const, text: `Added review comment to ${args.path}:${args.line} on PR #${args.pr_number}` }] };
+      return ok(`Added review comment to ${args.path}:${args.line} on PR #${args.pr_number}`);
+    },
+  );
+}
+
+function createReplyToReviewCommentTool(agent: Agent, task: Task) {
+  const githubRepo = agent.def.repo!.githubRepo;
+  return tool(
+    'reply_to_review_comment',
+    'Reply inside an existing review thread. Requires the comment_id of any comment in the target thread (from the knowledge log or get_review_threads).',
+    {
+      pr_number: z.number().describe('The PR number'),
+      comment_id: z.number().describe('REST comment id of any comment in the target thread'),
+      comment: z.string().describe('The reply text'),
+    },
+    async (args) => {
+      const client = getGitHubClient();
+      if (!client) throw new Error('GitHub client not configured');
+      await client.replyToReviewComment(githubRepo, args.pr_number, args.comment_id, args.comment);
+      return ok(`Replied to review comment ${args.comment_id} on PR #${args.pr_number}`);
     },
   );
 }
@@ -593,16 +690,16 @@ function createResolveReviewThreadTool(agent: Agent, task: Task) {
   const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'resolve_review_thread',
-    'Mark a review comment thread as resolved.',
+    'Mark a review thread as resolved. thread_id must be a GraphQL node id (e.g. PRRT_...) obtained from get_review_threads.',
     {
       pr_number: z.number().describe('The PR number'),
-      thread_id: z.string().describe('The thread ID to resolve'),
+      thread_id: z.string().describe('GraphQL thread node id from get_review_threads (e.g. PRRT_...)'),
     },
     async (args) => {
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
       await client.resolveReviewThread(githubRepo, args.pr_number, args.thread_id);
-      return { content: [{ type: 'text' as const, text: `Resolved review thread ${args.thread_id} on PR #${args.pr_number}` }] };
+      return ok(`Resolved review thread ${args.thread_id} on PR #${args.pr_number}`);
     },
   );
 }
@@ -915,12 +1012,15 @@ export function createRepoToolsMcpServer(agent: Agent, task: Task) {
       createGetPRTool(agent, task),
       createGetPRStatusTool(agent, task),
       createGetPRReviewsTool(agent, task),
+      createGetPRCommentsTool(agent, task),
+      createGetReviewThreadsTool(agent, task),
       // PR write
       createPushBranchTool(agent, task),
       createPullRequestTool(agent, task),
       createUpdatePRTool(agent, task),
       createAddPRCommentTool(agent, task),
       createAddReviewCommentTool(agent, task),
+      createReplyToReviewCommentTool(agent, task),
       createResolveReviewThreadTool(agent, task),
       createRequestReReviewTool(agent, task),
       createMergePRTool(agent, task),

--- a/src/connectors/github/client.ts
+++ b/src/connectors/github/client.ts
@@ -10,7 +10,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { App } from '@octokit/app';
 import { Octokit } from '@octokit/core';
-import type { PRStatus, PRReview, PRReviewComment, MergeableState } from '../../agents/tools.js';
+import type { PRStatus, PRReview, ReviewThread, PRComment, MergeableState } from '../../agents/tools.js';
 import { logger } from '../../system/logger.js';
 
 const execAsync = promisify(exec);
@@ -261,58 +261,102 @@ export class GitHubClient {
   }
 
   /**
-   * Get all reviews and comments on a PR
+   * Get review-level summary for a PR (approvals, change requests, review bodies).
+   * Line-level comments are returned by `getReviewThreads` instead.
    */
   async getPRReviews(githubRepo: string, prNumber: number): Promise<PRReview[]> {
     const octokit = await this.getOctokit();
     const { owner, repo } = this.parseRepo(githubRepo);
 
-    // Get reviews
     const reviewsResponse = await octokit.request(
       'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
-      {
-        owner,
-        repo,
-        pull_number: prNumber,
-      }
+      { owner, repo, pull_number: prNumber }
     );
 
-    // Get review comments
-    const commentsResponse = await octokit.request(
-      'GET /repos/{owner}/{repo}/pulls/{pull_number}/comments',
-      {
-        owner,
-        repo,
-        pull_number: prNumber,
-      }
-    );
-
-    // Group comments by review
-    const commentsByReview = new Map<number, PRReviewComment[]>();
-    for (const comment of commentsResponse.data) {
-      const reviewId = comment.pull_request_review_id;
-      if (reviewId) {
-        const existing = commentsByReview.get(reviewId) || [];
-        existing.push({
-          path: comment.path,
-          line: comment.line || comment.original_line || 0,
-          body: comment.body,
-          threadId: String(comment.id),
-        });
-        commentsByReview.set(reviewId, existing);
-      }
-    }
-
-    // Build review objects
-    const reviews: PRReview[] = reviewsResponse.data.map((review) => ({
+    return reviewsResponse.data.map((review) => ({
       id: String(review.id),
       user: review.user?.login || 'unknown',
       state: this.mapReviewState(review.state),
       body: review.body || '',
-      comments: commentsByReview.get(review.id) || [],
+      submittedAt: review.submitted_at || '',
     }));
+  }
 
-    return reviews;
+  /**
+   * Get all review threads on a PR via GraphQL.
+   * Returns thread node IDs (for resolveReviewThread) plus each comment's REST id
+   * (for replyToReviewComment via in_reply_to).
+   */
+  async getReviewThreads(githubRepo: string, prNumber: number): Promise<ReviewThread[]> {
+    const octokit = await this.getOctokit();
+    const { owner, repo } = this.parseRepo(githubRepo);
+
+    const query = `
+      query($owner: String!, $repo: String!, $pr: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $pr) {
+            reviewThreads(first: 100) {
+              nodes {
+                id
+                isResolved
+                isOutdated
+                path
+                line
+                comments(first: 100) {
+                  nodes {
+                    databaseId
+                    author { login }
+                    body
+                    createdAt
+                    url
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await octokit.graphql<{
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: Array<{
+              id: string;
+              isResolved: boolean;
+              isOutdated: boolean;
+              path: string;
+              line: number | null;
+              comments: {
+                nodes: Array<{
+                  databaseId: number;
+                  author: { login: string } | null;
+                  body: string;
+                  createdAt: string;
+                  url: string;
+                }>;
+              };
+            }>;
+          };
+        };
+      };
+    }>(query, { owner, repo, pr: prNumber });
+
+    return result.repository.pullRequest.reviewThreads.nodes.map((thread) => ({
+      threadId: thread.id,
+      isResolved: thread.isResolved,
+      isOutdated: thread.isOutdated,
+      path: thread.path,
+      line: thread.line,
+      comments: thread.comments.nodes.map((c) => ({
+        commentId: c.databaseId,
+        author: c.author?.login || 'unknown',
+        body: c.body,
+        createdAt: c.createdAt,
+        url: c.url,
+      })),
+    }));
   }
 
   private mapReviewState(state: string): 'approved' | 'changes_requested' | 'commented' {
@@ -327,14 +371,19 @@ export class GitHubClient {
   }
 
   /**
-   * Update PR description
+   * Update PR title, body, and/or base branch.
    */
-  async updatePR(githubRepo: string, prNumber: number, fields: { title?: string; body?: string }): Promise<void> {
+  async updatePR(
+    githubRepo: string,
+    prNumber: number,
+    fields: { title?: string; body?: string; base?: string }
+  ): Promise<void> {
     const octokit = await this.getOctokit();
     const { owner, repo } = this.parseRepo(githubRepo);
     const patch: Record<string, string> = {};
     if (fields.title !== undefined) patch.title = fields.title;
     if (fields.body !== undefined) patch.body = fields.body;
+    if (fields.base !== undefined) patch.base = fields.base;
 
     await octokit.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
       owner,
@@ -397,7 +446,8 @@ export class GitHubClient {
   }
 
   /**
-   * Resolve a review thread (requires GraphQL)
+   * Resolve a review thread via GraphQL. `threadId` must be the GraphQL node id
+   * (e.g. `PRRT_...`) obtained from `getReviewThreads`.
    */
   async resolveReviewThread(
     githubRepo: string,
@@ -406,23 +456,37 @@ export class GitHubClient {
   ): Promise<void> {
     const octokit = await this.getOctokit();
 
-    // GraphQL mutation to resolve the thread
-    // The threadId here is actually the comment ID, we need to find the thread
-    // For now, we'll use the REST API to minimize complexity
-    // In production, you'd use GraphQL with the actual thread node ID
-
-    logger.system(
-      `GitHub: Resolving review thread ${threadId} on PR #${prNumber} (requires GraphQL in production)`
+    await octokit.graphql(
+      `mutation($threadId: ID!) {
+        resolveReviewThread(input: { threadId: $threadId }) {
+          thread { id isResolved }
+        }
+      }`,
+      { threadId }
     );
 
-    // Placeholder - in production, use:
-    // await octokit.graphql(`
-    //   mutation {
-    //     resolveReviewThread(input: {threadId: "${threadId}"}) {
-    //       thread { isResolved }
-    //     }
-    //   }
-    // `);
+    logger.system(`GitHub: Resolved review thread ${threadId} on PR #${prNumber}`);
+  }
+
+  /**
+   * Reply to an existing review comment inside its thread.
+   * `commentId` is the REST numeric id of any comment in the thread.
+   */
+  async replyToReviewComment(
+    githubRepo: string,
+    prNumber: number,
+    commentId: number,
+    comment: string
+  ): Promise<void> {
+    const octokit = await this.getOctokit();
+    const { owner, repo } = this.parseRepo(githubRepo);
+
+    await octokit.request(
+      'POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies',
+      { owner, repo, pull_number: prNumber, comment_id: commentId, body: comment }
+    );
+
+    logger.system(`GitHub: Replied to review comment ${commentId} on PR #${prNumber}`);
   }
 
   /**
@@ -463,28 +527,24 @@ export class GitHubClient {
   }
 
   /**
-   * Get PR comments (issue comments on a PR)
-   * Returns comments sorted by creation time (oldest first)
+   * Get top-level PR conversation comments (issue comments on a PR).
+   * Returns comments sorted by creation time (oldest first).
    */
-  async getPRComments(
-    githubRepo: string,
-    prNumber: number
-  ): Promise<Array<{ id: number; user: string; body: string; createdAt: string }>> {
+  async getPRComments(githubRepo: string, prNumber: number): Promise<PRComment[]> {
     const octokit = await this.getOctokit();
     const { owner, repo } = this.parseRepo(githubRepo);
 
-    const response = await octokit.request('GET /repos/{owner}/{repo}/issues/{issue_number}/comments', {
-      owner,
-      repo,
-      issue_number: prNumber,
-      per_page: 100,
-    });
+    const response = await octokit.request(
+      'GET /repos/{owner}/{repo}/issues/{issue_number}/comments',
+      { owner, repo, issue_number: prNumber, per_page: 100 }
+    );
 
     return response.data.map((comment) => ({
       id: comment.id,
-      user: comment.user?.login || 'unknown',
+      author: comment.user?.login || 'unknown',
       body: comment.body || '',
       createdAt: comment.created_at,
+      url: comment.html_url,
     }));
   }
 

--- a/src/connectors/github/events.ts
+++ b/src/connectors/github/events.ts
@@ -140,6 +140,6 @@ async function handleExistingTaskDirect(
     task.debouncedSave();
   }
 
-  await appendGitHubEvent(taskId, repoKey, formatGitHubEvent(context));
+  await appendGitHubEvent(taskId, context.githubRepo, formatGitHubEvent(context));
   await task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
 }

--- a/src/connectors/github/events.ts
+++ b/src/connectors/github/events.ts
@@ -1,8 +1,8 @@
 /**
  * GitHub Events — Webhook HTTP handler and event processing
  *
- * Handles GitHub webhook requests: signature verification, routing,
- * triage for issue comments, and direct event handling.
+ * Handles GitHub webhook requests: signature verification, routing, and
+ * direct dispatch to the existing-task handler or merge check.
  */
 
 import { createRequire } from 'module';
@@ -14,10 +14,9 @@ import {
   routeGitHubEvent,
   handleMergeCheckDirect,
   formatGitHubContext,
-  formatGitHubEventMessage,
+  formatGitHubEvent,
   verifyWebhookSignature,
 } from './webhooks.js';
-import { createGitHubClient } from './client.js';
 import { Task } from '../../tasks/task.js';
 import { appendGitHubEvent } from '../../tasks/persistence.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
@@ -25,7 +24,6 @@ import { getAgentDefByGithubRepo } from '../../agents/registry.js';
 import { findBranchStateByPR } from './branch-state.js';
 import { logger } from '../../system/logger.js';
 import { getIsShuttingDown } from '../../system/shutdown.js';
-import { triageGitHubComment, type GitHubComment } from '../../system/triage.js';
 
 /**
  * Mount the GitHub webhook endpoint on an Express router
@@ -95,11 +93,7 @@ async function handleGitHubWebhook(
     return;
   }
 
-  if (route.action === 'triage') {
-    processGitHubTriage(route.taskId, payload).catch((err) =>
-      logger.error('Server', 'Error processing GitHub triage', err)
-    );
-  } else if (route.action === 'direct') {
+  if (route.action === 'direct') {
     if (route.handler === 'merge_check') {
       handleMergeCheckDirect(route.taskId);
     } else if (route.handler === 'existing_task') {
@@ -109,122 +103,43 @@ async function handleGitHubWebhook(
 }
 
 /**
- * Handle existing task event directly (for deterministic events)
- * Logs the event and reactivates the task
+ * Handle an existing-task event: log to shared knowledge, update PR bookkeeping
+ * (for issue_comment), and wake the PM agent.
+ *
+ * The issue_comment branch preserves `last_processed_comment_id` on both
+ * branch_states and legacy repoInfo so future features (e.g. backfill from
+ * external PR tracking) can resume mid-conversation. The same field doubles
+ * as a dedup guard against webhook redelivery.
  */
 async function handleExistingTaskDirect(
   taskId: string,
   context: ReturnType<typeof formatGitHubContext>
 ): Promise<void> {
-  const eventMessage = formatGitHubEventMessage(context);
   const repoDef = getAgentDefByGithubRepo(context.githubRepo);
   const repoKey = repoDef?.repo?.repoKey || 'unknown';
-
   const task = await Task.get(taskId);
-  await appendGitHubEvent(taskId, repoKey, eventMessage);
-  await task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
-}
 
-/**
- * Process GitHub triage inline (replaces triage queue for GitHub issue_comment)
- */
-async function processGitHubTriage(taskId: string, payload: Record<string, unknown>): Promise<void> {
-  const issue = payload.issue as Record<string, unknown> | undefined;
-  const comment = payload.comment as Record<string, unknown> | undefined;
-  const repository = payload.repository as Record<string, unknown> | undefined;
-
-  if (!issue?.pull_request || !comment || !repository) {
-    logger.warn('event-handler', 'GitHub payload missing required fields');
-    return;
-  }
-
-  const prNumber = issue.number as number;
-  const commentId = comment.id as number;
-  const githubRepo = repository.full_name as string;
-
-  const user = (comment.user as Record<string, unknown>)?.login as string || 'unknown';
-  const body = comment.body as string || '';
-  logger.system(`Processing GitHub PR #${prNumber} comment by ${user}: "${body}"`);
-
-  const githubClient = createGitHubClient();
-  if (!githubClient) {
-    logger.warn('event-handler', 'GitHub client not configured');
-    await handleGitHubCommentDirect(taskId, githubRepo, prNumber, comment);
-    return;
-  }
-
-  const repoDef = getAgentDefByGithubRepo(githubRepo);
-  if (!repoDef) {
-    logger.warn('event-handler', `Unknown repo ${githubRepo}`);
-    await handleGitHubCommentDirect(taskId, githubRepo, prNumber, comment);
-    return;
-  }
-
-  let commentHistory: GitHubComment[];
-  try {
-    commentHistory = await githubClient.getPRComments(githubRepo, prNumber);
-  } catch (error) {
-    logger.error('event-handler', 'Failed to fetch PR comments', error);
-    await handleGitHubCommentDirect(taskId, githubRepo, prNumber, comment);
-    return;
-  }
-
-  const currentComment = commentHistory.find((c) => c.id === commentId);
-  if (!currentComment) {
-    logger.warn('event-handler', `Comment ${commentId} not found in PR #${prNumber} history`);
-    await handleGitHubCommentDirect(taskId, githubRepo, prNumber, comment);
-    return;
-  }
-
-  const triageResult = await triageGitHubComment(currentComment, commentHistory, prNumber, githubRepo);
-
-  if (triageResult.action === 'existing_task') {
-    const task = await Task.get(taskId);
-    const repoKey = repoDef.repo!.repoKey;
+  if (context.eventType === 'issue_comment' && context.prNumber && context.commentId) {
     const repoInfo = task.metadata.repositories[repoKey];
-
-    // Look up last_processed_comment_id from branch_states first, then legacy
-    const branchMatch = repoInfo ? findBranchStateByPR(repoInfo, prNumber) : undefined;
+    const branchMatch = repoInfo ? findBranchStateByPR(repoInfo, context.prNumber) : undefined;
     const lastProcessedId = branchMatch?.state.last_processed_comment_id
-      || repoInfo?.last_processed_comment_id || 0;
+      ?? repoInfo?.last_processed_comment_id
+      ?? 0;
 
-    const newComments = commentHistory.filter((c) => c.id > lastProcessedId);
-
-    for (const c of newComments) {
-      const msg = `PR #${prNumber}: ${c.user} commented: ${c.body}`;
-      await appendGitHubEvent(taskId, repoKey, msg);
+    if (context.commentId <= lastProcessedId) {
+      logger.system(`GitHub: Skipping already-processed comment ${context.commentId} on PR #${context.prNumber}`);
+      return;
     }
 
     if (branchMatch) {
-      branchMatch.state.last_processed_comment_id = commentId;
+      branchMatch.state.last_processed_comment_id = context.commentId;
     }
     if (repoInfo) {
-      repoInfo.last_processed_comment_id = commentId;
+      repoInfo.last_processed_comment_id = context.commentId;
     }
-
     task.debouncedSave();
-    await task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
-  } else {
-    logger.system(`GitHub: Ignoring conversational comment on PR #${prNumber}`);
   }
-}
 
-/**
- * Fallback: Handle GitHub comment directly without triage
- */
-async function handleGitHubCommentDirect(
-  taskId: string,
-  githubRepo: string,
-  prNumber: number,
-  comment: Record<string, unknown>
-): Promise<void> {
-  const repoDef = getAgentDefByGithubRepo(githubRepo);
-  const repoKey = repoDef?.repo?.repoKey || 'unknown';
-
-  const user = (comment.user as Record<string, unknown>)?.login as string || 'unknown';
-  const body = comment.body as string || '';
-
-  const task = await Task.get(taskId);
-  await appendGitHubEvent(taskId, repoKey, `PR #${prNumber}: ${user} commented: ${body}`);
+  await appendGitHubEvent(taskId, repoKey, formatGitHubEvent(context));
   await task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
 }

--- a/src/connectors/github/webhooks.ts
+++ b/src/connectors/github/webhooks.ts
@@ -83,6 +83,7 @@ export function formatGitHubContext(
     const comment = payload.comment as Record<string, unknown> | undefined;
     context.prNumber = pullRequest?.number as number | undefined;
     context.body = comment?.body as string | undefined;
+    context.commentId = comment?.id as number | undefined;
     context.branch = (pullRequest?.head as Record<string, unknown>)?.ref as string | undefined;
   } else if (eventType === 'pull_request') {
     context.prNumber = pullRequest?.number as number | undefined;
@@ -149,39 +150,55 @@ export function extractTaskIdFromBranch(branch: string | undefined): string | un
 // ============================================================================
 
 /**
- * Format a GitHub event for the knowledge log
+ * Structured GitHub event for the knowledge log and CLI rendering.
+ * Mirrors the shape Slack and CLI emit so the CLI renders GitHub events
+ * uniformly: `[from in destination] @pm-agent message`.
  */
-export function formatGitHubEventMessage(context: GitHubEventContext): string {
-  const { eventType, action, user, prNumber, body, state } = context;
+export interface FormattedGitHubEvent {
+  from: string;
+  destination: string;
+  message: string;
+}
+
+/**
+ * Format a GitHub event into the structured Slack/CLI-compatible shape.
+ */
+export function formatGitHubEvent(context: GitHubEventContext): FormattedGitHubEvent {
+  const { eventType, action, user, prNumber, body, state, commentId } = context;
+  const prDest = prNumber ? `PR #${prNumber}` : 'PR';
+  const branchDest = `branch:${context.branch || 'unknown'}`;
+  const cidTag = commentId ? ` [comment_id=${commentId}]` : '';
 
   switch (eventType) {
     case 'pull_request_review':
       if (state === 'approved') {
-        return `PR #${prNumber} approved by ${user}`;
+        return { from: user, destination: prDest, message: 'approved' };
       } else if (state === 'changes_requested') {
-        return `PR #${prNumber}: ${user} requested changes${body ? `: ${body}` : ''}`;
+        return { from: user, destination: prDest, message: body ? `requested changes: ${body}` : 'requested changes' };
       } else {
-        return `PR #${prNumber}: ${user} commented${body ? `: ${body}` : ''}`;
+        return { from: user, destination: prDest, message: body ? `commented: ${body}` : 'commented' };
       }
 
     case 'pull_request_review_comment':
-      return `PR #${prNumber}: ${user} commented on code${body ? `: ${body}` : ''}`;
+      return { from: user, destination: prDest, message: body ? `commented on code${cidTag}: ${body}` : `commented on code${cidTag}` };
+
+    case 'issue_comment':
+      return { from: user, destination: prDest, message: body ? `${body}${cidTag}` : `(empty)${cidTag}` };
 
     case 'pull_request':
       if (action === 'closed') {
-        return `PR #${prNumber} ${state === 'merged' ? 'merged' : 'closed'} by ${user}`;
+        return { from: user, destination: prDest, message: state === 'merged' ? 'merged' : 'closed' };
       }
-      return `PR #${prNumber}: ${action} by ${user}`;
+      return { from: user, destination: prDest, message: action };
 
     case 'push':
-      return `Push to ${context.branch || 'branch'} by ${user}`;
+      return { from: user, destination: branchDest, message: 'pushed' };
 
     case 'workflow_run':
-      const conclusion = state || 'completed';
-      return `CI workflow ${conclusion} for ${context.branch || 'branch'}`;
+      return { from: 'ci', destination: branchDest, message: `workflow ${state || 'completed'}` };
 
     default:
-      return `GitHub event: ${eventType}/${action} by ${user}`;
+      return { from: user, destination: prDest, message: `${eventType}/${action}` };
   }
 }
 
@@ -228,13 +245,12 @@ export function handleMergeCheckDirect(taskId: string): void {
  */
 export type GitHubRouteResult =
   | { action: 'discard'; reason: string }
-  | { action: 'triage'; taskId: string }
   | { action: 'direct'; handler: 'merge_check' | 'existing_task'; taskId: string };
 
 /**
  * Internal route action
  */
-type InternalRouteAction = 'merge_check' | 'existing_task' | 'triage_comment' | 'noop';
+type InternalRouteAction = 'merge_check' | 'existing_task' | 'noop';
 
 /**
  * Deterministic routing based on event type
@@ -254,10 +270,10 @@ function determineRouteAction(context: GitHubEventContext): InternalRouteAction 
 
     case 'issue_comment':
       if (action !== 'created') return 'noop';
-      return 'triage_comment';
+      return 'existing_task';
 
     case 'pull_request':
-      if (action === 'closed') return 'noop';
+      if (action === 'closed') return 'existing_task';
       if (action === 'opened' || action === 'synchronize') return 'merge_check';
       return 'noop';
 
@@ -289,8 +305,8 @@ function getGitHubAppBotUsername(): string | null {
  *
  * Determines:
  * 1. If event should be discarded (not our branch, no task found, or our own bot)
- * 2. If event needs triage (issue_comment - to filter conversational noise)
- * 3. If event can be handled directly (approval, push, CI - deterministic)
+ * 2. If event routes to a merge check (approval, push, CI success)
+ * 3. If event routes to the existing-task handler (comments, reviews, CI failure, PR closed/merged)
  */
 export async function routeGitHubEvent(
   eventType: string,
@@ -328,16 +344,10 @@ export async function routeGitHubEvent(
   const routeAction = determineRouteAction(context);
 
   switch (routeAction) {
-    case 'triage_comment':
-      // issue_comment needs triage to filter conversational noise
-      return { action: 'triage', taskId };
-
     case 'existing_task':
-      // Deterministic routing to existing task handler
       return { action: 'direct', handler: 'existing_task', taskId };
 
     case 'merge_check':
-      // Deterministic routing to merge check
       return { action: 'direct', handler: 'merge_check', taskId };
 
     case 'noop':

--- a/src/system/triage.ts
+++ b/src/system/triage.ts
@@ -2,8 +2,7 @@
  * Triage Agent
  *
  * Lightweight classifier using Haiku model.
- * Slack messages: classifies intent (new_task, existing_task, cancel_task, noop)
- * GitHub PR comments: classifies actionability (existing_task, noop)
+ * Slack messages: classifies intent (new_task, existing_task, cancel_task, noop).
  */
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
@@ -161,80 +160,3 @@ export async function triageSlackMessage(
   };
 }
 
-// ============================================================================
-// GitHub PR Comment Triage
-// ============================================================================
-
-/**
- * GitHub PR comment for triage
- */
-export interface GitHubComment {
-  id: number;
-  user: string;
-  body: string;
-  createdAt: string;
-}
-
-/**
- * GitHub comment triage result - simpler than Slack (only existing_task or noop)
- */
-export interface GitHubCommentTriageResult {
-  action: "existing_task" | "noop";
-  confidence: "high" | "medium" | "low";
-  reasoning: string;
-}
-
-/**
- * GitHub comment triage schema - only existing_task or noop
- */
-const GitHubCommentTriageSchema = z.object({
-  action: z.enum(["existing_task", "noop"]),
-  confidence: z.enum(["high", "medium", "low"]),
-  reasoning: z.string(),
-});
-
-/**
- * Run the triage agent to classify a GitHub PR comment
- *
- * Determines if a PR comment requires PM attention or can be ignored.
- * - existing_task: Actionable feedback (change request, bug report, blocker, question)
- * - noop: Conversational (acknowledgment, thanks, simple confirmation)
- */
-export async function triageGitHubComment(
-  currentComment: GitHubComment,
-  commentHistory: GitHubComment[],
-  prNumber: number,
-  githubRepo: string
-): Promise<GitHubCommentTriageResult> {
-  const input = `
-GitHub PR Comment:
-- Repository: ${githubRepo}
-- PR Number: #${prNumber}
-- Comment Author: ${currentComment.user}
-
-Comment Thread History:
-${commentHistory.map((c) => `[${c.user}]: ${c.body}`).join("\n")}
-
-Current Comment:
-[${currentComment.user}]: ${currentComment.body}
-
-Classify this PR comment. Use:
-- "existing_task" if this comment requires action (change request, bug report, question needing answer, blocker, technical feedback)
-- "noop" if this comment is conversational (acknowledgment like "Done", "Thanks", "LGTM", simple confirmations, or resolved discussions)
-
-Respond with JSON only.`;
-
-  logger.system(`GitHub triage input for PR #${prNumber}:\n${input}`);
-
-  const result = await runTriage(
-    input,
-    GitHubCommentTriageSchema,
-    `github-pr-${prNumber}`
-  );
-
-  return {
-    action: result.action,
-    confidence: result.confidence,
-    reasoning: result.reasoning,
-  };
-}

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -262,22 +262,33 @@ export async function appendAgentMessage(
 }
 
 /**
- * Append a GitHub event to the knowledge log
+ * Append a GitHub event to the knowledge log.
+ *
+ * Accepts a structured payload matching the Slack/CLI shape so the CLI can
+ * render GitHub events uniformly: `[from in destination] @pm-agent message`.
+ *
  * @param repoKey - Repository identifier (e.g., 'backend', 'mobile') for multi-repo tasks
+ * @param event - Structured event with author, destination (e.g. "PR #42"), and clean message body
  */
 export async function appendGitHubEvent(
   taskId: string,
   repoKey: string,
-  message: string
+  event: { from: string; destination: string; message: string }
 ): Promise<void> {
+  const destination = `${repoKey}/${event.destination}`;
   const entry: LogEntry = {
     timestamp: new Date().toISOString(),
-    source: `github:${repoKey}`,
-    message,
+    source: `@<${event.from}> in github:${destination}`,
+    message: event.message,
   };
 
   await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
-  emitEvent('message', taskId, { from: `github:${repoKey}`, to: 'pm-agent', message });
+  emitEvent('message', taskId, {
+    from: event.from,
+    to: 'pm-agent',
+    destination: `github:${destination}`,
+    message: event.message,
+  });
 }
 
 /**

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -267,18 +267,18 @@ export async function appendAgentMessage(
  * Accepts a structured payload matching the Slack/CLI shape so the CLI can
  * render GitHub events uniformly: `[from in destination] @pm-agent message`.
  *
- * @param repoKey - Repository identifier (e.g., 'backend', 'mobile') for multi-repo tasks
+ * @param githubRepo - Full "owner/repo" identifier (e.g., 'sweatco/sweatcoin-mobile')
  * @param event - Structured event with author, destination (e.g. "PR #42"), and clean message body
  */
 export async function appendGitHubEvent(
   taskId: string,
-  repoKey: string,
+  githubRepo: string,
   event: { from: string; destination: string; message: string }
 ): Promise<void> {
-  const destination = `${repoKey}/${event.destination}`;
+  const destination = `github:${githubRepo}/${event.destination}`;
   const entry: LogEntry = {
     timestamp: new Date().toISOString(),
-    source: `@<${event.from}> in github:${destination}`,
+    source: `@<${event.from}> in ${destination}`,
     message: event.message,
   };
 
@@ -286,7 +286,7 @@ export async function appendGitHubEvent(
   emitEvent('message', taskId, {
     from: event.from,
     to: 'pm-agent',
-    destination: `github:${destination}`,
+    destination,
     message: event.message,
   });
 }


### PR DESCRIPTION
## Summary

- Remove the Haiku-based GitHub PR comment triage that silently dropped "conversational" comments, and fix routing so merged/closed PRs actually reach the existing-task handler (v22 plan in `docs/plans/`)
- Align GitHub knowledge-log events with the Slack/CLI `{from, destination, message}` shape so the CLI renders PR events uniformly (`[alice in github:backend/PR #42] @pm-agent …`)
- Fix two real bugs in the repo-agent review flow: `resolve_review_thread` was a no-op stub, and `add_review_comment` always created a new thread instead of replying. Adds `get_review_threads` (GraphQL, exposes real thread node ids + per-comment ids), `reply_to_review_comment`, `get_pr_comments`, and PR retargeting via `update_pr base`. Webhook-delivered review/issue comments now surface `[comment_id=N]` in the knowledge log so agents can reply without a lookup round-trip
- Fix the `report_completion` retry loop: idempotency guard + deferred `task.complete()` so the tool response streams back before teardown, preventing duplicated Slack posts

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (22/22 pass)
- [ ] Manual: PR comment → appears in log + wakes PM (previously dropped as "LGTM")
- [ ] Manual: merge PR → `[alice in github:backend/PR #N] @pm-agent merged` appears
- [ ] Manual: agent replies to a review comment using `[comment_id=N]` from log → reply nests in-thread on GitHub
- [ ] Manual: agent resolves a thread via `get_review_threads` → thread actually shows resolved on GitHub
- [ ] Manual: `report_completion` triggers once → no duplicate Slack posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)