### PR TITLE
Skip merged PRs in merge-orchestrator conflict filter

### DIFF
--- a/src/connectors/github/merge.ts
+++ b/src/connectors/github/merge.ts
@@ -113,7 +113,9 @@ export async function triggerMergeCheck(taskId: string): Promise<MergeCheckResul
       (pr.status.mergeableState === 'clean' ||
         (pr.status.mergeable && pr.status.mergeableState === 'blocked'))
   );
-  const conflicted = prStatuses.filter((pr) => pr.status.mergeableState === 'dirty');
+  const conflicted = prStatuses.filter(
+    (pr) => pr.status.state === 'open' && pr.status.mergeableState === 'dirty'
+  );
   const pending = prStatuses.filter(
     (pr) =>
       pr.status.state === 'open' &&


### PR DESCRIPTION
## Summary
- Merge orchestrator was sending false `[blocker]` notifications to PM for PRs that were already merged.
- GitHub's `mergeable_state` can remain `'dirty'` on a merged PR (stale pre-merge snapshot). The `conflicted` filter at [src/connectors/github/merge.ts:116](src/connectors/github/merge.ts#L116) checked only `mergeableState === 'dirty'` with no PR `state` guard, so merged PRs slipped into the conflict bucket and triggered `notifyPMAboutConflicts`.
- Added `state === 'open'` guard, matching the `pending` filter just below it.

## Test plan
- [x] Typecheck passes (`npm run typecheck`).
- [ ] Trigger merge orchestrator on a task whose linked PR is already merged but reports stale `dirty` — confirm no `[system] [blocker]` line in `knowledge.log`.
- [ ] Trigger on an open PR with real conflicts — confirm blocker still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)