### PR TITLE
Shared-channel guardrails for Slack Connect threads

### DIFF
--- a/docs/plans/v24-shared-channel-guardrails.md
+++ b/docs/plans/v24-shared-channel-guardrails.md
@@ -1,0 +1,202 @@
+# Shared-Channel Guardrails (External-Org Filtering)
+
+## Context
+
+Archie operates in Slack channels that can be shared with external organisations (Slack Connect). Today the integration has no notion of "home org" vs "external org": every human message reaches the PM agent with full content, file attachments are downloaded to the task sandbox, external `@mentions` can create or unmute tasks, and there is no user-visible signal that a channel is externally visible. This is a prompt-injection surface (external text can steer an autonomous agent with code-edit and posting powers), a data-egress surface (Archie may post sensitive internal content on behalf of an internal user into a shared channel), and an attachment-exfil surface (files uploaded by externals get fetched into the task workspace).
+
+Intended outcome: in any shared channel, (a) messages authored by external participants are structurally visible to the agent but content-redacted; (b) forwarded/unfurled external messages are kept with a provenance label so the agent sees explicit "came from external" signal and an internal user who chose to forward is on-record; (c) internal users in the thread receive a one-time ephemeral warning the first time Archie is active in that thread, and separately a one-time ephemeral when they forward external content; (d) external messages cause Archie to bail out of the event handler entirely (no agent spawn, no task creation, no reactions); (e) the PM agent's prompt is annotated when operating in a shared channel.
+
+Guests (single/multi-channel guests on the home workspace) are treated as external under the same rules.
+
+## Design
+
+### 1. Capture home team ID at startup
+
+`auth.test()` today captures `user_id`, `bot_id`, `url` but **not** `team_id`. Extend [initSlackClient()](src/connectors/slack/client.ts#L33-L46) to also read `team_id` from the `auth.test()` response (it *is* present in the API response — just not currently read) and store it in a module-level `homeTeamId: string | null`. Export `getHomeTeamId()`. No new env var.
+
+### 2. Shared-channel detection with 1-minute TTL cache
+
+New module-level cache in [src/connectors/slack/client.ts](src/connectors/slack/client.ts):
+
+```ts
+type ChannelSharedInfo = { isShared: boolean; fetchedAt: number };
+const channelSharedCache = new Map<string, ChannelSharedInfo>();
+const CHANNEL_SHARED_TTL_MS = 60_000;
+
+export async function isChannelShared(channelId: string): Promise<boolean>;
+```
+
+Implementation calls `conversations.info({ channel })` and evaluates:
+`is_ext_shared || is_pending_ext_shared || (connected_team_ids?.length ?? 0) > 1`.
+(`is_shared` alone is true for org-wide channels in Enterprise Grid; `is_ext_shared` is the external-org signal.) 1-minute TTL per channel; respect Slack's tier-3 rate limit (50+/min).
+
+DMs (`channelId` starting with `D`) short-circuit to `false` without an API call.
+
+### 3. Classify users as external
+
+Extend [SlackUserInfo](src/connectors/slack/client.ts#L863-L872) with `teamId: string`, `isRestricted: boolean`, `isUltraRestricted: boolean`. Populate in both [getUserInfo()](src/connectors/slack/client.ts#L652-L662) (from `users.info` response: `user.team_id`, `user.is_restricted`, `user.is_ultra_restricted`) and [listWorkspaceUsers()](src/connectors/slack/client.ts#L882-L913).
+
+New helper:
+```ts
+export function isExternalUser(info: SlackUserInfo): boolean {
+  const home = getHomeTeamId();
+  if (!home) return false;  // fail-open if auth.test() didn't return team_id
+  return info.teamId !== home || info.isRestricted || info.isUltraRestricted;
+}
+```
+
+Fail-open behaviour is acceptable because the alternative (fail-closed on missing team_id) would filter *everyone* and break the bot. We log a warning at startup if `homeTeamId` is null.
+
+### 4. Redact external messages in thread ingestion
+
+Extend [SlackThreadMessage](src/types/task.ts#L23-L28) with:
+```ts
+externalAuthor?: boolean;  // true when user is external per isExternalUser()
+redacted?: boolean;        // true when text/files should be treated as filtered
+```
+
+In [fetchSlackThread()](src/connectors/slack/client.ts#L795-L837), after resolving user info, check `isChannelShared(channelId)`:
+
+- If channel is **not shared**: behaviour unchanged.
+- If channel **is shared**: for each message whose author is external, emit a message object with `externalAuthor: true, redacted: true`, `text: ''`, no `files`, and `user: { id: msg.user, username: '<external>', realName: '<external>' }`. Do not fetch their real name (avoid a `users.info` side-trip for an external user; we only need the ID).
+
+### 5. Forwarded/unfurled external messages: preserve content with provenance label
+
+Slack delivers forwarded messages and permalink-unfurls as a parent `message` (authored by the internal forwarder) with `attachments[]` where each attachment has `is_msg_unfurl: true` (permalink) or comes from a forward variant containing `author_id`, `text`, `ts`, and `channel_id` for the *original* message.
+
+When the top-level author is **internal** in a shared channel, walk `attachments[]` for entries with `is_msg_unfurl: true` or a populated `author_id`. For any attachment whose `author_id` resolves to an external user (via cached `getUserInfo` + `isExternalUser`):
+
+1. Set `msg.forwardedFromExternal = { authorId, authorTeamId }` on the outer `SlackThreadMessage`.
+2. Keep the forwarded text content.
+3. In the knowledge log (§7), prepend the message with `[forwarded from @<Uext:team T>]` so the agent sees explicit provenance. Rationale: keeping the metadata lets the agent treat forwarded-external content with appropriate skepticism rather than mistaking it for something the internal user authored themselves.
+
+This flag also drives Warning B (§10).
+
+Extend `SlackThreadMessage` accordingly:
+```ts
+forwardedFromExternal?: { authorId: string; authorTeamId: string };
+```
+
+### 6. Update `SlackChannel` metadata
+
+Extend [SlackChannel](src/types/task.ts#L47-L55):
+
+```ts
+export interface SlackChannel extends ChannelBase {
+  type: 'slack';
+  thread_id: string;
+  channel_id: string;
+  channel_name: string;
+  last_processed_ts: string;
+  url?: string;
+  muted?: boolean;
+  isShared?: boolean;                  // snapshot of last observed state
+  warnedUsers?: string[];              // user IDs warned about shared channel
+  forwardNotifiedUsers?: string[];     // user IDs notified after forwarding externally-authored content
+}
+```
+
+No migration needed (optional fields; existing tasks pick up values on next message).
+
+On each inbound message, after computing `shared = await isChannelShared(channelId)`, write `existing.isShared = shared`. No clearing of warning lists on transitions — a user who was never warned (because the channel was previously not shared) will be warned automatically by the diff logic in §10 the next time a message arrives post-transition.
+
+The stored flag is a debugging/observability snapshot; the runtime decision always uses the cached `isChannelShared()` result.
+
+### 7. Knowledge-log format
+
+In [appendSlackMessage()](src/tasks/persistence.ts#L178-L205), extend the signature to take the `SlackThreadMessage` (or an equivalent shape carrying the new flags) rather than unpacking only `userInfo/message/files`. Three format variants:
+
+- **Normal:** unchanged — `@<U123:Real Name> in slack:#C:thread` + text.
+- **External redacted:** source stays `@<U123:external> in slack:#C:thread`; message body is a short fixed placeholder indicating it was filtered (exact wording decided at implementation time and kept out of the PM prompt so the two can evolve independently). No file info.
+- **Forwarded from external:** source is the internal forwarder (unchanged); message body prefixed with `[forwarded from @<Uext:team T>]` followed by the forwarded text. Provenance is kept so the agent can treat forwarded-external content with appropriate skepticism.
+
+Rationale: the agent sees who spoke (user ID + timestamp) so it can count distinct speakers and notice conversational shape, but sees no external-authored text — except where an internal user explicitly chose to forward it, in which case provenance is preserved.
+
+### 8. Bail out of the handler on external-authored events
+
+In [handleSlackEvent()](src/connectors/slack/events.ts#L272-L364), as the very first step (before the eyes-reaction at L287), resolve the event author's external status (`getUserInfo` + `isExternalUser`). If external:
+
+- Return immediately. No `fetchSlackThread`, no `task.append`, no agent spawn, no `addReaction`, no task creation, no unmute.
+
+Rationale: redacted external messages carry no useful signal for the agent to act on, so spawning an agent turn on them is pure waste. When an *internal* user next triggers the handler, `fetchSlackThread` re-reads the full thread history and redacts externals inline at that point — so no external message is ever lost to the log; it just lands in the log lazily at the next internal event.
+
+DMs: a DM from an external-classified user hits this same bail-out (DMs aren't "shared channels" but the external classification still applies to the author), so a guest DMing Archie silently does nothing.
+
+### 9. Skip file downloads from external authors
+
+In [Task.append()](src/tasks/task.ts#L210-L246), the two `downloadMessageFiles(...)` calls must short-circuit when `msg.externalAuthor === true` (files are already stripped in §4, so this is defence-in-depth). The attachment note in the knowledge log becomes `[Attachments: <filtered>]` if `redacted`.
+
+### 10. Ephemeral warnings
+
+New helper in [src/connectors/slack/client.ts](src/connectors/slack/client.ts):
+
+```ts
+export async function postEphemeral(
+  channel: string,
+  user: string,
+  text: string,
+): Promise<void>;
+```
+
+Thin wrapper around `chat.postEphemeral({ channel, user, text, thread_ts? })`. Respect `dryRun` flag (same as `postToThread`).
+
+**Warning A — shared-channel awareness (per thread × user):**
+
+On every inbound message handled by [handleSlackEvent](src/connectors/slack/events.ts#L272), after the external-author bail-out (§8) and after confirming the channel is shared and a task exists (or is being created), compute the thread participants from the already-fetched `thread.messages`. Filter to internal-only (skip externals — they presumably know they're external — and skip the bot). Diff against `channel.warnedUsers`. For each new user in the delta, post an ephemeral (`thread_ts = channel.thread_id`) with text roughly:
+
+> ⚠️ Heads up: this thread is in a shared channel with external org(s). Archie filters messages from external participants — if you need Archie to see something an external person said, re-say it yourself. Also be aware: anything Archie posts here (including on your behalf) is visible to the external org, so mind what you ask Archie to share.
+
+Union the delta into `warnedUsers` and persist.
+
+**Warning B — forward awareness (per thread × internal forwarder):**
+
+When §5 detection flags the event as forwarded-from-external, if the forwarder's ID is not in `channel.forwardNotifiedUsers`, post an ephemeral:
+
+> ℹ️ You forwarded a message from an external user. Archie will process its contents — just making sure you're aware.
+
+Add the forwarder to `forwardNotifiedUsers`. (No "Continue" button — pre-send interception isn't possible with Slack events anyway.)
+
+Both warnings are additive: a single message can trigger both.
+
+### 11. PM prompt: shared-channel notice
+
+In [src/agents/pm.ts](src/agents/pm.ts) (or wherever per-task system-prompt assembly happens — to confirm during implementation since Phase-1 only confirmed `prompts.ts` has the generic `newTask`/`existingTask` constants), inject a short notice when *any* of the task's Slack channels has `isShared === true`:
+
+> NOTE: This task is active in a Slack channel shared with an external organisation. Messages from external participants are filtered before they reach you. Be mindful that anything you post will be visible to the external org. Do not share repository contents, credentials, internal URLs, or task history with external parties.
+
+The prompt deliberately does not quote the exact redaction placeholder so the two can evolve independently. Recompute on each turn (cheap — already iterating channels for other reasons).
+
+### 12. External user handling in DMs
+
+DMs short-circuit §2's `isChannelShared` check to `false`, but the §8 bail-out is author-based, not channel-based, so an external-classified user (incl. guests) DMing Archie triggers the same bail-out and Archie does nothing. No task created, no reply. This matches "guests = externals, same rules" — externals shouldn't be able to privately drive Archie.
+
+## Critical Files
+
+- [src/connectors/slack/client.ts](src/connectors/slack/client.ts) — `initSlackClient` (L33), `SlackUserInfo` (L863), `getUserInfo` (L652), `listWorkspaceUsers` (L882), `fetchSlackThread` (L795), `fetchThreadHistory` (L341), `postToThread` (L86); new `isChannelShared`, `isExternalUser`, `postEphemeral`, `getHomeTeamId`.
+- [src/connectors/slack/events.ts](src/connectors/slack/events.ts) — `app_mention` handler (L78), `message` handler (L101), `handleSlackEvent` (L272).
+- [src/types/task.ts](src/types/task.ts) — `SlackChannel` (L47), `SlackThreadMessage` (L23).
+- [src/tasks/persistence.ts](src/tasks/persistence.ts) — `appendSlackMessage` (L178).
+- [src/tasks/task.ts](src/tasks/task.ts) — `Task.append` (L210), `registerSlackChannel` (L413), `downloadMessageFiles` call sites.
+- [src/agents/pm.ts](src/agents/pm.ts) / [src/agents/prompts.ts](src/agents/prompts.ts) — shared-channel notice injection.
+
+## Reused Utilities
+
+- `conversations.info` call pattern already exists at [client.ts:284-286](src/connectors/slack/client.ts#L284) — extend, don't duplicate.
+- `userCache` pattern at [client.ts:882](src/connectors/slack/client.ts#L882) — mirror its TTL-cache shape for `channelSharedCache`.
+- `dryRun` guard pattern in `postToThread`/`postNewMessage` — reuse in `postEphemeral`.
+- `restoreMentions` + `slackifyMarkdown` pipeline — reuse when building ephemeral text.
+
+## Verification
+
+Manual end-to-end tests (no existing test suite covers Slack flows):
+
+1. **Home-org message, non-shared channel:** `npm run dev`, have an internal user DM / @mention Archie. Confirm unchanged behaviour: knowledge.log shows full name+text, no ephemeral sent.
+2. **External user in shared channel (no internal user yet):** set up a test shared channel; have an external user @mention Archie; confirm: (a) handler bails out — no task created, no knowledge.log entry yet, no `eyes` reaction, no agent spawn.
+3. **Internal user in shared channel after external activity:** internal user @mentions Archie in the same thread; confirm: (a) task created with `isShared: true`, (b) knowledge.log now contains the *earlier* external message as a redacted entry (because `fetchSlackThread` re-reads history and redacts on read), (c) ephemeral Warning A posted to the internal user.
+4. **Second internal user joins mid-thread:** have a different internal user reply; confirm Warning A is posted to the new user and not re-posted to the first.
+5. **Forwarding:** internal user forwards an external message into the thread using Slack's native forward; confirm: (a) knowledge.log entry has `[forwarded from @<Uext:team T>]` prefix with content preserved, (b) Warning B ephemeral goes to the forwarder, (c) second forward by same user → no second Warning B.
+6. **Channel becomes shared mid-task:** start a task in a non-shared channel, then add an external org; confirm next internal message triggers Warning A for all current thread participants (the thread had no shared history so nobody had been warned before).
+7. **Guest DM:** have a single-channel guest DM Archie; confirm handler bails out (no task created, no reply, no log entry).
+8. **Home team ID missing:** force `homeTeamId = null` by mocking `auth.test()` response; confirm fail-open (nothing filtered) and a startup warning log.
+9. **Rate limit sanity:** send 30 messages in a minute across a single shared channel; confirm only 1 `conversations.info` call was issued (the 1-min TTL held).
+10. **Type check:** `npm run typecheck` passes.

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -205,6 +205,9 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     if (metadata.reminder) {
       contextLines.push(`Reminder: ${metadata.reminder.trigger_at} — ${metadata.reminder.reason}`);
     }
+    const inSharedChannel = Object.values(metadata.channels).some(
+      (ch) => ch.type === 'slack' && ch.isShared === true,
+    );
     const context = `
 ${contextLines.join('\n')}
 
@@ -215,6 +218,9 @@ Shared folder: ${sharedPath} [READ-ONLY]
   - metadata.json — task metadata
 `;
     systemPrompt = `${systemPrompt}\n\nCurrent Task Context:\n${context}`;
+    if (inSharedChannel) {
+      systemPrompt = `${systemPrompt}\n\nNOTE: This task is active in a Slack channel shared with an external organisation. Messages from external participants are filtered before they reach you. Be mindful that anything you post will be visible to the external org. Do not share repository contents, credentials, internal URLs, or task history with external parties.`;
+    }
 
     // Append PM overlay prompt from the pm plugin (business context, etc.)
     if (def.pmOverlayPrompt) {

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -6,7 +6,21 @@
  */
 
 import { WebClient } from '@slack/web-api';
-import type { SlackMessage, SlackThreadRef, SlackFile, SlackThread, SlackThreadMessage } from '../../types/index.js';
+import type { SlackThreadRef, SlackFile, SlackThread, SlackThreadMessage, SlackAuthor, SlackAttachment } from '../../types/index.js';
+
+/**
+ * Internal raw shape produced by `fetchThreadHistory`. Carries the unresolved
+ * top-level `user` ID; attachment authors are already resolved to SlackAuthor.
+ * Only consumed by `fetchSlackThread`, which resolves the top-level user and
+ * returns the public `SlackThreadMessage`. Not exported.
+ */
+interface RawSlackMessage {
+  user: string;
+  text: string;
+  ts: string;
+  files?: SlackFile[];
+  attachments?: SlackAttachment[];
+}
 import slackifyMarkdown from 'slackify-markdown';
 import { logger } from '../../system/logger.js';
 
@@ -14,6 +28,7 @@ let slackClient: WebClient | null = null;
 let botUserId: string | null = null;
 let botId: string | null = null;
 let workspaceUrl: string | null = null;
+let homeTeamId: string | null = null;
 let dryRun = false;
 
 /**
@@ -39,7 +54,11 @@ export async function initSlackClient(token: string): Promise<void> {
     botUserId = authResult.user_id as string;
     botId = authResult.bot_id as string | undefined ?? null;
     workspaceUrl = (authResult.url as string | undefined)?.replace(/\/$/, '') ?? null;
-    logger.slack(`Bot user ID: ${botUserId}, bot ID: ${botId}, workspace: ${workspaceUrl}`);
+    homeTeamId = (authResult.team_id as string | undefined) ?? null;
+    logger.slack(`Bot user ID: ${botUserId}, bot ID: ${botId}, workspace: ${workspaceUrl}, home team: ${homeTeamId}`);
+    if (!homeTeamId) {
+      logger.warn('Slack', 'auth.test did not return team_id — external-user filtering will fail open (no filtering applied)');
+    }
   } catch (error) {
     logger.warn('Slack', 'Failed to get bot user ID', error);
   }
@@ -57,6 +76,16 @@ export function getBotUserId(): string | null {
  */
 export function getBotId(): string | null {
   return botId;
+}
+
+/**
+ * Get the bot's home Slack workspace team ID (from auth.test).
+ * Used as the reference point for classifying users as internal vs external.
+ * May be null if auth.test() did not return team_id — in that case external
+ * filtering fails open (treats everyone as internal).
+ */
+export function getHomeTeamId(): string | null {
+  return homeTeamId;
 }
 
 /**
@@ -336,13 +365,16 @@ function applyMentionReplacements(
 }
 
 /**
- * Fetch thread history from Slack with mentions replaced
+ * Fetch thread history from Slack with mentions replaced.
+ *
+ * Returns the internal raw shape; consumers should use `fetchSlackThread`
+ * which resolves authors and packages everything into a `SlackThread`.
  */
-export async function fetchThreadHistory(
+async function fetchThreadHistory(
   channel: string,
   threadTs: string,
   oldest?: string
-): Promise<SlackMessage[]> {
+): Promise<RawSlackMessage[]> {
   const client = getSlackClient();
 
   const result = await client.conversations.replies({
@@ -356,78 +388,107 @@ export async function fetchThreadHistory(
     return [];
   }
 
-  // Extract text from message, handling all Slack message formats
-  const extractMessageText = (msg: typeof result.messages[0]): string => {
-    const parts: string[] = [];
+  // Intermediate shape: we extract authorId here; the public SlackAttachment
+  // exposes a fully resolved SlackAuthor — resolution happens after this loop.
+  interface RawAttachment { authorId?: string; text: string }
 
-    // 1. Primary: use main text field
-    if (msg.text) {
-      parts.push(msg.text);
-    }
+  // Extract a message into the forwarder's own text plus a list of structured
+  // attachments. Each attachment carries its own text and the original
+  // author's user ID when Slack provides one. Keeping author+text correlated
+  // per attachment lets downstream code redact / label individual attachments.
+  const extractMessageParts = (msg: typeof result.messages[0]): {
+    ownText: string;
+    attachments: RawAttachment[];
+  } => {
+    const ownParts: string[] = [];
 
-    // 2. Extract from blocks (Block Kit / rich_text)
+    // Slack delivers the same body in two places: structured `blocks`
+    // (rich_text / Block Kit) and a plain-text `text` field (legacy fallback
+    // for clients that can't render blocks). Prefer the structured form when
+    // present; otherwise fall back to `text`.
     const blocks = msg.blocks as Array<{
       type: string;
       text?: { text?: string };
       elements?: Array<unknown>;
     }> | undefined;
+    let consumedTopBlocks = false;
 
     if (blocks && Array.isArray(blocks)) {
       for (const block of blocks) {
         const blockText = extractBlockText(block);
-        if (blockText && !parts.includes(blockText)) {
-          parts.push(blockText);
+        if (blockText && !ownParts.includes(blockText)) {
+          ownParts.push(blockText);
+          consumedTopBlocks = true;
         }
       }
     }
 
-    // 3. Extract from attachments (forwarded messages, shared content, unfurls)
-    const attachments = msg.attachments as Array<{
-      text?: string;
-      fallback?: string;
-      pretext?: string;
-      title?: string;
-      message_blocks?: Array<{ message?: { blocks?: Array<unknown> } }>;
-    }> | undefined;
-
-    if (attachments && Array.isArray(attachments)) {
-      for (const att of attachments) {
-        // Try structured message_blocks first (forwarded messages)
-        if (att.message_blocks) {
-          for (const mb of att.message_blocks) {
-            if (mb.message?.blocks) {
-              for (const block of mb.message.blocks) {
-                const blockText = extractBlockText(block as { type: string; elements?: Array<unknown> });
-                if (blockText && !parts.includes(blockText)) {
-                  parts.push(`[Forwarded] ${blockText}`);
-                }
-              }
-            }
-          }
-        }
-
-        // Fall back to text/fallback fields
-        const attText = att.text || att.fallback;
-        if (attText && !parts.includes(attText)) {
-          // Check if this looks like a forwarded message (has is_share or from_url)
-          const isForwarded = (att as { is_share?: boolean }).is_share;
-          parts.push(isForwarded ? `[Forwarded] ${attText}` : attText);
-        }
-      }
+    if (!consumedTopBlocks && msg.text) {
+      ownParts.push(msg.text);
     }
 
-    // 4. Extract from files (file shares)
+    // Files (file shares) — appended to ownText since they belong to the
+    // top-level message, not to an attachment.
     const files = msg.files as Array<{ name?: string; title?: string }> | undefined;
     if (files && Array.isArray(files)) {
       const fileDescriptions = files
         .map(f => f.title || f.name)
         .filter(Boolean);
       if (fileDescriptions.length > 0) {
-        parts.push(`[Files: ${fileDescriptions.join(', ')}]`);
+        ownParts.push(`[Files: ${fileDescriptions.join(', ')}]`);
       }
     }
 
-    return parts.join('\n');
+    // Attachments (forwarded messages, shared content, unfurls). Each entry
+    // becomes one SlackAttachment with its author + text correlated.
+    const rawAttachments = msg.attachments as Array<{
+      author_id?: string;
+      text?: string;
+      fallback?: string;
+      pretext?: string;
+      title?: string;
+      message_blocks?: Array<{ message?: { user?: string; blocks?: Array<unknown> } }>;
+    }> | undefined;
+
+    const attachments: RawAttachment[] = [];
+    if (rawAttachments && Array.isArray(rawAttachments)) {
+      for (const att of rawAttachments) {
+        // Prefer structured message_blocks; skip text/fallback when present to
+        // avoid duplicating the same content.
+        const seg: string[] = [];
+        let authorId = att.author_id;
+        let consumedFromBlocks = false;
+        if (att.message_blocks) {
+          for (const mb of att.message_blocks) {
+            if (mb.message?.user && !authorId) authorId = mb.message.user;
+            if (mb.message?.blocks) {
+              for (const block of mb.message.blocks) {
+                const blockText = extractBlockText(block as { type: string; elements?: Array<unknown> });
+                if (blockText && !seg.includes(blockText)) {
+                  seg.push(blockText);
+                  consumedFromBlocks = true;
+                }
+              }
+            }
+          }
+        }
+
+        if (!consumedFromBlocks) {
+          const attText = att.text || att.fallback;
+          if (attText && !seg.includes(attText)) seg.push(attText);
+        }
+
+        const text = seg.join('\n');
+        if (text || authorId) {
+          attachments.push({ ...(authorId ? { authorId } : {}), text });
+        }
+      }
+    }
+
+    return {
+      ownText: ownParts.join('\n'),
+      attachments,
+    };
   };
 
   /**
@@ -555,8 +616,15 @@ export async function fetchThreadHistory(
     return parts.join('');
   };
 
-  // Batch fetch user/group/channel info for all messages
-  const messages = result.messages.map(m => ({ text: extractMessageText(m) }));
+  // Batch fetch user/group/channel info for all messages.
+  // For mention extraction we just need every text segment we'll surface,
+  // so concatenate ownText and all attachment texts into one blob.
+  const messages = result.messages.map((m) => {
+    const { ownText, attachments } = extractMessageParts(m);
+    return {
+      text: [ownText, ...attachments.map((a) => a.text)].filter(Boolean).join('\n'),
+    };
+  });
   const channelIds = new Set([channel]); // Include the thread's channel
   const { userInfoMap, groupInfoMap, channelInfoMap } = await fetchMentionInfo(messages, channelIds);
 
@@ -620,45 +688,191 @@ export async function fetchThreadHistory(
     return allFiles.length > 0 ? allFiles : undefined;
   };
 
+  // Resolve attachment authors to SlackAuthor objects up-front so each
+  // attachment carries its full author info (name, team, restriction flags).
+  const extractedPerMessage = result.messages.map((m) => extractMessageParts(m));
+  const attachmentAuthorIds = new Set<string>();
+  for (const { attachments } of extractedPerMessage) {
+    for (const att of attachments) {
+      if (att.authorId) attachmentAuthorIds.add(att.authorId);
+    }
+  }
+  const authorEntries = await Promise.all(
+    Array.from(attachmentAuthorIds).map(async (uid): Promise<readonly [string, SlackAuthor | null]> => {
+      try {
+        const info = await getUserInfo(uid);
+        return [uid, {
+          id: uid,
+          username: info.name,
+          realName: info.realName,
+          teamId: info.teamId,
+          isRestricted: info.isRestricted,
+          isUltraRestricted: info.isUltraRestricted,
+        }];
+      } catch {
+        return [uid, null];
+      }
+    })
+  );
+  const authorMap = new Map(authorEntries);
+
   // Apply replacements to all messages
-  return result.messages.map((msg) => {
+  return result.messages.map((msg, i) => {
     const files = extractFiles(msg);
+    const { ownText, attachments } = extractedPerMessage[i];
+    const resolvedAttachments: SlackAttachment[] = attachments.map((a) => {
+      const author = a.authorId ? authorMap.get(a.authorId) ?? undefined : undefined;
+      return {
+        ...(author ? { author } : {}),
+        text: applyMentionReplacements(a.text, userInfoMap, groupInfoMap, channelInfoMap),
+      };
+    });
     return {
-      type: msg.type || 'message',
-      channel,
       user: msg.user || 'unknown',
-      text: applyMentionReplacements(extractMessageText(msg), userInfoMap, groupInfoMap, channelInfoMap),
+      text: applyMentionReplacements(ownText, userInfoMap, groupInfoMap, channelInfoMap),
       ts: msg.ts || '',
-      thread_ts: msg.thread_ts,
       ...(files && files.length > 0 ? { files } : {}),
+      ...(resolvedAttachments.length > 0 ? { attachments: resolvedAttachments } : {}),
     };
   });
 }
 
 /**
- * Fetch new messages in a thread since a timestamp
- */
-export async function fetchNewMessages(
-  channel: string,
-  threadTs: string,
-  sinceTs: string
-): Promise<SlackMessage[]> {
-  return fetchThreadHistory(channel, threadTs, sinceTs);
-}
-
-/**
  * Get user info
  */
-export async function getUserInfo(userId: string): Promise<{ name: string; realName: string; tz?: string }> {
+export async function getUserInfo(userId: string): Promise<{
+  name: string;
+  realName: string;
+  tz?: string;
+  teamId?: string;
+  isRestricted?: boolean;
+  isUltraRestricted?: boolean;
+}> {
   const client = getSlackClient();
 
   const result = await client.users.info({ user: userId });
+  const user = result.user as {
+    name?: string;
+    real_name?: string;
+    profile?: { real_name?: string; display_name?: string; real_name_normalized?: string };
+    tz?: string;
+    team_id?: string;
+    is_restricted?: boolean;
+    is_ultra_restricted?: boolean;
+  } | undefined;
+
+  // External users (Slack Connect) often only populate the name under profile.*
+  // — fall through several fields before giving up to the user ID.
+  const realName =
+    user?.real_name ||
+    user?.profile?.real_name ||
+    user?.profile?.real_name_normalized ||
+    user?.profile?.display_name ||
+    user?.name ||
+    userId;
 
   return {
-    name: result.user?.name || userId,
-    realName: result.user?.real_name || userId,
-    tz: (result.user as Record<string, unknown>)?.tz as string | undefined,
+    name: user?.name || userId,
+    realName,
+    tz: user?.tz,
+    teamId: user?.team_id,
+    isRestricted: user?.is_restricted,
+    isUltraRestricted: user?.is_ultra_restricted,
   };
+}
+
+/**
+ * Classify a user as external relative to the bot's home Slack team.
+ * External = different team_id (Slack Connect / shared channels) OR a guest
+ * (`is_restricted` / `is_ultra_restricted`) on the home workspace.
+ *
+ * Fails open when homeTeamId is unknown (returns false) so the bot remains
+ * usable rather than filtering everyone — see startup warning in initSlackClient.
+ */
+export function isExternalUser(user: {
+  teamId?: string;
+  isRestricted?: boolean;
+  isUltraRestricted?: boolean;
+}): boolean {
+  const home = getHomeTeamId();
+  if (!home) return false;
+  if (user.isRestricted || user.isUltraRestricted) return true;
+  if (user.teamId && user.teamId !== home) return true;
+  return false;
+}
+
+// ---- Shared-channel detection (Slack Connect) -----------------------------
+// Cached per-channel with a 1-minute TTL: a channel can flip to shared mid-task
+// when an external org is added, and the warning logic depends on observing
+// the transition promptly. 1 min is well under Slack's tier-3 rate limit
+// (50+/min) even for >50 simultaneously active threads.
+
+interface ChannelSharedCacheEntry {
+  isShared: boolean;
+  fetchedAt: number;
+}
+const channelSharedCache = new Map<string, ChannelSharedCacheEntry>();
+const CHANNEL_SHARED_TTL_MS = 60_000;
+
+/**
+ * Returns whether a channel is shared with one or more external Slack
+ * workspaces (Slack Connect). DMs are never shared. Result is cached for
+ * 1 minute. On API failure, returns false (fail-open).
+ */
+export async function isChannelShared(channelId: string): Promise<boolean> {
+  if (channelId.startsWith('D')) return false;
+
+  const cached = channelSharedCache.get(channelId);
+  if (cached && Date.now() - cached.fetchedAt < CHANNEL_SHARED_TTL_MS) {
+    return cached.isShared;
+  }
+
+  try {
+    const client = getSlackClient();
+    const result = await client.conversations.info({ channel: channelId });
+    const channel = result.channel as {
+      is_ext_shared?: boolean;
+      is_pending_ext_shared?: boolean;
+      connected_team_ids?: string[];
+    } | undefined;
+    const isShared =
+      !!channel?.is_ext_shared ||
+      !!channel?.is_pending_ext_shared ||
+      ((channel?.connected_team_ids?.length ?? 0) > 1);
+    channelSharedCache.set(channelId, { isShared, fetchedAt: Date.now() });
+    return isShared;
+  } catch (error) {
+    logger.warn('Slack', `Failed to fetch shared-channel status for ${channelId}`, error);
+    return false;
+  }
+}
+
+/**
+ * Post an ephemeral message in a channel/thread visible only to one user.
+ * Used for shared-channel and forwarding warnings.
+ */
+export async function postEphemeral(
+  channel: string,
+  user: string,
+  text: string,
+  threadTs?: string,
+): Promise<void> {
+  if (dryRun) {
+    logger.system(`[DRY RUN] postEphemeral ${channel} → ${user} — ${text.slice(0, 120)}`);
+    return;
+  }
+  try {
+    const client = getSlackClient();
+    const slackText = slackifyMarkdown(restoreMentions(text));
+    await client.chat.postEphemeral({
+      channel,
+      user,
+      text: slackText,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+    });
+  } catch (error) {
+    logger.warn('Slack', `Failed to post ephemeral in ${channel} to ${user}`, error);
+  }
 }
 
 /**
@@ -797,9 +1011,10 @@ export async function fetchSlackThread(
   threadTs: string,
   currentMessageTs: string,
 ): Promise<SlackThread> {
-  const [channelInfo, rawMessages] = await Promise.all([
+  const [channelInfo, rawMessages, shared] = await Promise.all([
     getChannelInfo(channelId),
     fetchThreadHistory(channelId, threadTs),
+    isChannelShared(channelId),
   ]);
 
   // Filter out bot messages
@@ -807,30 +1022,45 @@ export async function fetchSlackThread(
     (msg) => msg.user && msg.user !== 'unknown' && msg.user !== botUserId
   );
 
-  // Batch-resolve user info for all unique authors
-  const uniqueUserIds = [...new Set(humanMessages.map((msg) => msg.user))];
+  // Resolve top-level message authors. Attachment authors are already
+  // resolved on each msg.attachments[].author by fetchThreadHistory.
+  const authorIds = new Set(humanMessages.map((msg) => msg.user));
   const userInfoEntries = await Promise.all(
-    uniqueUserIds.map(async (uid) => {
-      const info = await getUserInfo(uid);
-      return [uid, info] as const;
+    Array.from(authorIds).map(async (uid): Promise<readonly [string, SlackAuthor]> => {
+      try {
+        const info = await getUserInfo(uid);
+        return [uid, {
+          id: uid,
+          username: info.name,
+          realName: info.realName,
+          teamId: info.teamId,
+          isRestricted: info.isRestricted,
+          isUltraRestricted: info.isUltraRestricted,
+        }];
+      } catch {
+        return [uid, { id: uid, username: uid, realName: uid }];
+      }
     })
   );
   const userInfoMap = new Map(userInfoEntries);
 
-  // Build resolved messages
+  // Surface structured pieces (text, attachments, files) and let consumers
+  // decide redaction / labeling using `thread.shared` + `isExternalUser`.
   const messages: SlackThreadMessage[] = humanMessages.map((msg) => {
-    const info = userInfoMap.get(msg.user)!;
+    const author = userInfoMap.get(msg.user)!;
     return {
-      user: { id: msg.user, username: info.name, realName: info.realName },
+      user: author,
       text: msg.text,
       ts: msg.ts,
       ...(msg.files && msg.files.length > 0 ? { files: msg.files } : {}),
+      ...(msg.attachments && msg.attachments.length > 0 ? { attachments: msg.attachments } : {}),
     };
   });
 
   return {
     threadId: threadTs,
     channel: channelInfo,
+    shared,
     messages,
     currentMessageTs,
   };
@@ -869,6 +1099,9 @@ export interface SlackUserInfo {
   timezone: string;      // Timezone label (e.g., "Eastern Time (US & Canada)")
   isAdmin: boolean;      // Workspace admin
   isOwner: boolean;      // Workspace owner
+  teamId?: string;             // Slack team_id — used for external-org classification
+  isRestricted?: boolean;      // Multi-channel guest
+  isUltraRestricted?: boolean; // Single-channel guest
 }
 
 let userCache: SlackUserInfo[] = [];
@@ -901,6 +1134,9 @@ export async function listWorkspaceUsers(): Promise<SlackUserInfo[]> {
         timezone: member.tz_label ?? member.tz ?? '',
         isAdmin: member.is_admin ?? false,
         isOwner: member.is_owner ?? false,
+        teamId: member.team_id ?? undefined,
+        isRestricted: member.is_restricted ?? false,
+        isUltraRestricted: member.is_ultra_restricted ?? false,
       });
     }
     cursor = result.response_metadata?.next_cursor || undefined;

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -22,6 +22,10 @@ import {
   addReaction,
   removeReaction,
   setSlackDryRun,
+  getUserInfo,
+  isExternalUser,
+  isChannelShared,
+  postEphemeral,
 } from './client.js';
 import { Task } from '../../tasks/task.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
@@ -279,6 +283,24 @@ async function handleSlackEvent(event: {
 }): Promise<void> {
   const threadId = event.thread_ts || event.ts;
 
+  // ---- External-author bail-out --------------------------------------------
+  // Resolve the event author and bail if external (different team, or guest).
+  // No agent spawn, no task creation, no reactions, no log entries. The
+  // redacted history will be appended lazily the next time an internal user
+  // triggers the handler (fetchSlackThread re-reads full history and redacts).
+  if (event.user) {
+    try {
+      const authorInfo = await getUserInfo(event.user);
+      if (isExternalUser(authorInfo)) {
+        logger.system(`Skipping event from external/guest user ${event.user}`);
+        return;
+      }
+    } catch (error) {
+      // Fail open — if we can't classify, don't silently drop the event.
+      logger.warn('Slack', `Failed to classify event author ${event.user}`, error);
+    }
+  }
+
   // Instant acknowledgment — react before any LLM processing.
   // Remove eyes from the previous message first (only one message should have eyes at a time).
   if (event.type === 'app_mention' || event.channel.startsWith('D')) {
@@ -295,6 +317,7 @@ async function handleSlackEvent(event: {
   }
 
   const thread = await fetchSlackThread(event.channel, threadId, event.ts);
+  const shared = await isChannelShared(event.channel);
 
   // const triageResult = await triageSlackMessage(thread);
   // switch (triageResult.action) {
@@ -351,6 +374,7 @@ async function handleSlackEvent(event: {
 
     // Thread reply to an existing task — route to it
     await task.append(thread);
+    await sendSharedChannelWarnings(task, event.channel, threadId, thread, shared);
     await task.sendMessage(AGENT_PROMPTS.existingTask);
   } else if (event.type === 'app_mention' || event.channel.startsWith('D')) {
     logger.system(`Processing #${thread.channel.name} (thread: ${threadId})`);
@@ -358,7 +382,90 @@ async function handleSlackEvent(event: {
     // Bot was @mentioned, or this is a DM — start a new task
     const task = await Task.create();
     await task.append(thread);
+    await sendSharedChannelWarnings(task, event.channel, threadId, thread, shared);
     await task.sendMessage(AGENT_PROMPTS.newTask);
   }
   // Otherwise: thread reply in a thread the bot was never part of — ignore
 }
+
+const SHARED_CHANNEL_WARNING_TEXT =
+  ':warning: *Heads up:* this thread is in a Slack channel shared with an external organisation. ' +
+  'Archie filters messages from external participants — if you need Archie to see something an ' +
+  'external person said, re-say it yourself. Also be aware that anything Archie posts here ' +
+  '(including on your behalf) is visible to the external org, so mind what you ask Archie to share.';
+
+const FORWARD_NOTICE_TEXT =
+  ':information_source: You forwarded a message originally authored by an external user. ' +
+  'Archie will process its contents — just making sure you are aware.';
+
+/**
+ * Persist isShared and post ephemeral warnings to internal users in the thread.
+ *
+ * Warning A (shared-channel awareness): one ephemeral per (thread × user).
+ * Warning B (forward-from-external): one ephemeral per (thread × forwarder).
+ *
+ * Both lists live on the SlackChannel metadata for the thread.
+ */
+async function sendSharedChannelWarnings(
+  task: Task,
+  channelId: string,
+  threadId: string,
+  thread: import('../../types/task.js').SlackThread,
+  shared: boolean,
+): Promise<void> {
+  const channelKey = `slack:${channelId}:${threadId}`;
+  const ch = task.metadata.channels[channelKey];
+  if (!ch || ch.type !== 'slack') return;
+
+  // Snapshot isShared for observability. Runtime decisions still use isChannelShared cache.
+  ch.isShared = shared;
+
+  if (!shared) {
+    task.debouncedSave();
+    return;
+  }
+
+  // Warning A — diff thread participants vs already-warned set.
+  // Skip externals (they don't need our warning) and the bot.
+  const warned = new Set(ch.warnedUsers ?? []);
+  const botUserId = getBotUserId();
+  const internalParticipants = new Set<string>();
+  for (const msg of thread.messages) {
+    if (isExternalUser(msg.user)) continue;
+    if (!msg.user.id || msg.user.id === botUserId) continue;
+    internalParticipants.add(msg.user.id);
+  }
+  const toWarn = [...internalParticipants].filter((u) => !warned.has(u));
+  for (const userId of toWarn) {
+    await postEphemeral(channelId, userId, SHARED_CHANNEL_WARNING_TEXT, threadId);
+    warned.add(userId);
+  }
+  if (toWarn.length > 0) {
+    ch.warnedUsers = [...warned];
+  }
+
+  // Warning B — for each message that carries at least one externally-authored
+  // attachment, notify the forwarder (the message's top-level author) once
+  // per thread.
+  const forwardNotified = new Set(ch.forwardNotifiedUsers ?? []);
+  const forwardersToNotify = new Set<string>();
+  for (const msg of thread.messages) {
+    if (!msg.user.id || forwardNotified.has(msg.user.id)) continue;
+    const hasExternalAttachment = (msg.attachments ?? []).some(
+      (att) => att.author && isExternalUser(att.author),
+    );
+    if (hasExternalAttachment) {
+      forwardersToNotify.add(msg.user.id);
+    }
+  }
+  for (const userId of forwardersToNotify) {
+    await postEphemeral(channelId, userId, FORWARD_NOTICE_TEXT, threadId);
+    forwardNotified.add(userId);
+  }
+  if (forwardersToNotify.size > 0) {
+    ch.forwardNotifiedUsers = [...forwardNotified];
+  }
+
+  task.debouncedSave();
+}
+

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -9,7 +9,8 @@ import { mkdir, readFile, writeFile, appendFile } from 'fs/promises';
 import { createReadStream, existsSync } from 'fs';
 import { createInterface } from 'readline';
 import { join } from 'path';
-import type { TaskMetadata, LogEntry, FindingType, SlackFile } from '../types/index.js';
+import type { TaskMetadata, LogEntry, FindingType, SlackFile, SlackAttachment, SlackAuthor } from '../types/index.js';
+import { isExternalUser } from '../connectors/slack/client.js';
 import type { SystemEvent } from '../system/event-bus.js';
 import { activeTasks } from './task.js';
 import { SESSIONS_DIR } from '../system/workdir.js';
@@ -172,36 +173,83 @@ function formatLogEntry(entry: LogEntry): string {
 }
 
 /**
- * Append a Slack message to the knowledge log
- * @param files - Optional array of downloaded files with localPath set
+ * Append a Slack message to the knowledge log.
+ *
+ * Renders one of three layouts based on the structured data:
+ * - Redacted (external author): body replaced with a fixed placeholder, name
+ *   masked as `external` in the source line.
+ * - With forwarded-from-external attachment: forwarder's text first, then a
+ *   provenance label, then the forwarded content. Other (non-external)
+ *   attachments fold into the inline body.
+ * - Normal: just the author's text plus inline attachments and file list.
  */
 export async function appendSlackMessage(
   taskId: string,
   channelInfo: { id: string; name: string },
   threadId: string,
-  userInfo: { id: string; username: string; realName: string },
+  userInfo: SlackAuthor,
   message: string,
-  files?: SlackFile[]
+  files?: SlackFile[],
+  attachments?: SlackAttachment[],
+  options?: { redacted?: boolean }
 ): Promise<void> {
-  // Build message with optional file attachments
-  let fullMessage = message;
+  const redacted = options?.redacted === true;
 
-  if (files && files.length > 0) {
-    const fileInfo = files.map(f => {
-      const pathInfo = f.localPath ? ` (${f.localPath})` : '';
-      return `${f.name}${pathInfo}`;
-    }).join(', ');
-    fullMessage += `\n  [Attachments: ${fileInfo}]`;
+  let fullMessage: string;
+  if (redacted) {
+    fullMessage = '[redacted: external participant in shared channel]';
+  } else {
+    const inlineParts: string[] = [];
+    if (message) inlineParts.push(message);
+
+    let forwardedBlock = '';
+    for (const att of attachments ?? []) {
+      if (att.author && isExternalUser(att.author)) {
+        // Render the externally-authored attachment under a provenance label.
+        // Only the first one gets the label block; subsequent ones (rare)
+        // fold inline so the agent still sees them.
+        if (!forwardedBlock) {
+          const teamSuffix = att.author.teamId ? `, team ${att.author.teamId}` : '';
+          const label = `[forwarded from @<${att.author.id}:${att.author.realName}> — external${teamSuffix}]`;
+          forwardedBlock = `${label}\n${att.text}`;
+          continue;
+        }
+      }
+      if (att.text) inlineParts.push(att.text);
+    }
+    if (forwardedBlock) inlineParts.push(forwardedBlock);
+
+    fullMessage = inlineParts.join('\n');
+
+    if (files && files.length > 0) {
+      const fileInfo = files.map(f => {
+        const pathInfo = f.localPath ? ` (${f.localPath})` : '';
+        return `${f.name}${pathInfo}`;
+      }).join(', ');
+      fullMessage += `\n  [Attachments: ${fileInfo}]`;
+    }
   }
 
+  // Mask the author name in the source line when the body is redacted, so the
+  // log doesn't leak the external user's display name even though we keep it
+  // in memory for classification purposes.
+  const displayName = redacted ? 'external' : userInfo.realName;
   const entry: LogEntry = {
     timestamp: new Date().toISOString(),
-    source: `@<${userInfo.id}:${userInfo.realName}> in ${formatSlackChannelRef(channelInfo.id, channelInfo.name, threadId)}`,
+    source: `@<${userInfo.id}:${displayName}> in ${formatSlackChannelRef(channelInfo.id, channelInfo.name, threadId)}`,
     message: fullMessage,
   };
 
   await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
-  emitEvent('message', taskId, { from: userInfo.realName, to: 'pm-agent', destination: formatSlackChannelDisplay(channelInfo.name), message });
+  // Emit the original message body in events so live observers (CLI/UI) still
+  // see redacted vs internal as a clear category — pass the same string we
+  // wrote to the log.
+  emitEvent('message', taskId, {
+    from: displayName,
+    to: 'pm-agent',
+    destination: formatSlackChannelDisplay(channelInfo.name),
+    message: fullMessage,
+  });
 }
 
 /**

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -53,7 +53,7 @@ import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
 import { scanAgentDefs } from '../agents/registry.js';
 import { refreshPlugins } from '../system/workdir.js';
-import { postToThread, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, postNewMessage, getChannelInfo, getUserInfo, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
+import { postToThread, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, postNewMessage, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { logger } from '../system/logger.js';
 import { emitEvent } from '../system/event-bus.js';
@@ -211,6 +211,24 @@ export class Task {
     const channelId = `slack:${thread.channel.id}:${thread.threadId}`;
     const existing = this.metadata.channels[channelId] as SlackChannel | undefined;
 
+    // Redaction policy: when the channel is shared and the message author is
+    // external, drop content and don't download files. Author info is logged.
+    const writeMessage = async (msg: typeof thread.messages[number]): Promise<void> => {
+      const redact = thread.shared && isExternalUser(msg.user);
+      if (redact) {
+        await appendSlackMessage(
+          this.taskId, thread.channel, thread.threadId, msg.user, '', undefined, undefined,
+          { redacted: true },
+        );
+      } else {
+        const downloadedFiles = msg.files ? await downloadMessageFiles(this.taskId, msg.files) : undefined;
+        await appendSlackMessage(
+          this.taskId, thread.channel, thread.threadId, msg.user, msg.text,
+          downloadedFiles, msg.attachments,
+        );
+      }
+    };
+
     if (!existing) {
       // New thread — link it as a channel and append all messages
       this.metadata.channels[channelId] = {
@@ -224,8 +242,7 @@ export class Task {
       this.metadata.default_channel ??= channelId;
 
       for (const msg of thread.messages) {
-        const downloadedFiles = msg.files ? await downloadMessageFiles(this.taskId, msg.files) : undefined;
-        await appendSlackMessage(this.taskId, thread.channel, thread.threadId, msg.user, msg.text, downloadedFiles);
+        await writeMessage(msg);
       }
 
       this.debouncedSave();
@@ -236,8 +253,7 @@ export class Task {
     const lastProcessedTs = existing.last_processed_ts;
     for (const msg of thread.messages) {
       if (msg.ts <= lastProcessedTs) continue;
-      const downloadedFiles = msg.files ? await downloadMessageFiles(this.taskId, msg.files) : undefined;
-      await appendSlackMessage(this.taskId, thread.channel, thread.threadId, msg.user, msg.text, downloadedFiles);
+      await writeMessage(msg);
     }
 
     existing.last_processed_ts = thread.currentMessageTs;

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -19,18 +19,45 @@ export interface SlackThreadRef {
   last_processed_ts: string;
 }
 
-/** A fully-resolved message from a Slack thread */
-export interface SlackThreadMessage {
-  user: { id: string; username: string; realName: string };
-  text: string;           // mentions already resolved
-  ts: string;
-  files?: SlackFile[];    // raw file metadata (not yet downloaded)
+/**
+ * Resolved Slack user info attached to a message or an attachment.
+ *
+ * Carries everything needed to classify the user (home-team membership,
+ * guest status) without a second lookup. Use `isExternalUser` from the Slack
+ * client to evaluate.
+ */
+export interface SlackAuthor {
+  id: string;
+  username: string;     // @handle
+  realName: string;     // Full display name
+  teamId?: string;
+  isRestricted?: boolean;
+  isUltraRestricted?: boolean;
 }
 
-/** Full Slack thread context — all API data resolved, ready for task consumption */
+/** A fully-resolved message from a Slack thread */
+export interface SlackThreadMessage {
+  user: SlackAuthor;
+  /** The author's own typed text (top-level blocks/text + file descriptions), mentions already resolved. */
+  text: string;
+  ts: string;
+  files?: SlackFile[];    // raw file metadata (not yet downloaded)
+  /** Forwarded / unfurled message attachments — each carries its author and text. */
+  attachments?: SlackAttachment[];
+}
+
+/**
+ * Full Slack thread context — all API data resolved, ready for task consumption.
+ *
+ * `shared` is a thread-level signal: when true, the channel is currently
+ * shared with one or more external workspaces (Slack Connect). Consumers use
+ * `shared && isExternalUser(msg.user)` to decide whether to redact a message
+ * when writing it out — the data layer never strips content itself.
+ */
 export interface SlackThread {
   threadId: string;
   channel: { id: string; name: string };
+  shared: boolean;
   messages: SlackThreadMessage[];  // full thread, bot messages excluded
   currentMessageTs: string;
 }
@@ -52,6 +79,12 @@ export interface SlackChannel extends ChannelBase {
   last_processed_ts: string;
   url?: string;     // Full Slack URL to the thread (e.g. https://workspace.slack.com/archives/C.../p...)
   muted?: boolean;  // When true, messages are not routed to task until next @mention
+  /** Snapshot of last observed Slack-Connect / shared-channel state for this channel. */
+  isShared?: boolean;
+  /** User IDs already shown the shared-channel ephemeral warning in this thread. */
+  warnedUsers?: string[];
+  /** User IDs already shown the forward-from-external ephemeral notice in this thread. */
+  forwardNotifiedUsers?: string[];
 }
 
 /** GitHub channel — a PR conversation */
@@ -151,13 +184,19 @@ export interface SlackFile {
   localPath?: string;
 }
 
-export interface SlackMessage {
-  type: string;
-  channel: string;
-  user: string;
+/**
+ * A simplified attachment on a Slack message.
+ *
+ * Slack attachments cover several use cases (forwarded messages, permalink
+ * unfurls, link previews). We collapse them into a single shape: each entry
+ * has its own text and, when known, the original author resolved to a
+ * SlackAuthor. This keeps the author + content correlation that flat parallel
+ * fields would lose.
+ */
+export interface SlackAttachment {
+  /** Resolved author info, when the attachment carries an author (forwards / message unfurls). */
+  author?: SlackAuthor;
+  /** Text content of the attachment (forwarded message body, unfurled preview, etc.). */
   text: string;
-  ts: string;
-  thread_ts?: string;
-  /** Files attached to this message */
-  files?: SlackFile[];
 }
+


### PR DESCRIPTION
## Summary

- Filter messages authored by external-org users and guests when Archie operates in Slack-Connect (shared) channels: the event handler bails out on external authors, and consumers redact body/files in the knowledge log while preserving the user ID for structural awareness
- Detect and label forwarded / permalink-unfurled messages whose original author is external, with a one-time ephemeral to the forwarder; internal users in a shared thread get a one-time shared-channel awareness ephemeral
- Annotate the PM system prompt when any of the task's Slack channels is shared, reminding the agent that anything it posts is visible to the external org

Plan: [docs/plans/v24-shared-channel-guardrails.md](docs/plans/v24-shared-channel-guardrails.md)

## Test plan

- [x] Typecheck (`npm run typecheck`) and unit tests (`npm test`) pass
- [x] External user in shared channel → handler bails out, no task created, no `eyes` reaction
- [x] Internal user replies after external activity → prior external messages logged as `[redacted: external participant in shared channel]` (lazy redaction on history re-fetch)
- [x] Internal user gets shared-channel awareness ephemeral on first activity in the thread
- [x] Forwarding an external message → `[forwarded from @<id:Name> — external, team T...]` label + content; forwarder gets the forward-awareness ephemeral
- [x] DM from external/guest user fully skipped
- [x] Repeated posts/forwards from same internal user don't re-trigger ephemerals (idempotency)
- [x] PM prompt is annotated with the shared-channel notice (verified by asking the agent to quote it verbatim)
- [ ] Mid-thread join: second internal user replies in a shared thread → only the new user gets the warning (untested in this round; design supports it)
- [ ] Channel becomes shared mid-task: non-shared → shared transition triggers warning on next internal message (untested in this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)