### PR TITLE
Send Slack messages as native markdown blocks

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -69,7 +69,6 @@ Archie (Autonomous Responsive and Collaborative Hyper Intelligent Employee) is a
 | GitHub Integration | `@octokit/app` ^16.1.2, `@octokit/webhooks` ^14.2.0 |
 | Schema Validation | `zod` ^4.3.6, `zod-to-json-schema` ^3.25.0 |
 | Prompt Parsing | `gray-matter` ^4.0.3 (frontmatter extraction) |
-| Markdown | `slackify-markdown` ^4.5.0 (Slack formatting) |
 | Build | `tsc` (TypeScript compiler), `tsx` (dev mode) |
 | Deployment | Docker Compose (dev + prod configurations) |
 

--- a/docs/architecture/slack-integration.md
+++ b/docs/architecture/slack-integration.md
@@ -109,7 +109,7 @@ The PM agent communicates with users via the `post_to_slack` MCP tool, defined i
 1. The tool callback (`onPostToSlack` in `src/tasks/task.ts`) invokes the Slack post callback.
 2. The callback loads the task's metadata and calls `postToThreads()` from `src/connectors/slack/client.ts`.
 3. `postToThreads()` iterates over all `SlackThread` entries in the task metadata and posts the message to each one.
-4. Before posting, the message text is converted from standard Markdown to Slack's `mrkdwn` format using the `slackify-markdown` library.
+4. The message is sent as a Slack Block Kit `markdown` block (`{ type: 'markdown', text }`), which Slack renders natively as CommonMark — supporting tables, fenced code blocks, lists, blockquotes, and links without manual conversion. See [Markdown block reference](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/). Per-message payload is capped at 12,000 characters; `assertSlackMarkdownLength()` in `src/connectors/slack/client.ts` enforces this before any logging or send so rejected payloads do not pollute `knowledge.log`.
 5. The message is also logged to the task's `knowledge.log` as a decision entry.
 
 The PM agent is the only agent with access to `post_to_slack`. Repo agents communicate findings back to PM via `send_message_to_agent`, and PM decides what to relay to the user.

--- a/docs/architecture/slack-integration.md
+++ b/docs/architecture/slack-integration.md
@@ -107,10 +107,9 @@ See `src/connectors/slack/events.ts`, `handleExistingTask()` -- specifically the
 The PM agent communicates with users via the `post_to_slack` MCP tool, defined in `src/agents/tools.ts`. When the PM calls this tool:
 
 1. The tool callback (`onPostToSlack` in `src/tasks/task.ts`) invokes the Slack post callback.
-2. The callback loads the task's metadata and calls `postToThreads()` from `src/connectors/slack/client.ts`.
-3. `postToThreads()` iterates over all `SlackThread` entries in the task metadata and posts the message to each one.
-4. The message is sent as a Slack Block Kit `markdown` block (`{ type: 'markdown', text }`), which Slack renders natively as CommonMark — supporting tables, fenced code blocks, lists, blockquotes, and links without manual conversion. See [Markdown block reference](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/). Per-message payload is capped at 12,000 characters; `assertSlackMarkdownLength()` in `src/connectors/slack/client.ts` enforces this before any logging or send so rejected payloads do not pollute `knowledge.log`.
-5. The message is also logged to the task's `knowledge.log` as a decision entry.
+2. The callback loads the task's metadata and calls `postSlackMessage()` from `src/connectors/slack/client.ts` for each linked target — replying inside an existing thread when `threadTs` is supplied, or starting a new top-level message otherwise.
+3. The message is sent as a Slack Block Kit `markdown` block (`{ type: 'markdown', text }`), which Slack renders natively as CommonMark — supporting headings, tables, fenced code blocks, lists, blockquotes, task lists, and links without manual conversion. See [Markdown block reference](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/). Per-message payload is capped at 12,000 characters; `postSlackMessage()` enforces this and throws `SlackMarkdownLimitError` on overflow.
+4. On a successful send, the message is logged to the task's `knowledge.log` as a decision entry. A failed send (length limit, transport error) skips the log so rejected payloads never reach `knowledge.log` or the event bus, and the agent receives split-and-retry guidance via the tool response.
 
 The PM agent is the only agent with access to `post_to_slack`. Repo agents communicate findings back to PM via `send_message_to_agent`, and PM decides what to relay to the user.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "ink-text-input": "^6.0.0",
         "picocolors": "^1.1.1",
         "react": "^18.3.1",
