### PR TITLE
Separate IANA and human-readable timezone fields in Slack user info

### DIFF
--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -113,7 +113,7 @@ Use as many of these as needed during your turn:
 When a user asks to be reminded of something at a specific time (e.g. "remind me at 9am tomorrow", "ping me in 2 hours", "follow up next Monday"):
 
 1. **Identify whose timezone applies.** This is the person the time expression is relative to — usually the user who sent the triggering message (their Slack user ID is on the message), or whoever the reminder is explicitly *for* if they named someone else.
-2. **Look up that user's IANA timezone.** Call `find_slack_user` with their Slack ID or name. The result includes a line like `Timezone: America/Los_Angeles (Pacific Time (US & Canada))` — the IANA value (left of the parentheses) is what you need. Never guess the timezone from the human label, and never assume UTC.
+2. **Look up that user's IANA timezone.** Call `find_slack_user` with their Slack ID or name. The result has a `Timezone (IANA): ...` line — that value (e.g. `America/Los_Angeles`) is what you pass to `parse_datetime`. Ignore the `Timezone (label): ...` line; it's for humans only. Never guess the timezone, and never assume UTC.
 3. **Parse the time.** Call `parse_datetime` with the user's natural-language expression and the IANA timezone from step 2. It returns an ISO 8601 datetime in UTC.
 4. **Set the reminder.** Call `set_reminder` with the ISO datetime and a short `reason` describing what to do when you wake up. Only one reminder can be pending per task — calling `set_reminder` again replaces it.
 5. **Cancel if no longer needed.** Use `cancel_reminder` if the reason becomes obsolete before the reminder fires.

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -110,15 +110,7 @@ Use as many of these as needed during your turn:
 
 ### Scheduling Reminders
 
-When a user asks to be reminded of something at a specific time (e.g. "remind me at 9am tomorrow", "ping me in 2 hours", "follow up next Monday"):
-
-1. **Identify whose timezone applies.** This is the person the time expression is relative to — usually the user who sent the triggering message (their Slack user ID is on the message), or whoever the reminder is explicitly *for* if they named someone else.
-2. **Look up that user's IANA timezone.** Call `find_slack_user` with their Slack ID or name. The result has a `Timezone (IANA): ...` line — that value (e.g. `America/Los_Angeles`) is what you pass to `parse_datetime`. Ignore the `Timezone (label): ...` line; it's for humans only. Never guess the timezone, and never assume UTC.
-3. **Parse the time.** Call `parse_datetime` with the user's natural-language expression and the IANA timezone from step 2. It returns an ISO 8601 datetime in UTC.
-4. **Set the reminder.** Call `set_reminder` with the ISO datetime and a short `reason` describing what to do when you wake up. Only one reminder can be pending per task — calling `set_reminder` again replaces it.
-5. **Cancel if no longer needed.** Use `cancel_reminder` if the reason becomes obsolete before the reminder fires.
-
-When the reminder fires, the task reactivates and you receive a system message with the reason. Re-read knowledge.log to recover context, then act.
+When a user asks to be reminded at a specific time, look up their IANA timezone via `find_slack_user`, pass it to `parse_datetime` along with the time expression, then call `set_reminder` with the resulting ISO datetime. Use `cancel_reminder` if the reason becomes obsolete. Only one reminder can be pending per task — setting a new one replaces it. When it fires, the task reactivates with the reason as a system message.
 
 ### Cross-Channel Communication
 

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -110,7 +110,7 @@ Use as many of these as needed during your turn:
 
 ### Scheduling Reminders
 
-When a user asks to be reminded at a specific time, look up their IANA timezone via `find_slack_user`, pass it to `parse_datetime` along with the time expression, then call `set_reminder` with the resulting ISO datetime. Use `cancel_reminder` if the reason becomes obsolete. Only one reminder can be pending per task — setting a new one replaces it. When it fires, the task reactivates with the reason as a system message.
+When a user asks to be reminded at a specific time, look up their IANA timezone via `find_slack_user`, pass it to `parse_datetime` with the time expression, then call `set_reminder` with the resulting ISO datetime.
 
 ### Cross-Channel Communication
 

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -108,6 +108,18 @@ Use as many of these as needed during your turn:
 
 - `launch_task(prompt, reason)`: Launch a new independent background task. Use for fire-and-forget work that shouldn't block the current conversation. The launched task starts with no channel — its own PM will decide where to reach someone (DM, new thread) or complete silently. A notification about the launch is automatically posted to the current channel, so don't repost. Not available to tasks that have no channel of their own.
 
