### PR TITLE
Add AI-generated task titles

### DIFF
--- a/docs/plans/v25-task-titles.md
+++ b/docs/plans/v25-task-titles.md
@@ -1,0 +1,252 @@
+# Task Titles — Implementation Plan
+
+## Context
+
+Tasks today are identified by `task_id` (timestamp + random) and `channel_name` (e.g. `DM with Egor`). Neither communicates what the task is about. Goal: generate a Haiku-authored one-line title at task creation, surface it via API + CLI, and push it to Slack DM thread titles via `assistant.threads.setTitle` for DM-originated tasks.
+
+Trigger: every `task.append(thread)` in `events.ts`, fire-and-forget, guarded by `if (!task.metadata.title)` so pre-feature tasks pick up a title on next interaction. Once set, never regenerated. No active backfill.
+
+## Scope
+
+- All tasks (DMs and channel mentions) get a title.
+- Slack-side title sync only applies to DM tasks (Slack API does not support setting titles for non-assistant channel threads).
+- Title generated for any task that doesn't already have one, guarded by `if (!task.metadata.title)`. Guard fires for new tasks AND resumed pre-feature tasks — old tasks pick up a title organically on next interaction. Once set, never regenerated.
+- No active scan / backfill. Inactive pre-feature tasks stay title-less unless a Slack event re-touches them.
+
+## Out of Scope
+
+- Active backfill job.
+- Title regeneration when conversation pivots topic.
+- PM agent override / update via tool.
+- User-facing title editing.
+- Setting Slack thread titles for non-DM channels (API does not support it).
+
+## Phases
+
+Five phases, sequenced. Each compiles and typechecks independently.
+
+---
+
+### Phase 1 — Type + render-helper extraction
+
+**Goal:** Add optional `title` to metadata; extract body-rendering from `appendSlackMessage` with byte-exact parity. Pure refactor — no behavior change.
+
+**Files:**
+
+- `src/types/task.ts` — add `title?: string` to `TaskMetadata` (between `default_channel` and `slack_threads`). Optional → backwards compatible, no migration.
+
+- `src/tasks/persistence.ts` — extract `renderMessageForContext()`:
+
+  ```ts
+  export function renderMessageForContext(
+    msg: { user: SlackAuthor; text: string; files?: SlackFile[]; attachments?: SlackAttachment[] },
+    options: { redacted: boolean }
+  ): string
+  ```
+
+  Move body lines 198–231 verbatim. `appendSlackMessage` keeps signature; replaces those lines with one call to the helper. Lines 233–253 (displayName masking, `LogEntry`, `appendFile`, `emitEvent`) stay in `appendSlackMessage`.
+
+  **Parity guarantee:** identical conditional ordering, identical `\n` joins, identical `[Attachments: ...]` and `[forwarded from ...]` formatting. Verify via diff against an old log post-refactor.
+
+---
+
+### Phase 2 — Title generator + Slack title wrapper
+
+**New file `src/tasks/title-generator.ts`:**
+
+```ts
+export async function generateTaskTitle(thread: SlackThread): Promise<string | null>
+```
+
+Pattern mirrors `src/mcp/research-tools.ts:53-102` (NOT `triage.ts` — skip `processAgentEventForLogging` to keep noise low):
+
+1. Per message, compute `redacted = thread.shared && isExternalUser(msg.user)`. Render via `renderMessageForContext(msg, { redacted })`. Author label: `'external'` when redacted else `realName`.
+2. Concatenate transcript lines `[<author>]: <body>`.
+3. **Skip-LLM guard:** if all rendered bodies equal the redaction placeholder or are empty, return `null` — no LLM call.
+4. Zod schema: `z.object({ title: z.string() })`. Convert via `toJSONSchema` (zod 4 native, matches `research-tools.ts`).
+5. `query()` opts: `model: 'haiku'`, `cwd: SESSIONS_DIR`, `executable: 'node'`, env `{ NODE_ENV, ANTHROPIC_API_KEY, PATH }`, `allowedTools: []`, `outputFormat: { type: 'json_schema', schema }`. System prompt:
+
+   ```
+   You generate a concise title for a task based on the initial conversation that started it.
+
+   Rules:
+   - Maximum 60 characters
+   - Free-form style (imperative, noun phrase, question — whatever fits)
+   - No quotes, no trailing punctuation
+   - Match the conversation's primary language
+   - Capture the actual subject, not generic phrases
+   ```
+
+   Output structure enforced by `json_schema` outputFormat — no need to instruct shape in prompt.
+6. Iterate events; on `event.type === 'result'`:
+   - `subtype === 'success'`: `safeParse`, take `title`, `.trim()`, strip surrounding quotes + trailing punctuation `[.!?…]+$`, slice 60 chars. Empty → `null`.
+   - other subtypes: `logger.warn('title-generator', ...)`, return `null`.
+7. Outer try/catch → log + `null` on throw.
+
+**Files attached to messages:** never sent to title generator (titles only need text).
+
+**No retry.** Single attempt. Slack DMs fall back to first-message preview natively.
+
+**Failure modes:**
+
+| Failure | Behavior |
+| --- | --- |
+| Haiku call fails (network/API) | `logger.warn`, returns `null` |
+| Haiku returns malformed JSON / fails schema | `logger.warn`, returns `null` |
+| Empty/whitespace title after cleaning | returns `null` |
+| All rendered messages are redaction placeholders | skip LLM call entirely, return `null` |
+| `setAssistantThreadTitle` fails | warn logged, swallowed; metadata title still persisted |
+| `assistant:write` scope missing | API error → warn logged, swallowed |
+
+**New file `src/connectors/slack/title.ts`:**
+
+```ts
+export async function setAssistantThreadTitle(
+  client: WebClient, channel_id: string, thread_ts: string, title: string
+): Promise<void>
+```
+
+Try/catch around `client.assistant.threads.setTitle(...)`. Errors → `logger.warn('slack-title', ...)`, swallowed. Caller (events.ts) only invokes for DM channels.
+
+---
+
+### Phase 3 — Tests
+
+Follow `pr-tools.test.ts` style (`vi.mock` at top).
+
+**`src/tasks/__tests__/title-generator.test.ts`** — mock `query` from `@anthropic-ai/claude-agent-sdk` as async generator. Cases:
+- success → trimmed title ≤60 chars
+- title with quotes + trailing period → cleaned
+- >60 chars → truncated
+- empty/whitespace from model → `null`
+- `subtype: 'error_during_execution'` → `null`, warn logged
+- thrown query → `null`
+- fully-redacted thread → `query` NOT called, returns `null`
+- mixed thread → external bodies redacted in transcript, internal intact
+- internal author + external attachment → `[forwarded from ...]` label in transcript
+
+**`src/tasks/__tests__/persistence.test.ts`** — direct unit tests on `renderMessageForContext`:
+- plain message → text only
+- message + files → `\n  [Attachments: name (path)]` suffix
+- redacted → exactly `'[redacted: external participant in shared channel]'`
+- internal + external attachment → forwarded label + content
+- multiple attachments, only first external → second folds inline (matches current behavior)
+- empty message + attachments only → no leading newline
+
+Skipping `setAssistantThreadTitle` test (5-line try/catch). Skipping events.ts integration tests — covered by manual verification.
+
+---
+
+### Phase 4 — Wiring
+
+**`src/connectors/slack/events.ts`** — add `generateTitleAndSync` helper at top-level (co-located with sole caller, keeps `task.ts` slim):
+
+```ts
+async function generateTitleAndSync(task: Task, thread: SlackThread): Promise<void> {
+  const title = await generateTaskTitle(thread);
+  if (!title) return;
+  task.metadata.title = title;
+  task.debouncedSave();
+  if (thread.channel.id.startsWith('D')) {
+    await setAssistantThreadTitle(getSlackClient(), thread.channel.id, thread.threadId, title);
+  }
+}
+```
+
+Add imports: `generateTaskTitle`, `setAssistantThreadTitle`, `getSlackClient`, `SlackThread`.
+
+**Trigger guard** — at both call sites in `handleSlackEvent`, immediately after `await task.append(thread)`:
+
+```ts
+if (!task.metadata.title) {
+  generateTitleAndSync(task, thread).catch((err) =>
+    logger.warn('title-generator', `pipeline failed: ${err}`)
+  );
+}
+```
+
+Both sites: existing-task path (~line 376) and new-task path (~line 384). Fire-and-forget — PM agent doesn't block on Haiku.
+
+**Race note:** guard is non-atomic. Two events on same thread within Haiku roundtrip can both fire. Outcome: extra LLM call, second `debouncedSave()` writes same field. Acceptable — no corruption.
+
+---
+
+### Phase 5 — API + CLI surfaces
+
+**`src/connectors/api/routes.ts`** — `GET /api/tasks` (lines 98-108): add `title: metadata.title ?? null` to summary object. `GET /api/tasks/:id` already returns full `metadata` — `title` flows automatically.
+
+**`src/cli/components/TaskList.tsx`** — add `title?: string | null` to `TaskSummary` interface. In render block (lines 175-189): keep current layout (task_id + channel as today), append title trailing after channel when present. Example row:
+
+```
+> [+] task-20260425-2136-abcd  #bot-test  Fix iOS login crash on cold start  3 active
+```
+
+Title text should not be dim (primary content); channel stays as it is. Truncate-end already applies via `wrap="truncate-end"`.
+
+**`src/cli/components/TaskDetail.tsx`** — `detail.metadata` already fetched (line 168). Add `setTitle` state alongside `setStatus`/`setReminder`. Header (lines 343-357): render `metadata.title` prominently when present; fall back to `channel_name`.
+
+---
+
+## Data Flow
+
+```
+Slack DM or channel mention received
+  → events.ts: resolve task (Task.create() OR fetch existing)
+  → task.append(thread)            // messages persisted (with redaction)
+  → if (!task.metadata.title) {
+       fire-and-forget: generateTitleAndSync(task, thread)
+         ├─ generateTaskTitle(thread)          [renders via shared helper, Haiku via query()]
+         ├─ on success: metadata.title = result, debouncedSave()
+         └─ if originating channel is DM:
+              setAssistantThreadTitle(channel_id, thread_ts, title)
+    }
+  → task.sendMessage(...)   // PM / agent not blocked
+```
+
+## Slack API Notes
+
+- `setAssistantThreadTitle` wraps `client.assistant.threads.setTitle({ channel_id, thread_ts, title })`.
+- Required Slack scope: `assistant:write`. Agents & AI Apps feature toggle must be enabled for the bot.
+- Caller responsibility: only invoke for DM channels (channel_id starts with `D`). Channel-mention tasks skip Slack-side title sync.
+
+## Critical Files
+
+- [src/types/task.ts](src/types/task.ts) — TaskMetadata field
+- [src/tasks/persistence.ts](src/tasks/persistence.ts) — extract renderMessageForContext
+- [src/tasks/title-generator.ts](src/tasks/title-generator.ts) — new
+- [src/connectors/slack/title.ts](src/connectors/slack/title.ts) — new
+- [src/connectors/slack/events.ts](src/connectors/slack/events.ts) — wiring
+- [src/connectors/api/routes.ts](src/connectors/api/routes.ts) — list response
+- [src/cli/components/TaskList.tsx](src/cli/components/TaskList.tsx) — list rendering
+- [src/cli/components/TaskDetail.tsx](src/cli/components/TaskDetail.tsx) — header rendering
+
+## Reused Utilities
+
+- `renderMessageForContext` (extracted from `appendSlackMessage`) — single source of truth for redaction + forwarded-attachment rendering
+- `isExternalUser` from `src/connectors/slack/client.ts:792`
+- `getSlackClient` from `src/connectors/slack/client.ts:105`
+- `query` pattern from `src/mcp/research-tools.ts:53-102`
+- `toJSONSchema` from `zod` (matches research-tools.ts)
+- `task.debouncedSave()` and `task.metadata` mutation pattern (already used by `sendSharedChannelWarnings`)
+
+## Verification
+
+End-to-end manual checks after Phase 5:
+
+1. **DM new task** — DM bot with substantive content. Within ~10s: CLI list shows title; Slack DM thread title updates; `metadata.json` has `.title`; knowledge.log byte-identical to pre-refactor (diff old log).
+2. **Channel mention** — `@archie ...` in public channel. Title in metadata + CLI; Slack thread title NOT updated (channel_id starts with `C`).
+3. **Pre-feature task resume** — old task without `title`, send follow-up. Title generated; subsequent messages do NOT re-trigger (no extra warns in logs).
+4. **API key missing** — unset `ANTHROPIC_API_KEY` for events scope. Task creates; PM runs; `title-generator` warn logged; CLI falls back to channel_name.
+5. **Fully-redacted thread** — Slack-Connect channel, only external posters. Title generator returns `null` without `query()` call (verify via log absence). CLI falls back.
+6. `npm run typecheck` passes after each phase.
+7. `npm test` passes (vitest) — new tests + existing 2 test files green.
+
+## Decisions Confirmed
+
+- **TaskList layout:** channel first, title trailing (keeps current layout intact, appends title after channel).
+- **Race lock:** none. Non-atomic guard is acceptable; rare duplicate Haiku call lands on same field, no corruption.
+- **`setAssistantThreadTitle` test:** skipped (wrapper is 5 lines).
+
+## Outstanding Risk
+
+- `assistant:write` scope must be on deployed bot token. If missing, `setTitle` returns API error → swallowed warn, metadata title still persists. Worth one-time scope audit before rollout.