-        "slackify-markdown": "^4.5.0",
         "zod": "^4.3.6",
         "zod-to-json-schema": "^3.25.0"
       },
@@ -3097,15 +3096,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/mdast": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
-      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2"
-      }
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -3179,12 +3169,6 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/unist": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3466,16 +3450,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -3556,16 +3530,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/ccount": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
-      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3586,36 +3550,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/character-entities": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-reference-invalid": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chrono-node": {
@@ -4039,18 +3973,6 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -4205,12 +4127,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
@@ -4714,63 +4630,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-alphabetical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-alphanumerical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-decimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-electron": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
@@ -4798,16 +4657,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-hexadecimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-in-ci": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
@@ -4821,15 +4670,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-promise": {
@@ -5264,16 +5104,6 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
-    "node_modules/longest-streak": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5296,19 +5126,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/markdown-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-      "license": "MIT",
-      "dependencies": {
-        "repeat-string": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5316,138 +5133,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
-      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "micromark": "~2.11.0",
-        "parse-entities": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
-      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-gfm-autolink-literal": "^0.1.0",
-        "mdast-util-gfm-strikethrough": "^0.2.0",
-        "mdast-util-gfm-table": "^0.1.0",
-        "mdast-util-gfm-task-list-item": "^0.1.0",
-        "mdast-util-to-markdown": "^0.6.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
-      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
-      "license": "MIT",
-      "dependencies": {
-        "ccount": "^1.0.0",
-        "mdast-util-find-and-replace": "^1.1.0",
-        "micromark": "^2.11.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
-      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-to-markdown": "^0.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
-      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "markdown-table": "^2.0.0",
-        "mdast-util-to-markdown": "~0.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
-      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-to-markdown": "~0.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
-      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "longest-streak": "^2.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.0.0",
-        "zwitch": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -5469,106 +5154,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/micromark": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.0.0",
-        "parse-entities": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
-      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.0",
-        "micromark-extension-gfm-autolink-literal": "~0.5.0",
-        "micromark-extension-gfm-strikethrough": "~0.6.5",
-        "micromark-extension-gfm-table": "~0.4.0",
-        "micromark-extension-gfm-tagfilter": "~0.3.0",
-        "micromark-extension-gfm-task-list-item": "~0.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
-      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
-      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
-      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
-      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
-      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mime-db": {
@@ -5757,24 +5342,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/parse-entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/parseurl": {
@@ -5977,55 +5544,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/remark-gfm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
-      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-gfm": "^0.1.0",
-        "micromark-extension-gfm": "^0.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-parse": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^0.8.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-stringify": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
-      "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-to-markdown": "^0.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/require-from-string": {
@@ -6364,21 +5882,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
-    "node_modules/slackify-markdown": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/slackify-markdown/-/slackify-markdown-4.5.0.tgz",
-      "integrity": "sha512-qr/BvNVzC6Gok1agvGP2CRou60+M8eFON/bJERZ64YsvKStHtcG3qK3IL58ZvBSEnWJTYZmrTi2zat+1vJd1yA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-to-markdown": "^0.6.2",
-        "remark-gfm": "^1.0.0",
-        "remark-parse": "^9.0.0",
-        "remark-stringify": "^9.0.1",
-        "unified": "^9.0.0",
-        "unist-util-remove": "^2.0.1",
-        "unist-util-visit": "^2.0.3"
-      }
-    },
     "node_modules/slice-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
@@ -6585,16 +6088,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -6707,89 +6200,6 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
-    "node_modules/unified": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
-      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-buffer": "^2.0.0",
-        "is-plain-obj": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-2.1.0.tgz",
-      "integrity": "sha512-J8NYPyBm4baYLdCbjmf1bhPu45Cr1MWTm77qd9istEkzWpnN6O9tMsEbB2JhNnBCqGENRqEWomQ+He6au0B27Q==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
@@ -6818,36 +6228,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vfile": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -7124,16 +6504,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "ink-text-input": "^6.0.0",
     "picocolors": "^1.1.1",
     "react": "^18.3.1",
-    "slackify-markdown": "^4.5.0",
     "zod": "^4.3.6",
     "zod-to-json-schema": "^3.25.0"
   },

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -63,7 +63,8 @@ To users, Archie is ONE AI assistant. Never expose internal mechanics:
 - Never mention task owners, delegation, or internal coordination
 - Keep messages natural, brief, and focused on what users care about
 - For social contexts (welcomes, celebrations, announcements), respond warmly as a team member would