+### Scheduling Reminders
+
+When a user asks to be reminded of something at a specific time (e.g. "remind me at 9am tomorrow", "ping me in 2 hours", "follow up next Monday"):
+
+1. **Identify whose timezone applies.** This is the person the time expression is relative to — usually the user who sent the triggering message (their Slack user ID is on the message), or whoever the reminder is explicitly *for* if they named someone else.
+2. **Look up that user's IANA timezone.** Call `find_slack_user` with their Slack ID or name. The result includes a line like `Timezone: America/Los_Angeles (Pacific Time (US & Canada))` — the IANA value (left of the parentheses) is what you need. Never guess the timezone from the human label, and never assume UTC.
+3. **Parse the time.** Call `parse_datetime` with the user's natural-language expression and the IANA timezone from step 2. It returns an ISO 8601 datetime in UTC.
+4. **Set the reminder.** Call `set_reminder` with the ISO datetime and a short `reason` describing what to do when you wake up. Only one reminder can be pending per task — calling `set_reminder` again replaces it.
+5. **Cancel if no longer needed.** Use `cancel_reminder` if the reason becomes obsolete before the reminder fires.
+
+When the reminder fires, the task reactivates and you receive a system message with the reason. Re-read knowledge.log to recover context, then act.
+
 ### Cross-Channel Communication
 
 You can reach people and channels beyond the originating thread:

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -209,7 +209,11 @@ function createFindSlackUserTool(_agent: Agent, _task: Task) {
       const list = matches.slice(0, 10).map(u => {
         const parts = [`${u.realName} (@${u.name}) — ID: ${u.id}`];
         if (u.title) parts.push(`  Title: ${u.title}`);
-        if (u.timezone) parts.push(`  Timezone: ${u.timezone}`);
+        if (u.tz || u.timezone) {
+          const iana = u.tz || '(unknown IANA)';
+          const label = u.timezone ? ` (${u.timezone})` : '';
+          parts.push(`  Timezone: ${iana}${label}  ← pass the IANA value to parse_datetime`);
+        }
         if (u.displayName && u.displayName !== u.realName) parts.push(`  Display name: ${u.displayName}`);
         return `- ${parts.join('\n')}`;
       }).join('\n');

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -209,11 +209,8 @@ function createFindSlackUserTool(_agent: Agent, _task: Task) {
       const list = matches.slice(0, 10).map(u => {
         const parts = [`${u.realName} (@${u.name}) — ID: ${u.id}`];
         if (u.title) parts.push(`  Title: ${u.title}`);
-        if (u.tz || u.timezone) {
-          const iana = u.tz || '(unknown IANA)';
-          const label = u.timezone ? ` (${u.timezone})` : '';
-          parts.push(`  Timezone: ${iana}${label}  ← pass the IANA value to parse_datetime`);
-        }
+        if (u.tz) parts.push(`  Timezone (IANA): ${u.tz}`);
+        if (u.timezone) parts.push(`  Timezone (label): ${u.timezone}`);
         if (u.displayName && u.displayName !== u.realName) parts.push(`  Display name: ${u.displayName}`);
         return `- ${parts.join('\n')}`;
       }).join('\n');

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -1172,7 +1172,8 @@ export interface SlackUserInfo {
   realName: string;      // Full name
   displayName: string;   // Display name (may differ from realName)
   title: string;         // Job title (e.g., "Senior Engineer")
-  timezone: string;      // Timezone label (e.g., "Eastern Time (US & Canada)")
+  timezone: string;      // Human timezone label (e.g., "Eastern Time (US & Canada)")
+  tz: string;            // IANA timezone (e.g., "America/New_York") — pass to parse_datetime
   isAdmin: boolean;      // Workspace admin
   isOwner: boolean;      // Workspace owner
   teamId?: string;             // Slack team_id — used for external-org classification
@@ -1207,7 +1208,8 @@ export async function listWorkspaceUsers(): Promise<SlackUserInfo[]> {
         realName: member.real_name ?? member.name ?? member.id!,
         displayName: member.profile?.display_name || member.real_name || member.name || member.id!,
         title: member.profile?.title ?? '',
-        timezone: member.tz_label ?? member.tz ?? '',
+        timezone: member.tz_label ?? '',
+        tz: member.tz ?? '',
         isAdmin: member.is_admin ?? false,
         isOwner: member.is_owner ?? false,
         teamId: member.team_id ?? undefined,


### PR DESCRIPTION
## Summary
This PR separates timezone information in the Slack user connector into two distinct fields: a human-readable timezone label and an IANA timezone identifier. This enables proper datetime parsing for scheduling features that require IANA timezone format.

## Key Changes
- **SlackUserInfo interface**: Added new `tz` field for IANA timezone (e.g., "America/New_York") while clarifying that `timezone` is the human-readable label
- **listWorkspaceUsers()**: Updated to populate `timezone` from `tz_label` only and `tz` from the `tz` field separately, preventing fallback behavior that mixed formats
- **find_slack_user tool output**: Modified to display both timezone formats distinctly, showing IANA timezone first (for use with `parse_datetime`) and human-readable label second
- **PM agent documentation**: Added guidance on the scheduling workflow: lookup user via `find_slack_user`, pass their IANA timezone to `parse_datetime`, then call `set_reminder` with the resulting ISO datetime

## Implementation Details
The changes ensure that when agents need to schedule reminders at user-specified times, they have access to the IANA timezone identifier required by `parse_datetime`, while still preserving the human-readable timezone label for display purposes.

https://claude.ai/code/session_01F6wruyy4wXrVezQ6ZtoJe3