--- a/slack-manifest.yaml
+++ b/slack-manifest.yaml
@@ -6,6 +6,9 @@ features:
   bot_user:
     display_name: Archie
     always_online: true
+  assistant_view:
+    assistant_description: "Autonomous Responsive and Collaborative Hyper Intelligent Employee"
+    suggested_prompts: []
 oauth_config:
   scopes:
     bot:
@@ -21,6 +24,7 @@ oauth_config:
       - usergroups:read
       - files:read
       - reactions:write
+      - assistant:write
 settings:
   interactivity:
     is_enabled: true
@@ -29,6 +33,7 @@ settings:
     request_url: https://archie.sweatco.team/webhooks/slack
     bot_events:
       - app_mention
+      - assistant_thread_started
       - message.channels
       - message.im
   org_deploy_enabled: false

--- a/src/cli/components/TaskDetail.tsx
+++ b/src/cli/components/TaskDetail.tsx
@@ -74,6 +74,7 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string>('');
   const [reminder, setReminder] = useState<{ trigger_at: string; reason: string } | null>(null);
+  const [title, setTitle] = useState<string | null>(null);
   const prevOnEvent = useRef<SystemEvent | null>(null);
   const prevOnConnect = useRef<boolean | undefined>(undefined);
   const scrollRef = useRef<ScrollViewRef>(null);