-- Use simple markdown (**bold**, _italic_, lists) but avoid headers (##)
+- Slack renders standard CommonMark in messages: headings (`#`, `##`, …), **bold**, _italic_, lists, `inline code`, fenced code blocks (with language for syntax highlighting), tables, blockquotes, links, task lists.
+- **Slack message length limit**: each message sent via `post_to_user` or `report_completion(message)` is capped at 12,000 characters. If the response would exceed this, split it across multiple `post_to_user` calls — send the first chunks, then call `report_completion` (with the final chunk or no message). The tool will return an error if you exceed the limit; shorten or split and retry.
 
 ### 5. The Delegation Protocol
 

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -23,6 +23,19 @@ import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../
 import { appendAgentFinding } from '../tasks/persistence.js';
 import { launchTask } from '../tasks/launch.js';
 import { logger } from '../system/logger.js';
+import { SLACK_MARKDOWN_LIMIT, SlackMarkdownLimitError } from '../connectors/slack/client.js';
+
+function formatSlackSendError(err: unknown): string {
+  if (err instanceof SlackMarkdownLimitError) {
+    return (
+      `Slack rejected the message: ${err.actualLength} chars exceeds the ${SLACK_MARKDOWN_LIMIT}-char per-message limit. ` +
+      `Nothing was delivered or logged. Split the content into multiple messages under the limit, ` +
+      `breaking on paragraphs and keeping code blocks/tables whole.`
+    );
+  }
+  const reason = err instanceof Error ? err.message : String(err);
+  return `Failed to post message: ${reason}`;
+}
 import { findSlackUsers, findSlackChannels } from '../connectors/slack/client.js';
 import { scheduleReminder, cancelReminder } from '../system/reminder-scheduler.js';
 import * as chrono from 'chrono-node';
@@ -169,7 +182,12 @@ function createPostToUserTool(agent: Agent, task: Task) {
         );
       }
       task.touch();
-      const newChannelKey = await task.postToUser(args.message, agentName, args.target);
+      let newChannelKey: string | null;
+      try {
+        newChannelKey = await task.postToUser(args.message, agentName, args.target);
+      } catch (err) {
+        return ok(formatSlackSendError(err));
+      }
       if (newChannelKey) {
         return ok(`Message posted. New channel linked: ${newChannelKey} (saved in task metadata for future use)`);
       }
@@ -319,7 +337,14 @@ function createReportCompletionTool(agent: Agent, task: Task) {
             'or call report_completion() without a message to finish silently.'
           );
         }
-        await task.postToUser(args.message, agentName);
+        try {
+          await task.postToUser(args.message, agentName);
+        } catch (err) {
+          // Surface the error to the agent so it can retry (e.g. split the
+          // message). Do NOT complete the task — completion only proceeds
+          // after a successful post (or no message at all).
+          return ok(formatSlackSendError(err));
+        }
       }
       logger.agentAction(agentName, 'Reporting completion', '');
       task.touch();

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -151,41 +151,39 @@ export function getSlackClient(): WebClient {
 }
 
 /**
- * Post a message to a Slack thread
+ * Post a Slack message as a `markdown` block.
+ *
+ * - With `threadTs`: replies inside that thread.
+ * - Without `threadTs`: posts a new top-level message; the returned `ts` becomes
+ *   the thread root for future replies.
+ *
+ * Throws `SlackMarkdownLimitError` when `text` exceeds the per-message limit
+ * — callers should perform any logging/event emission only AFTER this resolves
+ * successfully so rejected payloads are not persisted.
+ *
+ * Returns `undefined` in dry-run mode.
  */
