### PR TITLE
Log task title generation success

### DIFF
--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -271,6 +271,7 @@ async function generateTitleAndSync(task: Task, thread: SlackThread): Promise<vo
 
   task.metadata.title = title;
   task.debouncedSave();
+  logger.system(`Task ${task.taskId} title set: "${title}"`);
 
   if (thread.channel.id.startsWith('D')) {
     await setAssistantThreadTitle(getSlackClient(), thread.channel.id, thread.threadId, title);

--- a/src/connectors/slack/title.ts
+++ b/src/connectors/slack/title.ts
@@ -20,6 +20,7 @@ export async function setAssistantThreadTitle(
 ): Promise<void> {
   try {
     await client.assistant.threads.setTitle({ channel_id, thread_ts, title });
+    logger.system(`Slack DM title synced (${channel_id}/${thread_ts})`);
   } catch (err) {
     logger.warn('slack-title', `setTitle failed for ${channel_id}/${thread_ts}: ${err}`);
   }


### PR DESCRIPTION
## Summary

- Log when a task title is set in metadata: `Task <id> title set: "<title>"`
- Log when Slack DM thread title is synced via `assistant.threads.setTitle`: `Slack DM title synced (<channel>/<ts>)`
- Failure paths already covered by existing `logger.warn` calls in `title-generator.ts` (haiku errors, schema fail, throws) and `title.ts` (setTitle errors).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 40/40 passing
- [x] Manual: trigger title gen, observe both success log lines in server output

🤖 Generated with [Claude Code](https://claude.com/claude-code)