@@ -167,6 +168,7 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
       ]);
       setStatus(detail.metadata?.status || '');
       setReminder(detail.metadata?.reminder ?? null);
+      setTitle(detail.metadata?.title ?? null);
       setAgents(detail.agents || []);
       setEvents(eventsResult.events);
       setEventCursor(eventsResult.total);
@@ -346,6 +348,7 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
       <Box paddingX={1}>
         <Text wrap="truncate-end">
           <Text bold>Task: {taskId}</Text>
+          {title && <Text>  {title}</Text>}
           <Text dimColor>  status: </Text>
           <Text color={status === 'in_progress' ? 'yellow' : status === 'completed' ? 'green' : 'red'}>
             {status}

--- a/src/cli/components/TaskList.tsx
+++ b/src/cli/components/TaskList.tsx
@@ -17,6 +17,7 @@ interface TaskSummary {
   participants: string[];
   created_at: string;
   updated_at: string;
+  title: string | null;
   channel_name: string | null;
   reminder: { trigger_at: string; reason: string } | null;
   agents?: { agentId: string; active: boolean }[];
@@ -183,6 +184,7 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
                 {' '}{task.task_id}
               </Text>
               <Text dimColor>  {channel}</Text>
+              {task.title && <Text>  {task.title}</Text>}
               {activeAgents > 0 && <Text color="green">  {activeAgents} active</Text>}
               {task.reminder && <Text color="magenta">  ⏰ {formatDateTime(task.reminder.trigger_at)} — {task.reminder.reason.length > 50 ? task.reminder.reason.slice(0, 50) + '…' : task.reminder.reason}</Text>}
             </Text>

--- a/src/connectors/api/routes.ts
+++ b/src/connectors/api/routes.ts
@@ -102,6 +102,7 @@ export function mountApiRoutes(app: Application): void {
           participants: metadata.participants,
           created_at: metadata.created_at,
           updated_at: metadata.updated_at,
+          title: metadata.title ?? null,
           channel_name,
           reminder: metadata.reminder ?? null,
           agents: activeTask ? activeTask.getAgentStatus() : [],

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -26,12 +26,16 @@ import {
   isExternalUser,
   isChannelShared,
   postEphemeral,
+  getSlackClient,
 } from './client.js';
 import { Task } from '../../tasks/task.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
 import { logger } from '../../system/logger.js';
 import { getIsShuttingDown } from '../../system/shutdown.js';
 import { findTaskByThread } from '../../tasks/persistence.js';
+import { generateTaskTitle } from '../../tasks/title-generator.js';
+import { setAssistantThreadTitle } from './title.js';
+import type { SlackThread } from '../../types/task.js';
 // import { triageSlackMessage } from '../../system/triage.js';
 
 /**
@@ -250,6 +254,31 @@ export async function mountSlackApp(
 
 
 // ============================================================================
+// Task Title Pipeline
+// ============================================================================
+
+/**
+ * Fire-and-forget title generation + Slack sync.
+ *
+ * Generates a Haiku-authored title for the task and persists it on metadata.
+ * For DM-originated tasks, also pushes the title to Slack via
+ * `assistant.threads.setTitle` so the bot's DM list shows a meaningful name.
+ *
+ * Errors are swallowed by the called helpers — title is best-effort.
+ */
+async function generateTitleAndSync(task: Task, thread: SlackThread): Promise<void> {
+  const title = await generateTaskTitle(thread);
+  if (!title) return;
+
+  task.metadata.title = title;
+  task.debouncedSave();
+
+  if (thread.channel.id.startsWith('D')) {
+    await setAssistantThreadTitle(getSlackClient(), thread.channel.id, thread.threadId, title);
+  }
+}
+
+// ============================================================================
 // Slack Routing
 // ============================================================================
 
@@ -374,6 +403,11 @@ async function handleSlackEvent(event: {
 
     // Thread reply to an existing task — route to it
     await task.append(thread);
+    if (!task.metadata.title) {
+      generateTitleAndSync(task, thread).catch((err) =>
+        logger.warn('title-generator', `pipeline failed: ${err}`),
+      );
+    }
     await sendSharedChannelWarnings(task, event.channel, threadId, thread, shared);
     await task.sendMessage(AGENT_PROMPTS.existingTask);
   } else if (event.type === 'app_mention' || event.channel.startsWith('D')) {
@@ -382,6 +416,11 @@ async function handleSlackEvent(event: {
     // Bot was @mentioned, or this is a DM — start a new task
     const task = await Task.create();
     await task.append(thread);
+    if (!task.metadata.title) {
+      generateTitleAndSync(task, thread).catch((err) =>
+        logger.warn('title-generator', `pipeline failed: ${err}`),
+      );
+    }
     await sendSharedChannelWarnings(task, event.channel, threadId, thread, shared);
     await task.sendMessage(AGENT_PROMPTS.newTask);
   }

--- a/src/connectors/slack/title.ts
+++ b/src/connectors/slack/title.ts
@@ -1,0 +1,26 @@
+/**
+ * Slack assistant thread title wrapper.
+ *
+ * Wraps `assistant.threads.setTitle` for DM-originated tasks. Errors are
+ * logged and swallowed — title is still persisted in metadata even if Slack
+ * sync fails.
+ *
+ * Required Slack scope: `assistant:write`. The Agents & AI Apps feature
+ * toggle must be enabled on the bot.
+ */
+
+import type { WebClient } from '@slack/web-api';
+import { logger } from '../../system/logger.js';
+
+export async function setAssistantThreadTitle(
+  client: WebClient,
+  channel_id: string,
+  thread_ts: string,
+  title: string,
+): Promise<void> {
+  try {
+    await client.assistant.threads.setTitle({ channel_id, thread_ts, title });
+  } catch (err) {
+    logger.warn('slack-title', `setTitle failed for ${channel_id}/${thread_ts}: ${err}`);
+  }
+}

--- a/src/tasks/__tests__/persistence.test.ts
+++ b/src/tasks/__tests__/persistence.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for renderMessageForContext.
+ *
+ * Direct tests on the pure rendering helper extracted from appendSlackMessage.
+ * Covers redaction, forwarded-attachment labels, file lists, edge cases.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../connectors/slack/client.js', () => ({
+  isExternalUser: (user: { teamId?: string; isRestricted?: boolean; isUltraRestricted?: boolean }) => {
+    if (user.isRestricted || user.isUltraRestricted) return true;
+    if (user.teamId && user.teamId !== 'T_HOME') return true;
+    return false;
+  },
+  formatSlackChannelRef: vi.fn(),
+  formatSlackChannelDisplay: vi.fn(),
+}));
+
+vi.mock('../../system/logger.js', () => ({
+  logger: { warn: vi.fn(), system: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../system/event-bus.js', () => ({
+  emitEvent: vi.fn(),
+  onEvent: vi.fn(),
+}));
+
+vi.mock('../../system/workdir.js', () => ({
+  SESSIONS_DIR: '/tmp/sessions',
+}));
+
+vi.mock('./task.js', () => ({
+  activeTasks: new Map(),
+}));
+
+import { renderMessageForContext } from '../persistence.js';
+
+describe('renderMessageForContext', () => {
+  it('renders plain message text with no attachments', () => {
+    const out = renderMessageForContext({ text: 'hello world' }, { redacted: false });
+    expect(out).toBe('hello world');
+  });
+
+  it('appends file list as trailing [Attachments] line', () => {
+    const out = renderMessageForContext(
+      {
+        text: 'see file',
+        files: [
+          { id: 'F1', name: 'a.txt', mimetype: 'text/plain', url_private: '', localPath: '/p/a.txt' },
+        ],
+      },
+      { redacted: false },
+    );
+    expect(out).toBe('see file\n  [Attachments: a.txt (/p/a.txt)]');
+  });
+
+  it('returns the redaction placeholder when redacted is true', () => {
+    const out = renderMessageForContext(
+      {
+        text: 'should not appear',
+        attachments: [{ text: 'also hidden' }],
+      },
+      { redacted: true },
+    );
+    expect(out).toBe('[redacted: external participant in shared channel]');
+  });
+
+  it('renders externally-authored attachment under a forwarded-from label', () => {
+    const out = renderMessageForContext(
+      {
+        text: 'check this out',
+        attachments: [
+          {
+            text: 'external content body',
+            author: {
+              id: 'UEXT',
+              username: 'ext',
+              realName: 'External Person',
+              teamId: 'T_OTHER',
+            },
+          },
+        ],
+      },
+      { redacted: false },
+    );
+    expect(out).toBe(
+      'check this out\n[forwarded from @<UEXT:External Person> — external, team T_OTHER]\nexternal content body',
+    );
+  });
+
+  it('only labels first external attachment; later externals fold inline', () => {
+    const out = renderMessageForContext(
+      {
+        text: 'top',
+        attachments: [
+          {
+            text: 'first ext',
+            author: { id: 'U1', username: 'a', realName: 'A', teamId: 'T_OTHER' },
+          },
+          {
+            text: 'second ext',
+            author: { id: 'U2', username: 'b', realName: 'B', teamId: 'T_OTHER' },
+          },
+        ],
+      },
+      { redacted: false },
+    );
+    // top, second ext (folded inline), then forwarded block for first
+    expect(out).toBe(
+      'top\nsecond ext\n[forwarded from @<U1:A> — external, team T_OTHER]\nfirst ext',
+    );
+  });
+
+  it('renders empty text + only attachments without leading newline', () => {
+    const out = renderMessageForContext(
+      {
+        text: '',
+        attachments: [{ text: 'inline body' }],
+      },
+      { redacted: false },
+    );
+    expect(out).toBe('inline body');
+  });
+
+  it('omits team suffix when external author has no teamId', () => {
+    const out = renderMessageForContext(
+      {
+        text: 'top',
+        attachments: [
+          {
+            text: 'guest content',
+            author: { id: 'UG', username: 'g', realName: 'G', isRestricted: true },
+          },
+        ],
+      },
+      { redacted: false },
+    );
+    expect(out).toBe('top\n[forwarded from @<UG:G> — external]\nguest content');
+  });
+});

--- a/src/tasks/__tests__/title-generator.test.ts
+++ b/src/tasks/__tests__/title-generator.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for generateTaskTitle.
+ *
+ * Mocks the Claude Agent SDK's query() with an async generator and asserts:
+ * - cleaned/truncated output on success
+ * - null on error subtypes, throws, empty results, fully-redacted threads
+ * - external authors redacted in transcript before being passed to query()
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SlackThread } from '../../types/index.js';
+
+// ---- Mocks ----
+
+const state = vi.hoisted(() => ({
+  queryEvents: [] as any[],
+  queryShouldThrow: false,
+  lastQueryArgs: null as any,
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn((args: any) => {
+    state.lastQueryArgs = args;
+    if (state.queryShouldThrow) {
+      throw new Error('boom');
+    }
+    return (async function* () {
+      for (const e of state.queryEvents) yield e;
+    })();
+  }),
+}));
+
+vi.mock('../../connectors/slack/client.js', () => ({
+  isExternalUser: (user: { teamId?: string; isRestricted?: boolean; isUltraRestricted?: boolean }) => {
+    if (user.isRestricted || user.isUltraRestricted) return true;
+    if (user.teamId && user.teamId !== 'T_HOME') return true;
+    return false;
+  },
+  formatSlackChannelRef: vi.fn(),
+  formatSlackChannelDisplay: vi.fn(),
+}));
+
+vi.mock('../../system/logger.js', () => ({
+  logger: { warn: vi.fn(), system: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../system/event-bus.js', () => ({
+  emitEvent: vi.fn(),
+  onEvent: vi.fn(),
+}));
+
+vi.mock('../../system/workdir.js', () => ({
+  SESSIONS_DIR: '/tmp/sessions',
+}));
+
+vi.mock('../task.js', () => ({
+  activeTasks: new Map(),
+}));
+
+import { generateTaskTitle } from '../title-generator.js';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { logger } from '../../system/logger.js';
+const warnSpy = logger.warn as unknown as ReturnType<typeof vi.fn>;
+
+// ---- Helpers ----
+
+function makeThread(overrides?: Partial<SlackThread>): SlackThread {
+  return {
+    threadId: '1.0',
+    channel: { id: 'D1', name: 'DM' },
+    shared: false,
+    currentMessageTs: '1.0',
+    messages: [
+      {
+        ts: '1.0',
+        text: 'hello, can you help fix the broken auth flow on Android',
+        user: { id: 'U1', username: 'me', realName: 'Egor', teamId: 'T_HOME' },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function successEvent(title: string): any {
+  return { type: 'result', subtype: 'success', structured_output: { title } };
+}
+
+beforeEach(() => {
+  state.queryEvents = [];
+  state.queryShouldThrow = false;
+  state.lastQueryArgs = null;
+  warnSpy.mockClear();
+  (query as any).mockClear();
+});
+
+// ---- Tests ----
+
+describe('generateTaskTitle', () => {
+  it('returns trimmed title on success', async () => {
+    state.queryEvents = [successEvent('  Fix auth flow on Android  ')];
+    const title = await generateTaskTitle(makeThread());
+    expect(title).toBe('Fix auth flow on Android');
+  });
+
+  it('strips surrounding quotes and trailing punctuation', async () => {
+    state.queryEvents = [successEvent('"Fix auth flow on Android."')];
+    const title = await generateTaskTitle(makeThread());
+    expect(title).toBe('Fix auth flow on Android');
+  });
+
+  it('truncates titles longer than 60 chars', async () => {
+    state.queryEvents = [successEvent('A'.repeat(120))];
+    const title = await generateTaskTitle(makeThread());
+    expect(title).not.toBeNull();
+    expect(title!.length).toBe(60);
+  });
+
+  it('returns null when model returns empty/whitespace', async () => {
+    state.queryEvents = [successEvent('   ')];
+    const title = await generateTaskTitle(makeThread());
+    expect(title).toBeNull();
+  });
+
+  it('returns null on error_during_execution and logs a warning', async () => {
+    state.queryEvents = [{ type: 'result', subtype: 'error_during_execution' }];
+    const title = await generateTaskTitle(makeThread());
+    expect(title).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns null on error_max_structured_output_retries', async () => {
+    state.queryEvents = [{ type: 'result', subtype: 'error_max_structured_output_retries' }];
+    const title = await generateTaskTitle(makeThread());
+    expect(title).toBeNull();
+  });
+
+  it('returns null when query() throws', async () => {
+    state.queryShouldThrow = true;
+    const title = await generateTaskTitle(makeThread());
+    expect(title).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('skips LLM and returns null when thread is fully redacted', async () => {
+    const thread = makeThread({
+      shared: true,
+      messages: [
+        {
+          ts: '1.0',
+          text: 'external talk',
+          user: { id: 'UEXT', username: 'ext', realName: 'External', teamId: 'T_OTHER' },
+        },
+      ],
+    });
+    const title = await generateTaskTitle(thread);
+    expect(title).toBeNull();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('redacts external authors in transcript but keeps internal intact', async () => {
+    state.queryEvents = [successEvent('Mixed thread title')];
+    const thread = makeThread({
+      shared: true,
+      messages: [
+        {
+          ts: '1.0',
+          text: 'should be redacted',
+          user: { id: 'UEXT', username: 'ext', realName: 'External', teamId: 'T_OTHER' },
+        },
+        {
+          ts: '2.0',
+          text: 'internal subject',
+          user: { id: 'UINT', username: 'me', realName: 'Egor', teamId: 'T_HOME' },
+        },
+      ],
+    });
+    await generateTaskTitle(thread);
+    expect(query).toHaveBeenCalled();
+    const transcript = state.lastQueryArgs.prompt as string;
+    expect(transcript).toContain('[external]: [redacted: external participant in shared channel]');
+    expect(transcript).toContain('[Egor]: internal subject');
+    expect(transcript).not.toContain('should be redacted');
+  });
+
+  it('includes forwarded-from label for externally-authored attachment from internal author', async () => {
+    state.queryEvents = [successEvent('Forwarded title')];
+    const thread = makeThread({
+      shared: false,
+      messages: [
+        {
+          ts: '1.0',
+          text: 'fyi',
+          user: { id: 'UINT', username: 'me', realName: 'Egor', teamId: 'T_HOME' },
+          attachments: [
+            {
+              text: 'forwarded body',
+              author: { id: 'UEXT', username: 'ext', realName: 'External', teamId: 'T_OTHER' },
+            },
+          ],
+        },
+      ],
+    });
+    await generateTaskTitle(thread);
+    const transcript = state.lastQueryArgs.prompt as string;
+    expect(transcript).toContain('[forwarded from @<UEXT:External> — external, team T_OTHER]');
+    expect(transcript).toContain('forwarded body');
+  });
+
+  it('uses haiku model and json_schema output format', async () => {
+    state.queryEvents = [successEvent('A title')];
+    await generateTaskTitle(makeThread());
+    expect(state.lastQueryArgs.options.model).toBe('haiku');
+    expect(state.lastQueryArgs.options.outputFormat?.type).toBe('json_schema');
+    expect(state.lastQueryArgs.options.tools).toEqual([]);
+  });
+});

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -173,15 +173,58 @@ function formatLogEntry(entry: LogEntry): string {
 }
 
 /**
- * Append a Slack message to the knowledge log.
+ * Render the body of a Slack message for context (knowledge log, title generator, etc.).
  *
- * Renders one of three layouts based on the structured data:
- * - Redacted (external author): body replaced with a fixed placeholder, name
- *   masked as `external` in the source line.
- * - With forwarded-from-external attachment: forwarder's text first, then a
+ * Single source of truth for redaction + forwarded-attachment rendering.
+ * - Redacted: fixed placeholder.
+ * - With externally-authored attachment: forwarder's text first, then a
  *   provenance label, then the forwarded content. Other (non-external)
  *   attachments fold into the inline body.
- * - Normal: just the author's text plus inline attachments and file list.
+ * - Normal: author's text plus inline attachments and file list.
+ */
+export function renderMessageForContext(
+  msg: { text: string; files?: SlackFile[]; attachments?: SlackAttachment[] },
+  options: { redacted: boolean }
+): string {
+  if (options.redacted) {
+    return '[redacted: external participant in shared channel]';
+  }
+
+  const inlineParts: string[] = [];
+  if (msg.text) inlineParts.push(msg.text);
+
+  let forwardedBlock = '';
+  for (const att of msg.attachments ?? []) {
+    if (att.author && isExternalUser(att.author)) {
+      // Render the externally-authored attachment under a provenance label.
+      // Only the first one gets the label block; subsequent ones (rare)
+      // fold inline so the agent still sees them.
+      if (!forwardedBlock) {
+        const teamSuffix = att.author.teamId ? `, team ${att.author.teamId}` : '';
+        const label = `[forwarded from @<${att.author.id}:${att.author.realName}> — external${teamSuffix}]`;
+        forwardedBlock = `${label}\n${att.text}`;
+        continue;
+      }
+    }
+    if (att.text) inlineParts.push(att.text);
+  }
+  if (forwardedBlock) inlineParts.push(forwardedBlock);
+
+  let fullMessage = inlineParts.join('\n');
+
+  if (msg.files && msg.files.length > 0) {
+    const fileInfo = msg.files.map(f => {
+      const pathInfo = f.localPath ? ` (${f.localPath})` : '';
+      return `${f.name}${pathInfo}`;
+    }).join(', ');
+    fullMessage += `\n  [Attachments: ${fileInfo}]`;
+  }
+
+  return fullMessage;
+}
+
+/**
+ * Append a Slack message to the knowledge log.
  */
 export async function appendSlackMessage(
   taskId: string,
@@ -194,41 +237,10 @@ export async function appendSlackMessage(
   options?: { redacted?: boolean }
 ): Promise<void> {
   const redacted = options?.redacted === true;
-
-  let fullMessage: string;
-  if (redacted) {
-    fullMessage = '[redacted: external participant in shared channel]';
-  } else {
-    const inlineParts: string[] = [];
-    if (message) inlineParts.push(message);
-
-    let forwardedBlock = '';
-    for (const att of attachments ?? []) {
-      if (att.author && isExternalUser(att.author)) {
-        // Render the externally-authored attachment under a provenance label.
-        // Only the first one gets the label block; subsequent ones (rare)
-        // fold inline so the agent still sees them.
-        if (!forwardedBlock) {
-          const teamSuffix = att.author.teamId ? `, team ${att.author.teamId}` : '';
-          const label = `[forwarded from @<${att.author.id}:${att.author.realName}> — external${teamSuffix}]`;
-          forwardedBlock = `${label}\n${att.text}`;
-          continue;
-        }
-      }
-      if (att.text) inlineParts.push(att.text);
-    }
-    if (forwardedBlock) inlineParts.push(forwardedBlock);
-
-    fullMessage = inlineParts.join('\n');
-
-    if (files && files.length > 0) {
-      const fileInfo = files.map(f => {
-        const pathInfo = f.localPath ? ` (${f.localPath})` : '';
-        return `${f.name}${pathInfo}`;
-      }).join(', ');
-      fullMessage += `\n  [Attachments: ${fileInfo}]`;
-    }
-  }
+  const fullMessage = renderMessageForContext(
+    { text: message, files, attachments },
+    { redacted },
+  );
 
   // Mask the author name in the source line when the body is redacted, so the
   // log doesn't leak the external user's display name even though we keep it

--- a/src/tasks/title-generator.ts
+++ b/src/tasks/title-generator.ts
@@ -1,0 +1,135 @@
+/**
+ * Title Generator
+ *
+ * Generates a concise, AI-authored title for a task from its initial Slack
+ * thread. Single Haiku call via the Claude Agent SDK with structured JSON
+ * output. Returns null on any failure (logged, not thrown) — caller treats
+ * absence of a title as a benign fallback to channel_name.
+ */
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { z, toJSONSchema } from 'zod';
+import type { SlackThread } from '../types/index.js';
+import { renderMessageForContext } from './persistence.js';
+import { isExternalUser } from '../connectors/slack/client.js';
+import { logger } from '../system/logger.js';
+
+const REDACTION_PLACEHOLDER = '[redacted: external participant in shared channel]';
+
+const TitleSchema = z.object({
+  title: z.string(),
+});
+const rawTitleSchema = toJSONSchema(TitleSchema) as Record<string, unknown>;
+// Strip JSON Schema dialect URL — some SDK validators reject it.
+const { $schema: _drop, ...titleJsonSchema } = rawTitleSchema;
+
+const SYSTEM_PROMPT = `You generate a concise title for a task based on the initial conversation that started it.
+
+Rules:
+- Maximum 60 characters
+- Free-form style (imperative, noun phrase, question — whatever fits)
+- No quotes, no trailing punctuation
+- Match the conversation's primary language
+- Capture the actual subject, not generic phrases
+
+Respond with JSON only.`;
+
+/**
+ * Render the thread as a transcript for the title generator. Per-message
+ * redaction matches what the agent sees in knowledge.log (parity via the
+ * shared renderMessageForContext helper).
+ */
+function buildTranscript(thread: SlackThread): { transcript: string; hasUsableContent: boolean } {
+  const lines: string[] = [];
+  let hasUsableContent = false;
+
+  for (const msg of thread.messages) {
+    const redacted = thread.shared && isExternalUser(msg.user);
+    const body = renderMessageForContext(msg, { redacted });
+    const author = redacted ? 'external' : msg.user.realName;
+    lines.push(`[${author}]: ${body}`);
+    if (!redacted && body.trim() !== '' && body !== REDACTION_PLACEHOLDER) {
+      hasUsableContent = true;
+    }
+  }
+
+  return { transcript: lines.join('\n'), hasUsableContent };
+}
+
+function cleanTitle(raw: string): string | null {
+  let t = raw.trim();
+  if (!t) return null;
+  // Strip surrounding matching quotes (single, double, or smart)
+  const quotePairs: Array<[string, string]> = [['"', '"'], ["'", "'"], ['“', '”'], ['‘', '’']];
+  for (const [open, close] of quotePairs) {
+    if (t.startsWith(open) && t.endsWith(close) && t.length >= 2) {
+      t = t.slice(1, -1).trim();
+      break;
+    }
+  }
+  // Strip trailing punctuation
+  t = t.replace(/[.!?…]+$/u, '').trim();
+  if (!t) return null;
+  if (t.length > 60) t = t.slice(0, 60).trim();
+  return t || null;
+}
+
+/**
+ * Generate a title for a task from its initial Slack thread.
+ * Returns null on any failure (network error, malformed output, empty result,
+ * fully-redacted input).
+ */
+export async function generateTaskTitle(thread: SlackThread): Promise<string | null> {
+  try {
+    const { transcript, hasUsableContent } = buildTranscript(thread);
+    if (!hasUsableContent) {
+      return null;
+    }
+
+    let result: z.infer<typeof TitleSchema> | null = null;
+
+    const prompt = `Generate a concise title for the following conversation.
+
+${transcript}
+
+Respond with JSON only.`;
+
+    for await (const event of query({
+      prompt,
+      options: {
+        model: 'haiku',
+        systemPrompt: SYSTEM_PROMPT,
+        executable: 'node',
+        env: {
+          NODE_ENV: process.env.NODE_ENV || 'development',
+          ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+          PATH: process.env.PATH,
+        },
+        tools: [],
+        maxTurns: 2,
+        outputFormat: {
+          type: 'json_schema',
+          schema: titleJsonSchema,
+        },
+      },
+    })) {
+      if (event.type !== 'result') continue;
+      if (event.subtype === 'success') {
+        const parsed = TitleSchema.safeParse((event as any).structured_output);
+        if (parsed.success) {
+          result = parsed.data;
+        } else {
+          logger.warn('title-generator', `schema validation failed: ${parsed.error.message}`);
+        }
+      } else {
+        logger.warn('title-generator', `haiku call failed: ${event.subtype}`);
+      }
+    }
+
+    if (!result) return null;
+    return cleanTitle(result.title);
+  } catch (err) {
+    logger.warn('title-generator', `unexpected failure: ${err}`);
+    return null;
+  }
+}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -142,6 +142,7 @@ export interface TaskMetadata {
   participants: AgentName[];
   channels: Record<string, Channel>;   // Active message delivery targets, keyed by channel ID
   default_channel: string | null;      // Channel ID of the originating channel (null for CLI-originated tasks)
+  title?: string;                      // AI-generated one-line summary; absent on pre-feature tasks
   slack_threads?: SlackThreadRef[];    // Legacy — only present on old tasks loaded from disk, removed after migration
   agent_sessions: Record<string, AgentSessionState | string>; // union handles legacy string values on disk
   repositories: Record<string, RepositoryInfo>;


### PR DESCRIPTION
## Summary

- Generate concise Haiku-authored titles at task creation, persisted on `TaskMetadata.title`. Trigger fire-and-forget after every `task.append(thread)` in events.ts, guarded by `if (!task.metadata.title)` so pre-feature tasks pick up titles on next interaction.
- Surface in CLI list + detail header and `GET /api/tasks` response. DM-originated tasks also push title to Slack via `assistant.threads.setTitle`.
- Extracts `renderMessageForContext()` from `appendSlackMessage` so the title generator and knowledge log share a single redaction/forwarded-attachment renderer.
- Adds `assistant:write` scope + `assistant_view` + `assistant_thread_started` event to Slack manifest.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 40/40 passing (18 new: 7 renderMessageForContext + 11 generateTaskTitle)
- [x] Manual: DM bot, verify title appears in CLI list + Slack DM thread title
- [x] Manual: `@archie` channel mention, verify title in CLI but no Slack-side update
- [x] Manual: pre-feature task resume, verify one-time title generation
- [x] Manual: confirm `assistant:write` scope on deployed bot token

🤖 Generated with [Claude Code](https://claude.com/claude-code)