-export async function postToThread(
-  channel: string,
-  threadTs: string,
-  text: string
-): Promise<string | undefined> {
+export async function postSlackMessage(args: {
+  channel: string;
+  text: string;
+  threadTs?: string;
+}): Promise<string | undefined> {
+  const { channel, text, threadTs } = args;
   if (dryRun) {
-    logger.system(`[DRY RUN] postToThread ${channel}:${threadTs} — ${text.slice(0, 120)}`);
+    const target = threadTs ? `${channel}:${threadTs}` : channel;
+    logger.system(`[DRY RUN] postSlackMessage ${target} — ${text.slice(0, 120)}`);
     return undefined;
   }
   const renderedText = restoreMentions(text);
   assertSlackMarkdownLength(renderedText);
   const client = getSlackClient();
-
   const result = await client.chat.postMessage({
     channel,
-    thread_ts: threadTs,
+    ...(threadTs ? { thread_ts: threadTs } : {}),
     text: renderedText,
     blocks: markdownBlock(renderedText) as any,
   });
-
   return result.ts;
-}
-
-/**
- * Post a message to multiple threads (for tasks with multiple linked threads)
- */
-export async function postToThreads(
-  threads: SlackThreadRef[],
-  text: string
-): Promise<void> {
-  for (const thread of threads) {
-    await postToThread(thread.channel_id, thread.thread_id, text);
-  }
 }
 
 /**
@@ -961,7 +959,7 @@ export async function askUserInThread(
     message += options.map((opt, i) => `${i + 1}. ${opt}`).join('\n');
   }
 
-  await postToThread(channel, threadTs, message);
+  await postSlackMessage({ channel, threadTs, text: message });
 }
 
 /**
@@ -1311,22 +1309,3 @@ export async function openDMChannel(userId: string): Promise<string> {
   return result.channel!.id!;
 }
 
-/**
- * Post a top-level message to a channel (not in a thread).
- * Creates a new thread — the returned ts becomes the thread_id for replies.
- */
-export async function postNewMessage(channel: string, text: string): Promise<string | undefined> {
-  if (dryRun) {
-    logger.system(`[DRY RUN] postNewMessage ${channel} — ${text.slice(0, 120)}`);
-    return undefined;
-  }
-  const renderedText = restoreMentions(text);
-  assertSlackMarkdownLength(renderedText);
-  const client = getSlackClient();
-  const result = await client.chat.postMessage({
-    channel,
-    text: renderedText,
-    blocks: markdownBlock(renderedText) as any,
-  });
-  return result.ts;
-}

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -21,8 +21,49 @@ interface RawSlackMessage {
   files?: SlackFile[];
   attachments?: SlackAttachment[];
 }
-import slackifyMarkdown from 'slackify-markdown';
 import { logger } from '../../system/logger.js';
+
+/**
+ * Slack `markdown` block cumulative payload limit (per chat.postMessage).
+ * Source: https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
+ */
+export const SLACK_MARKDOWN_LIMIT = 12000;
+
+/**
+ * Thrown when a Slack-bound message exceeds the markdown block character limit.
+ * Carries the actual length so tool wrappers can build agent-facing guidance.
+ */
+export class SlackMarkdownLimitError extends Error {
+  readonly actualLength: number;
+  readonly limit: number;
+  constructor(actualLength: number) {
+    super(
+      `Slack markdown payload is ${actualLength} chars, exceeds ${SLACK_MARKDOWN_LIMIT} limit.`
+    );
+    this.name = 'SlackMarkdownLimitError';
+    this.actualLength = actualLength;
+    this.limit = SLACK_MARKDOWN_LIMIT;
+  }
+}
+
+/**
+ * Throw if `text` exceeds Slack's markdown block character limit.
+ * Callers should invoke this BEFORE logging the message anywhere
+ * so a rejected payload does not pollute the knowledge log.
+ */
+export function assertSlackMarkdownLength(text: string): void {
+  if (text.length > SLACK_MARKDOWN_LIMIT) {
+    throw new SlackMarkdownLimitError(text.length);
+  }
+}
+
+/**
+ * Build a single Slack `markdown` block carrying CommonMark text.
+ * Slack renders it natively (tables, code, lists) — no legacy mrkdwn conversion.
+ */
+function markdownBlock(text: string): unknown[] {
+  return [{ type: 'markdown', text }];
+}
 
 let slackClient: WebClient | null = null;
 let botUserId: string | null = null;
@@ -121,16 +162,15 @@ export async function postToThread(
     logger.system(`[DRY RUN] postToThread ${channel}:${threadTs} — ${text.slice(0, 120)}`);
     return undefined;
   }
+  const renderedText = restoreMentions(text);
+  assertSlackMarkdownLength(renderedText);
   const client = getSlackClient();
-
-  // Restore @<ID:Name> mentions to <@ID> before slackify (which would escape the angle brackets)
-  const slackText = slackifyMarkdown(restoreMentions(text));
 
   const result = await client.chat.postMessage({
     channel,
     thread_ts: threadTs,
-    text: slackText,
-    mrkdwn: true,
+    text: renderedText,
+    blocks: markdownBlock(renderedText) as any,
   });
 
   return result.ts;
@@ -862,12 +902,14 @@ export async function postEphemeral(
     return;
   }
   try {
+    const renderedText = restoreMentions(text);
+    assertSlackMarkdownLength(renderedText);
     const client = getSlackClient();
-    const slackText = slackifyMarkdown(restoreMentions(text));
     await client.chat.postEphemeral({
       channel,
       user,
-      text: slackText,
+      text: renderedText,
+      blocks: markdownBlock(renderedText) as any,
       ...(threadTs ? { thread_ts: threadTs } : {}),
     });
   } catch (error) {
@@ -1278,12 +1320,13 @@ export async function postNewMessage(channel: string, text: string): Promise<str
     logger.system(`[DRY RUN] postNewMessage ${channel} — ${text.slice(0, 120)}`);
     return undefined;
   }
+  const renderedText = restoreMentions(text);
+  assertSlackMarkdownLength(renderedText);
   const client = getSlackClient();
-  const slackText = slackifyMarkdown(restoreMentions(text));
   const result = await client.chat.postMessage({
     channel,
-    text: slackText,
-    mrkdwn: true,
+    text: renderedText,
+    blocks: markdownBlock(renderedText) as any,
   });
   return result.ts;
 }

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -14,7 +14,6 @@ import type { App as AppType } from '@slack/bolt';
 
 import {
   initSlackClient,
-  postToThreads,
   updateMessage,
   getBotUserId,
   fetchSlackThread,

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -53,7 +53,7 @@ import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
 import { scanAgentDefs } from '../agents/registry.js';
 import { refreshPlugins } from '../system/workdir.js';
-import { postToThread, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, postNewMessage, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
+import { postToThread, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, postNewMessage, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay, assertSlackMarkdownLength } from '../connectors/slack/client.js';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { logger } from '../system/logger.js';
 import { emitEvent } from '../system/event-bus.js';
@@ -289,6 +289,9 @@ export class Task {
 
     // New DM — open DM channel, reuse existing thread or create new
     if (target?.new_dm) {
+      // Validate length BEFORE logging so a rejected message is not persisted
+      // to the knowledge log or emitted to the event bus.
+      assertSlackMarkdownLength(message);
       const dmChannelId = await openDMChannel(target.new_dm);
       const existing = this.findChannelBySlackId(dmChannelId);
       if (existing) {
@@ -309,6 +312,7 @@ export class Task {
 
     // New thread in a channel
     if (target?.new_thread) {
+      assertSlackMarkdownLength(message);
       const channelInfo = await getChannelInfo(target.new_thread);
       const ts = await postNewMessage(target.new_thread, message);
       if (!ts) return null; // dry-run
@@ -322,6 +326,7 @@ export class Task {
     if (target?.channel) {
       const ch = this.metadata.channels[target.channel];
       if (ch?.type === 'slack') {
+        assertSlackMarkdownLength(message);
         const dest = Task.formatSlackDest(ch);
         this.logOutgoingMessage(sender, message, dest.display, ch);
         await this.postToSlackRef(ch, message);
@@ -341,6 +346,7 @@ export class Task {
       return null;
     }
     if (defaultCh.type === 'slack') {
+      assertSlackMarkdownLength(message);
       const dest = Task.formatSlackDest(defaultCh);
       this.logOutgoingMessage(sender, message, dest.display, defaultCh);
       await this.postToSlackRef(defaultCh, message);

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -53,7 +53,7 @@ import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
 import { scanAgentDefs } from '../agents/registry.js';
 import { refreshPlugins } from '../system/workdir.js';
-import { postToThread, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, postNewMessage, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay, assertSlackMarkdownLength } from '../connectors/slack/client.js';
+import { postSlackMessage, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { logger } from '../system/logger.js';
 import { emitEvent } from '../system/event-bus.js';
@@ -289,32 +289,35 @@ export class Task {
 
     // New DM — open DM channel, reuse existing thread or create new
     if (target?.new_dm) {
-      // Validate length BEFORE logging so a rejected message is not persisted
-      // to the knowledge log or emitted to the event bus.
-      assertSlackMarkdownLength(message);
       const dmChannelId = await openDMChannel(target.new_dm);
       const existing = this.findChannelBySlackId(dmChannelId);
       if (existing) {
-        const dest = Task.formatSlackDest(existing.channel);
-        this.logOutgoingMessage(sender, message, dest.display, existing.channel);
-        await this.postToSlackRef(existing.channel, message);
+        // Reply inside the linked DM thread. Send first, then log on success
+        // so a rejected message (e.g. exceeding the markdown limit) is not
+        // persisted to the knowledge log or emitted to the event bus.
+        await postSlackMessage({
+          channel: existing.channel.channel_id,
+          threadTs: existing.channel.thread_id,
+          text: message,
+        });
+        this.logOutgoingMessage(sender, message, Task.formatSlackDest(existing.channel).display, existing.channel);
         return existing.key;
+      } else {
+        const userInfo = await getUserInfo(target.new_dm);
+        const channelName = `DM with ${userInfo.realName}`;
+        const ts = await postSlackMessage({ channel: dmChannelId, text: message });
+        if (!ts) return null; // dry-run
+        const key = this.registerSlackChannel(dmChannelId, ts, channelName);
+        const ch = this.metadata.channels[key] as SlackChannel;
+        this.logOutgoingMessage(sender, message, Task.formatSlackDest(ch).display, ch);
+        return key;
       }
-      const userInfo = await getUserInfo(target.new_dm);
-      const channelName = `DM with ${userInfo.realName}`;
-      const ts = await postNewMessage(dmChannelId, message);
-      if (!ts) return null; // dry-run
-      const key = this.registerSlackChannel(dmChannelId, ts, channelName);
-      const ch = this.metadata.channels[key] as SlackChannel;
-      this.logOutgoingMessage(sender, message, Task.formatSlackDest(ch).display, ch);
-      return key;
     }
 
     // New thread in a channel
     if (target?.new_thread) {
-      assertSlackMarkdownLength(message);
       const channelInfo = await getChannelInfo(target.new_thread);
-      const ts = await postNewMessage(target.new_thread, message);
+      const ts = await postSlackMessage({ channel: target.new_thread, text: message });
       if (!ts) return null; // dry-run
       const key = this.registerSlackChannel(target.new_thread, ts, channelInfo.name);
       const ch = this.metadata.channels[key] as SlackChannel;
@@ -326,10 +329,8 @@ export class Task {
     if (target?.channel) {
       const ch = this.metadata.channels[target.channel];
       if (ch?.type === 'slack') {
-        assertSlackMarkdownLength(message);
-        const dest = Task.formatSlackDest(ch);
-        this.logOutgoingMessage(sender, message, dest.display, ch);
-        await this.postToSlackRef(ch, message);
+        await postSlackMessage({ channel: ch.channel_id, threadTs: ch.thread_id, text: message });
+        this.logOutgoingMessage(sender, message, Task.formatSlackDest(ch).display, ch);
       }
       return null;
     }
@@ -346,10 +347,8 @@ export class Task {
       return null;
     }
     if (defaultCh.type === 'slack') {
-      assertSlackMarkdownLength(message);
-      const dest = Task.formatSlackDest(defaultCh);
-      this.logOutgoingMessage(sender, message, dest.display, defaultCh);
-      await this.postToSlackRef(defaultCh, message);
+      await postSlackMessage({ channel: defaultCh.channel_id, threadTs: defaultCh.thread_id, text: message });
+      this.logOutgoingMessage(sender, message, Task.formatSlackDest(defaultCh).display, defaultCh);
     } else if (defaultCh.type === 'cli') {
       this.logOutgoingMessage(sender, message, 'cli');
     }
@@ -409,13 +408,6 @@ export class Task {
         removeReaction(ch.channel_id, ch.last_processed_ts, 'eyes');
       }
     }
-  }
-
-  /**
-   * Post to a single Slack thread ref.
-   */
-  private async postToSlackRef(ch: SlackChannel, message: string): Promise<void> {
-    await postToThread(ch.channel_id, ch.thread_id, message);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replace `slackify-markdown` legacy mrkdwn conversion with Slack's [`markdown` block](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/) — CommonMark renders natively (headings, tables, fenced code blocks with syntax highlighting, task lists, blockquotes). Drops the `slackify-markdown` dependency.
- Enforce the per-message **12,000-character limit** via `assertSlackMarkdownLength`, called BEFORE any logging in `postToUser` so rejected payloads never reach `knowledge.log` or the event bus. Surface a `SlackMarkdownLimitError` to `post_to_user` / `report_completion` tools with split-and-retry guidance.
- Update PM prompt to reflect the new markdown capabilities and the length cap.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 40/40 pass
- [x] `npm run build` clean
- [x] Live Slack test: headings, lists, task lists, tables, syntax-highlighted code blocks, mentions, emoji all render correctly in `Archie Test` thread
- [x] Verify oversize message rejection: send >12k payload, confirm tool returns split guidance and nothing is logged to `knowledge.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)