### PR TITLE
Add artifact sharing between agents and Slack file uploads

### DIFF
--- a/docs/plans/v26-artifact-sharing.md
+++ b/docs/plans/v26-artifact-sharing.md
@@ -1,0 +1,123 @@
+# Artifact Sharing Between Agents and to User
+
+## Context
+
+Currently, when agents collaborate on documents (e.g. backend agent drafts a plan, mobile reviews, backend revises, sends to PM, PM relays to user), the full document body is inlined in every `send_message_to_agent` and `post_to_user` call. The shared `knowledge.log` accumulates many copies of the same evolving document, bloating context and burning tokens.
+
+We add an **artifact** primitive: agents copy a file into the task's shared folder under a content-versioned name and pass only the path in messages. Recipients read the file directly. Knowledge log records each share as a one-line audit entry, not a full document body.
+
+Additionally, PM (and only PM, since `post_to_user` is PM-only) can attach files when posting to Slack, allowing it to deliver dev plans, research outputs, or other artifacts to the user as Slack file uploads instead of inline text.
+
+## Design Summary
+
+- **Artifact storage**: `<task>/shared/artifacts/` — flat directory, no per-agent subfolders.
+- **Filename**: `<basename>.<8-char-uuid>.<ext>` (e.g. `plan.a1b2c3d4.md`). UUID assigned per share call.
+- **Content dedup**: if the source file's content (sha256) matches an existing artifact in the dir with the same basename+ext, return the existing path instead of writing a new copy. This preserves "same file shared twice → single artifact" while still creating new versions when content changes.
+- **Sandbox**: tool runs in-process (Node), bypasses sandbox. `shared/artifacts/` stays in `denyWritePaths` for agent shells. Read access to `sharedPath` already granted to all tracks — recipients read artifacts via their normal `Read` tool.
+- **Knowledge log + events**: single new log entry per share. Also a system event so live CLI/UI observers see it.
+  - Internal share: log line `[ts] [agent] [artifact] <relative-path> — <description>`; event type `agent:log` with `data: { finding: 'shared artifact: <path> — <description>', type: 'artifact' }` so existing CLI rendering at [TaskDetail.tsx:100](src/cli/components/TaskDetail.tsx#L100) shows it without changes. Add `'artifact'` to `FindingType` union.
+  - Outbound to user: extend existing `[Attachments: …]` suffix on the message log entry (mirrors inbound path at [persistence.ts:215-221](src/tasks/persistence.ts#L215)). The `message` event already emitted by `logOutgoingMessage` carries the rendered message; including the attachments suffix in the rendered string is enough — CLI shows it via existing `case 'message'` branch at [TaskDetail.tsx:95](src/cli/components/TaskDetail.tsx#L95). No new event type needed.
+- **Path validation**: source path must resolve (after symlink resolution) under the agent's `allowReadPaths` set. Reuses sandbox path config from `spawn.ts`.
+
+## Files to Modify
+
+### 1. New: `src/agents/artifacts.ts`
+
+Core helpers:
+
+- `validatePathInSandbox(absPath, allowReadPaths): Promise<string>` — resolve symlinks via `realpath`, return canonical path, throw if outside allowed roots. Used by both `share_artifact` and `post_to_user` artifact validation.
+- `copyArtifactToShared(taskId, sourcePath, agentId): Promise<{ artifactPath: string; reused: boolean }>` — compute sha256 of source; check existing files in `shared/artifacts/` matching `<basename>.*.<ext>` for same hash; if hit, return existing absolute path with `reused=true`; else generate `<basename>.<uuid8>.<ext>`, copy, return new absolute path.
+- `getArtifactsDir(taskId): string` — `join(getSharedPath(taskId), 'artifacts')`. Mirrors `getResearchesDir` pattern.
+
+### 2. `src/tasks/persistence.ts`
+
+- Add `getArtifactsPath(taskId)` near `getAttachmentsPath` (line 91).
+- Add `appendArtifactShared(taskId, agentId, artifactPath, description)` — writes log entry: `[ts] [agentId] [artifact] <relative-path> — <description>` and emits `emitEvent('agent:log', taskId, { finding: 'shared artifact: <relPath> — <description>', type: 'artifact' }, agentId)`. Mirrors `appendAgentFinding` shape.
+- Extend `renderMessageForContext` (or the outbound-message rendering path used by `logOutgoingMessage` in [task.ts:359](src/tasks/task.ts#L359)) to accept optional `artifacts: { name: string; path: string }[]` and append `[Attachments: a.md (path), b.md (path)]` suffix when present. The same string is logged AND placed in the `message` event payload, so CLI/SSE observers see attachments without extra event types.
+- Add `'artifact'` to `FindingType` in [src/types/task.ts](src/types/task.ts) (union currently: `'discovery' | 'decision' | 'completion' | 'blocker'`).
+
+### 3. `src/agents/tools.ts`
+
+- Add `createShareArtifactTool(agent, task)` (after `createLogFindingTool`):
+  - Inputs: `path: string` (absolute), `description: string`.
+  - Resolves agent's `allowReadPaths` from spawn-time sandbox config (need to thread this through — see "Sandbox path access" below).
+  - Calls `copyArtifactToShared`, then `appendArtifactShared`.
+  - Returns: `Shared as <abs-path>. Logged to knowledge log.` (or raw error string on failure).
+  - On `reused=true`, returned text notes existing version: `Already shared at <abs-path> (identical content). Logged.`
+- Add tool to **both** `createBaseAgentMcpServer` (line 1103, used by repo + plugin tracks) and `createPMAgentMcpServer` (line 1042).
+- Extend `createPostToUserTool` (line 159):
+  - New optional input: `artifact_paths: string[]`.
+  - Each path validated against PM's `allowReadPaths`.
+  - Pass list to `task.postToUser`, which forwards to a new Slack helper.
+
+### 4. `src/connectors/slack/client.ts`
+
+- Add `postSlackMessageWithFiles(args: { channel, text, threadTs?, filePaths: string[] }): Promise<string | undefined>` using `client.files.uploadV2({ channel_id, thread_ts, initial_comment, file_uploads: [{ file: localPath, filename }, …] })`. Slack SDK v6 `uploadV2` returns when files are visible.
+- In dry-run, log `[DRY RUN] postSlackMessageWithFiles ${channel}:${threadTs} — N files: a.md, b.md`.
+- For consistency, when `text.length > SLACK_MARKDOWN_LIMIT` and there are no files, route through existing `postSlackMessage` (preserves limit error path); when `text` itself is short and files attached, use uploadV2.
+
+### 5. `src/tasks/task.ts` — `postToUser`
+
+- Accept new optional `artifactPaths: string[]` param.
+- Each branch (existing-DM reply, new-DM, new-thread, target.channel, default) selects between `postSlackMessage` (no attachments) and `postSlackMessageWithFiles` (with attachments).
+- `logOutgoingMessage` extended (or sibling helper added) to render attachments suffix `[Attachments: a.md (path), b.md (path)]` mirroring `renderMessageForContext` (line 215).
+
+### 6. Sandbox path access for tool
+
+Tool handler needs to know each agent's `allowReadPaths` to validate. Two options:
+
+- **Option A (preferred)**: stash sandbox config on the `Agent` object at spawn time (`agent.allowReadPaths: string[]`). Tool reads `agent.allowReadPaths` directly. One-line addition in `spawn.ts` after each `sandboxOpts` block (3 places — pm/repo/plugin tracks).
+- **Option B**: rebuild allow-paths in tool from task + agent. Duplicates spawn.ts logic. Avoid.
+
+Plan uses **Option A**.
+
+### 7. Prompt updates
+
+Core mental model to instill: agents send two kinds of things — **messages/updates** (status, questions, decisions → `send_message_to_agent` / `post_to_user` / `log_finding`) and **documents** (plans, reports, diffs, longer outputs → `share_artifact`, then send the path). Don't paste document bodies into messages.
+
+- `prompts/agent-core.md` (repo + plugin agents) — add short subsection under "Core Communication Tools":
+
+  **Messages vs. Documents**
+
+  Use `send_message_to_agent` and `log_finding` for short text: status, questions, decisions, completion reports. Use `share_artifact(path, description)` when you have a document — a plan, report, diff, or any longer output another agent will read or revise. It writes the file into the task's shared folder and returns an absolute path; pass that path in your message instead of pasting the body. Read incoming artifacts with the standard `Read` tool on the path the sender gave you. When you revise a document you previously shared, edit your local copy and call `share_artifact` again — each share is content-versioned, so previous versions remain available.
+
+  Then add bullet under the tool list: `share_artifact(path, description)`: publish a document to the shared artifacts folder. Returns an absolute path other agents can `Read`.
+
+- `prompts/pm-agent.md` — add the same short "Messages vs. Documents" subsection (PM does not load `agent-core.md`), and:
+  - Add `share_artifact` bullet under Action Tools.
+  - Extend `post_to_user` entry: "Optionally pass `artifact_paths: [path, …]` to attach files to the Slack message. When the user asked for a document (dev plan, research report, design proposal), attach it as an artifact rather than pasting the full body — keeps the thread skim-friendly and lets the user download the file."
+
+Tool descriptions carry operational detail (path validation, dedup, return shape); prompts cover when and why to reach for the tool.
+
+### 8. `src/agents/agent.ts`
+
+- Add `allowReadPaths: string[]` field on `Agent`. Populated by spawn.ts.
+
+## Critical Files Referenced
+
+- `src/agents/tools.ts` — tool definitions ([tools.ts:119-155](src/agents/tools.ts#L119-L155) base tool pattern; [tools.ts:1042-1112](src/agents/tools.ts#L1042-L1112) MCP servers)
+- `src/agents/spawn.ts` — sandbox config per track ([spawn.ts:248-265](src/agents/spawn.ts#L248) PM, [spawn.ts:266+](src/agents/spawn.ts#L266) repo, [spawn.ts:430-489](src/agents/spawn.ts#L430) plugin)
+- `src/tasks/persistence.ts` — log helpers ([persistence.ts:170](src/tasks/persistence.ts#L170) format, [persistence.ts:215-221](src/tasks/persistence.ts#L215) attachment rendering precedent)
+- `src/tasks/task.ts` — `postToUser` ([task.ts:287-356](src/tasks/task.ts#L287))
+- `src/connectors/slack/client.ts` — Slack send ([client.ts:166-187](src/connectors/slack/client.ts#L166))
+- `src/mcp/research-tools.ts` — research artifact precedent ([research-tools.ts:327-341](src/mcp/research-tools.ts#L327))
+- `prompts/agent-core.md`, `prompts/pm-agent.md` — prompt updates
+
+## Verification
+
+1. **Build**: `npm run build` and `npm run typecheck` clean.
+2. **Internal share unit-style check**:
+   - Create a fake task dir under `workdir/sessions/test-artifact/`.
+   - Write a file in `agents/backend/out.md`.
+   - Call `copyArtifactToShared` directly via a small node script (or REPL-style).
+   - Verify `shared/artifacts/out.<8hex>.md` exists; second call with identical bytes returns same path; second call with mutated bytes creates new file.
+   - Verify knowledge.log entry written.
+3. **End-to-end multi-agent**: in a dev task, instruct backend agent to write a plan to `out/plan.md`, share it, then send the path to mobile. Confirm:
+   - Mobile can `Read` the shared path.
+   - knowledge.log shows one `[artifact]` line, no inlined plan body.
+   - Repeat share with edits → new artifact file.
+4. **PM Slack upload**: trigger PM to call `post_to_user(message, artifact_paths=[shared/artifacts/plan.<hash>.md])`. Verify file appears in Slack thread, knowledge.log entry includes `[Attachments: plan.<hash>.md (path)]`.
+5. **CLI live view**: while running an end-to-end task, watch the CLI (`src/cli`) to confirm `[artifact]` lines render in the task detail view (via existing `agent:log` event branch) and outbound `[Attachments: …]` shows up on the user-message line.
+6. **Path rejection**: attempt to share `/etc/hosts` or a path outside agent's read scope — confirm tool returns clear error and no file copied.
+7. **Symlink escape**: create a symlink in agent workspace pointing to `/etc/passwd`, attempt share — confirm `realpath` resolution rejects.
+8. **Slack file size**: attempt to upload a large file that exceeds Slack limit — confirm tool surfaces Slack's error to the agent (not swallowed).

--- a/prompts/agent-core.md
+++ b/prompts/agent-core.md
@@ -31,6 +31,11 @@ Key principle: Unless explicitly assigned as Task Owner, you are a Participant.
 
 - **send_message_to_agent**: Send a message to another agent for coordination, questions, work requests, or reporting findings
 - **log_finding**: Write to the shared knowledge log (visible to all agents and pm-agent) to record discoveries, decisions, completions, or blockers
+- **share_artifact**: Share a document (plan, report, diff, or any longer output) with OTHER AGENTS by publishing an immutable snapshot to the task's shared artifacts folder. Returns an absolute path other agents can `Read`. The published copy is read-only and never updated — to publish revisions, edit your local file and call again.
+
+### Messages vs. Documents
+
+Use `send_message_to_agent` and `log_finding` for short text — status, questions, decisions, completion reports. Use `share_artifact(path, description)` when you have a document to share with another agent — a plan, report, diff, or any longer output another agent will read or revise. It **copies** the file into the task's shared folder as an **immutable, read-only snapshot** and returns an absolute path; pass that path in your `send_message_to_agent` call instead of pasting the body. Your local file stays untouched, and the published copy will never change after publication. Read incoming artifacts with the standard `Read` tool on the path the sender gave you. When you have revisions to publish, edit your local copy and call `share_artifact` again — each call creates a new versioned snapshot, so previous versions remain available.
 
 ## Coordination Strategies
 
@@ -143,7 +148,7 @@ f. Stopping Points and Reporting - who you'll report to]
 
 ## Key Principles to Remember
 
-- **Never use plain text output to communicate.** Text you emit outside of tool calls is not delivered to any agent — it is discarded by the harness. Every communication must go through a tool: use `send_message_to_agent` to talk to agents, and `log_finding` to record to the shared log. If your turn contains only text and no tool calls, nothing happens — your message is lost.
+- **Never use plain text output to communicate.** Text you emit outside of tool calls is not delivered to any agent — it is discarded by the harness. Every communication must go through a tool: use `send_message_to_agent` to talk to agents, `share_artifact` to share a document with another agent, and `log_finding` to record to the shared log. If your turn contains only text and no tool calls, nothing happens — your message is lost.
 - Your role is determined by explicit assignment, not by the complexity of the task
 - Sequential coordination requires you to STOP immediately after sending a request
 - Parallel coordination requires agreement on approach before simultaneous implementation

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -97,8 +97,14 @@ Use as many of these as needed during your turn:
   - `target.channel`: Post to a specific linked thread (use the channel key from metadata)
   - `target.new_dm`: Start a new DM with a user (pass their Slack user ID). Links the DM thread to this task so replies flow back. Returns the channel key.
   - `target.new_thread`: Start a new thread in a channel (pass Slack channel ID). Links it to this task. Returns the channel key.
+- `post_files_to_user`: Upload one or more files as Slack attachments to an EXISTING linked thread (default channel, or pass `channel` with a linked channel key). Does not open new threads or DMs — call `post_to_user` first to open one if needed, then pass the returned channel key here. Files post without text, so the narrative goes through `post_to_user`.
+- `share_artifact`: Share a document (plan, report, diff, or any longer output) with OTHER AGENTS by publishing an immutable snapshot to the task's shared artifacts folder. Returns an absolute path other agents can `Read`. The published copy is read-only and never updated — to publish revisions, edit your local file and call again. Inter-agent only — to deliver a file to the user, use `post_files_to_user`.
 - `find_slack_user`: Search for a Slack user by name or ID. Returns matching users with IDs. Use before sending DMs.
 - `find_slack_channel`: Search for a Slack channel by name or ID. Returns matching channels with IDs. Use before posting to new threads.
+
+### Messages vs. Documents
+
+Use `send_message_to_agent`, `post_to_user`, and `log_finding` for short text — status, questions, decisions, completion reports, narrative updates. Use `share_artifact(path, description)` when you have a document — a plan, report, diff, or any longer output another agent or the user will read. It **copies** the file into the task's shared folder as an **immutable, read-only snapshot** and returns an absolute path. Your local file stays untouched, and the published copy will never change. Send the returned path in `send_message_to_agent` to other agents. To deliver the document to the user, post the narrative with `post_to_user`, then upload the file(s) with `post_files_to_user` (same target). To publish a revision, edit your local copy and call `share_artifact` again — each call creates a new versioned snapshot, so previous versions remain available.
 
 ### Thread Management Tools
 
@@ -336,7 +342,7 @@ You live inside Slack threads where multiple people may be having a conversation
 
 ## Honesty and Limitations
 
-- **Never use plain text output to communicate.** Text you emit outside of tool calls is not delivered to users or agents — it is discarded by the harness. Every communication must go through a tool: use `post_to_user` to talk to users, `send_message_to_agent` to talk to agents, and `log_finding` to record to the shared log. If your turn contains only text and no tool calls, nothing happens — your message is lost.
+- **Never use plain text output to communicate.** Text you emit outside of tool calls is not delivered to users or agents — it is discarded by the harness. Every communication must go through a tool: use `post_to_user` to talk to users, `post_files_to_user` to upload files to them, `send_message_to_agent` to talk to agents, `share_artifact` to share a document with another agent, and `log_finding` to record to the shared log. If your turn contains only text and no tool calls, nothing happens — your message is lost.
 - Never make up answers. If you don't know something, say so clearly to the user.
 - All information relayed to users must be strictly based on what agents reported or what you've read — not assumptions.
 - Do not work around tool limitations or restrictions. If something can't be done, tell the user.

--- a/slack-manifest.yaml
+++ b/slack-manifest.yaml
@@ -23,6 +23,7 @@ oauth_config:
       - users:read
       - usergroups:read
       - files:read
+      - files:write
       - reactions:write
       - assistant:write
 settings:

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -102,6 +102,8 @@ function getRegisteredToolNames(server: ReturnType<typeof createRepoToolsMcpServ
 const SPAWN_PM_TOOLS = [
   'mcp__pm-agent-tools__send_message_to_agent',
   'mcp__pm-agent-tools__post_to_user',
+  'mcp__pm-agent-tools__post_files_to_user',
+  'mcp__pm-agent-tools__share_artifact',
   'mcp__pm-agent-tools__find_slack_user',
   'mcp__pm-agent-tools__find_slack_channel',
   'mcp__pm-agent-tools__assign_task_owner',

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -8,6 +8,7 @@
 
 import type { AgentDef, AgentHandle } from '../types/agent.js';
 import type { AgentName, AgentSessionState } from '../types/task.js';
+import type { SandboxOptions } from './sandbox.js';
 import { MessageQueue } from './message-queue.js';
 import { spawnAgent } from './spawn.js';
 import { logger } from '../system/logger.js';
@@ -17,6 +18,14 @@ export class Agent {
   readonly queue: MessageQueue;
   handle?: AgentHandle;
   session: AgentSessionState;
+  /**
+   * Sandbox config for this agent (read/write paths, network rules).
+   * Populated by `spawnAgent` after the per-track sandbox is computed. Used by
+   * in-process tools (e.g. `share_artifact`, `post_to_user` artifact_paths) to
+   * validate that a path the agent passes points inside its allowed area —
+   * keeping a single source of truth instead of duplicating per-tool path lists.
+   */
+  sandbox?: SandboxOptions;
 
   constructor(def: AgentDef) {
     this.def = def;

--- a/src/agents/artifacts.ts
+++ b/src/agents/artifacts.ts
@@ -1,0 +1,135 @@
+/**
+ * Artifact Sharing
+ *
+ * Helpers backing the `share_artifact` tool and the `artifact_paths` parameter
+ * on `post_to_user`. Agents call into these from their tool handlers, which run
+ * in the Node process — bypassing the per-agent OS sandbox while still enforcing
+ * the same read-scope rules (so agents cannot publish files they could not have
+ * read in the first place).
+ *
+ * Storage layout: `<task>/shared/artifacts/<basename>.<8hex>.<ext>` (flat).
+ * Same content + same basename+ext is deduped: re-sharing returns the existing
+ * path. New content alongside an existing basename creates a new versioned file
+ * — version history is preserved for free.
+ */
+
+import { mkdir, copyFile, readFile, readdir, realpath } from 'fs/promises';
+import { existsSync } from 'fs';
+import { createHash, randomUUID } from 'crypto';
+import { join, basename, extname, sep, isAbsolute } from 'path';
+import type { SandboxOptions } from './sandbox.js';
+import { getArtifactsPath } from '../tasks/persistence.js';
+
+/**
+ * Resolve `inputPath` to an absolute, real (symlink-followed) path that lives
+ * inside the sandbox's read scope. Throws on any rule violation.
+ *
+ * Companion to a future `assertWritable` (sandbox.allowWritePaths) — the pair
+ * keeps the call sites readable while sharing the same root-validation logic.
+ */
+export async function assertReadable(
+  inputPath: string,
+  sandbox: SandboxOptions,
+): Promise<string> {
+  return assertInsideRoots(inputPath, sandbox.allowReadPaths, 'readable');
+}
+
+async function assertInsideRoots(
+  inputPath: string,
+  roots: readonly string[],
+  scope: 'readable' | 'writable',
+): Promise<string> {
+  if (!inputPath) {
+    throw new Error('Path is required.');
+  }
+  if (!isAbsolute(inputPath)) {
+    throw new Error(`Path must be absolute: ${inputPath}`);
+  }
+  let resolved: string;
+  try {
+    resolved = await realpath(inputPath);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`Cannot access path: ${reason}`);
+  }
+  const allowed = roots.some((root) => isPathInside(resolved, root));
+  if (!allowed) {
+    throw new Error(
+      `Path is outside your ${scope} sandbox: ${inputPath} (resolved to ${resolved}).`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Copy `sourcePath` into the task's shared artifacts folder, deduping by
+ * content hash within the same basename+extension. Returns the absolute target
+ * path and whether an existing artifact was reused.
+ */
+export async function copyArtifactToShared(
+  taskId: string,
+  sourcePath: string,
+): Promise<{ artifactPath: string; reused: boolean }> {
+  const artifactsDir = getArtifactsPath(taskId);
+  if (!existsSync(artifactsDir)) {
+    await mkdir(artifactsDir, { recursive: true });
+  }
+
+  const ext = extname(sourcePath);
+  const stem = basename(sourcePath, ext);
+  const sourceHash = await hashFile(sourcePath);
+
+  // Look for an existing `<stem>.<hex>.<ext>` whose content already matches.
+  const existing = await findExistingArtifact(artifactsDir, stem, ext, sourceHash);
+  if (existing) {
+    return { artifactPath: existing, reused: true };
+  }
+
+  const versionTag = randomUUID().replace(/-/g, '').slice(0, 8);
+  const targetName = ext ? `${stem}.${versionTag}${ext}` : `${stem}.${versionTag}`;
+  const targetPath = join(artifactsDir, targetName);
+  await copyFile(sourcePath, targetPath);
+  return { artifactPath: targetPath, reused: false };
+}
+
+async function hashFile(path: string): Promise<string> {
+  const buf = await readFile(path);
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+async function findExistingArtifact(
+  dir: string,
+  stem: string,
+  ext: string,
+  hash: string,
+): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  // Match `<stem>.<anything>.<ext>` (or `<stem>.<anything>` when no ext).
+  const prefix = `${stem}.`;
+  for (const name of entries) {
+    if (!name.startsWith(prefix)) continue;
+    if (ext) {
+      if (!name.endsWith(ext)) continue;
+    } else {
+      // No-ext artifact: skip names that contain a dot beyond the version tag.
+      const middle = name.slice(prefix.length);
+      if (middle.includes('.')) continue;
+    }
+    const candidate = join(dir, name);
+    if ((await hashFile(candidate)) === hash) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function isPathInside(child: string, parent: string): boolean {
+  const c = child.endsWith(sep) ? child : child + sep;
+  const p = parent.endsWith(sep) ? parent : parent + sep;
+  return c.startsWith(p);
+}

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -488,6 +488,11 @@ Shared folder: ${sharedPath} [READ-ONLY]
     };
   }
 
+  // Expose the sandbox config on the agent so in-process tools (e.g.
+  // `share_artifact`, `post_to_user` artifact_paths) can validate paths against
+  // the same boundaries the OS sandbox + filesystem-guard hooks enforce.
+  agent.sandbox = sandboxOpts;
+
   // ---- Build query options (session ID may change on retry) ----
 
   const buildQueryOptions = (sessionId?: string) => ({

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -20,7 +20,8 @@ import { getAgentIds } from './registry.js';
 import { getGitHubClient } from '../connectors/github/client.js';
 import { gitExec } from '../connectors/github/repo-clone.js';
 import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
-import { appendAgentFinding } from '../tasks/persistence.js';
+import { appendAgentFinding, appendArtifactShared } from '../tasks/persistence.js';
+import { copyArtifactToShared, assertReadable } from './artifacts.js';
 import { launchTask } from '../tasks/launch.js';
 import { logger } from '../system/logger.js';
 import { SLACK_MARKDOWN_LIMIT, SlackMarkdownLimitError } from '../connectors/slack/client.js';
@@ -49,6 +50,17 @@ const execAsync = promisify(exec);
 
 const ok = (text: string) => ({ content: [{ type: 'text' as const, text }] });
 const err = (text: string) => ({ content: [{ type: 'text' as const, text: `Error: ${text}` }] });
+
+/**
+ * Get the agent's sandbox config. Populated by `spawnAgent` before any tool
+ * runs; throws if a tool somehow executes before spawn (programmer error).
+ */
+function requireSandbox(agent: Agent) {
+  if (!agent.sandbox) {
+    throw new Error(`Agent ${agent.def.id} has no sandbox config — was it spawned?`);
+  }
+  return agent.sandbox;
+}
 
 /**
  * Find stash index by message name in `git stash list` output.
@@ -154,6 +166,40 @@ function createLogFindingTool(agent: Agent, task: Task) {
   );
 }
 
+function createShareArtifactTool(agent: Agent, task: Task) {
+  return tool(
+    'share_artifact',
+    'Share a document (plan, report, diff, or any longer output) with OTHER AGENTS by publishing an immutable snapshot to the task\'s shared artifacts folder. ' +
+    'This is for inter-agent sharing only — to deliver a file to the user, use `post_files_to_user`. ' +
+    'The tool COPIES the file — your local file is left in place, and the published copy is read-only and never updated. ' +
+    'Pass an absolute path to a file inside your readable sandbox; the tool returns the absolute path of the immutable copy under shared/artifacts/, which you should send in `send_message_to_agent` instead of pasting the document body. ' +
+    'Identical content is deduped by hash — re-sharing the same bytes returns the existing snapshot path. To publish revisions, edit your local file and call share_artifact again — each call creates a new versioned snapshot, preserving history.',
+    {
+      path: z.string().describe('Absolute path to the file you want to share'),
+      description: z.string().describe('Short description of what the artifact contains; logged for other agents'),
+    },
+    async (args) => {
+      const agentName = agent.def.id as AgentName;
+      let resolvedSource: string;
+      try {
+        resolvedSource = await assertReadable(args.path, requireSandbox(agent));
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+      let copyResult;
+      try {
+        copyResult = await copyArtifactToShared(task.taskId, resolvedSource);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+      task.touch();
+      await appendArtifactShared(task.taskId, agentName, copyResult.artifactPath, args.description);
+      const verb = copyResult.reused ? 'Already shared' : 'Shared immutable snapshot';
+      return ok(`${verb} at ${copyResult.artifactPath}. This is a read-only copy — other agents can Read it but it will never be updated. To publish revisions, edit your local file and call share_artifact again. Logged to knowledge log.`);
+    },
+  );
+}
+
 // ---- PM-only tools ----
 
 function createPostToUserTool(agent: Agent, task: Task) {
@@ -163,7 +209,8 @@ function createPostToUserTool(agent: Agent, task: Task) {
     'Use target.channel to post to a specific linked thread. ' +
     'Use target.new_dm with a user ID to start a DM conversation (links it to this task). ' +
     'Use target.new_thread with a channel ID to start a new thread in a channel (links it to this task). ' +
-    'When creating new DMs/threads, returns the channel key for future use.',
+    'When creating new DMs/threads, returns the channel key for future use. ' +
+    'To attach files, send the message first, then call `post_files_to_user` with the same target.',
     {
       message: z.string().describe('The message to send'),
       target: z.object({
@@ -185,13 +232,49 @@ function createPostToUserTool(agent: Agent, task: Task) {
       let newChannelKey: string | null;
       try {
         newChannelKey = await task.postToUser(args.message, agentName, args.target);
-      } catch (err) {
-        return ok(formatSlackSendError(err));
+      } catch (e) {
+        return ok(formatSlackSendError(e));
       }
       if (newChannelKey) {
         return ok(`Message posted. New channel linked: ${newChannelKey} (saved in task metadata for future use)`);
       }
       return ok('Message posted.');
+    },
+  );
+}
+
+function createPostFilesToUserTool(agent: Agent, task: Task) {
+  return tool(
+    'post_files_to_user',
+    'Upload one or more files as Slack file attachments to the user. Files must point to absolute paths inside your readable sandbox (e.g. shared/artifacts/...). ' +
+    'Without `channel`, attaches to the default channel. With `channel`, attaches to an already-linked thread. ' +
+    'This tool only attaches files to existing threads — it does not create new threads or DMs. To open a destination, call `post_to_user` first with `target.new_dm` or `target.new_thread`, then pass the returned channel key here. ' +
+    'Files are sent without accompanying text — call `post_to_user` separately for any message you want next to the files.',
+    {
+      paths: z.array(z.string()).min(1).describe('Absolute file paths to upload as Slack attachments'),
+      channel: z.string().optional().describe('Channel key of an existing linked thread (e.g., "slack:C123:456.789"). Omit to post to the default channel.'),
+    },
+    async (args) => {
+      const agentName = agent.def.id as AgentName;
+      if (!args.channel && Object.keys(task.metadata.channels).length === 0) {
+        return ok(
+          'No channel linked to this task. Open one first with post_to_user(target.new_dm or target.new_thread), then call post_files_to_user with the returned channel key.'
+        );
+      }
+      let validatedPaths: string[];
+      try {
+        const sandbox = requireSandbox(agent);
+        validatedPaths = await Promise.all(args.paths.map((p) => assertReadable(p, sandbox)));
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+      task.touch();
+      try {
+        await task.postFilesToUser(validatedPaths, agentName, args.channel);
+      } catch (e) {
+        return ok(formatSlackSendError(e));
+      }
+      return ok(`${validatedPaths.length} file(s) uploaded.`);
     },
   );
 }
@@ -1046,6 +1129,8 @@ export function createPMAgentMcpServer(agent: Agent, task: Task) {
     tools: [
       createSendMessageTool(agent, task),
       createPostToUserTool(agent, task),
+      createPostFilesToUserTool(agent, task),
+      createShareArtifactTool(agent, task),
       createFindSlackUserTool(agent, task),
       createFindSlackChannelTool(agent, task),
       createAssignTaskOwnerTool(agent, task),
@@ -1107,6 +1192,7 @@ export function createBaseAgentMcpServer(agent: Agent, task: Task) {
     tools: [
       createSendMessageTool(agent, task),
       createLogFindingTool(agent, task),
+      createShareArtifactTool(agent, task),
     ],
   });
 }

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -187,6 +187,48 @@ export async function postSlackMessage(args: {
 }
 
 /**
+ * Upload one or more files via `files.uploadV2`.
+ *
+ * No accompanying text — uploadV2 does not support the `markdown` block type
+ * we use elsewhere, so callers post narrative text via `postSlackMessage`
+ * separately (typically immediately before this call to seed a thread root).
+ *
+ * Returns `undefined` in dry-run mode.
+ */
+export async function postSlackFiles(args: {
+  channel: string;
+  threadTs?: string;
+  files: { path: string; filename: string }[];
+}): Promise<void> {
+  const { channel, threadTs, files } = args;
+  if (files.length === 0) {
+    throw new Error('postSlackFiles called with no files');
+  }
+  if (dryRun) {
+    const target = threadTs ? `${channel}:${threadTs}` : channel;
+    const names = files.map((f) => f.filename).join(', ');
+    logger.system(`[DRY RUN] postSlackFiles ${target} — ${files.length} file(s): ${names}`);
+    return;
+  }
+  const client = getSlackClient();
+  try {
+    await client.files.uploadV2({
+      channel_id: channel,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+      file_uploads: files.map((f) => ({ file: f.path, filename: f.filename })),
+    });
+  } catch (uploadErr) {
+    const errAny = uploadErr as { code?: string; data?: unknown; message?: string };
+    logger.warn(
+      'Slack',
+      `files.uploadV2 failed channel=${channel} threadTs=${threadTs ?? '-'} files=${files.length} ` +
+      `code=${errAny.code ?? 'n/a'} message=${errAny.message ?? 'n/a'} data=${JSON.stringify(errAny.data ?? null)}`,
+    );
+    throw uploadErr;
+  }
+}
+
+/**
  * Post an interactive message with blocks to a Slack thread
  * Used for messages with buttons (e.g., edit mode approval)
  */

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -93,6 +93,13 @@ export function getAttachmentsPath(taskId: string): string {
 }
 
 /**
+ * Get the path to a task's artifacts directory (for cross-agent file sharing)
+ */
+export function getArtifactsPath(taskId: string): string {
+  return join(getSharedPath(taskId), 'artifacts');
+}
+
+/**
  * Download Slack files to task's attachments folder
  * Returns files with localPath populated
  */
@@ -170,6 +177,24 @@ export async function loadMetadata(taskId: string): Promise<TaskMetadata | null>
 function formatLogEntry(entry: LogEntry): string {
   const typeStr = entry.type ? ` [${entry.type}]` : '';
   return `[${entry.timestamp}] [${entry.source}]${typeStr} ${entry.message}\n`;
+}
+
+/**
+ * Build the `[Attachments: …]` suffix for a list of artifact paths.
+ * Mirrors the inbound rendering at the bottom of `renderMessageForContext` so
+ * outgoing messages with attachments look symmetric in the knowledge log.
+ * Returns an empty string when there are no paths.
+ */
+export function renderAttachmentsSuffix(artifactPaths: readonly string[]): string {
+  if (!artifactPaths.length) return '';
+  const fileInfo = artifactPaths
+    .map((p) => {
+      const slash = p.lastIndexOf('/');
+      const name = slash === -1 ? p : p.slice(slash + 1);
+      return `${name} (${p})`;
+    })
+    .join(', ');
+  return `\n  [Attachments: ${fileInfo}]`;
 }
 
 /**
@@ -285,19 +310,50 @@ export async function appendAgentFinding(
 }
 
 /**
- * Append a user-facing message to the knowledge log (no event — caller emits)
+ * Append an artifact share to the knowledge log.
+ *
+ * Records that an agent published a file to `shared/artifacts/`. Other agents can
+ * read the artifact via the absolute path. Reuses the `agent:log` event channel so
+ * existing CLI/SSE rendering picks it up without changes.
+ */
+export async function appendArtifactShared(
+  taskId: string,
+  agentName: string,
+  artifactPath: string,
+  description: string,
+): Promise<void> {
+  const finding = `shared artifact: ${artifactPath} — ${description}`;
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    source: agentName,
+    type: 'artifact',
+    message: finding,
+  };
+
+  await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
+  emitEvent('agent:log', taskId, { finding, type: 'artifact' }, agentName);
+}
+
+/**
+ * Append a user-facing message to the knowledge log (no event — caller emits).
+ *
+ * When `artifactPaths` is non-empty, the rendered message includes a trailing
+ * `[Attachments: …]` line (same shape used for inbound Slack files) so the log
+ * shows what was attached.
  */
 export async function appendMessageToUser(
   taskId: string,
   agentName: string,
   message: string,
   destination?: string,
+  artifactPaths?: readonly string[],
 ): Promise<void> {
   const source = destination ? `${agentName} in ${destination}` : agentName;
+  const renderedMessage = message + renderAttachmentsSuffix(artifactPaths ?? []);
   const entry: LogEntry = {
     timestamp: new Date().toISOString(),
     source,
-    message,
+    message: renderedMessage,
   };
   await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
 }

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -42,6 +42,7 @@ import {
   appendAgentMessage,
   appendMessageToUser,
   appendSlackMessage,
+  renderAttachmentsSuffix,
   downloadMessageFiles,
   ensureSessionsDir,
   generateTaskId,
@@ -53,7 +54,8 @@ import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
 import { scanAgentDefs } from '../agents/registry.js';
 import { refreshPlugins } from '../system/workdir.js';
-import { postSlackMessage, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
+import { postSlackMessage, postSlackFiles, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
+import { basename } from 'path';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { logger } from '../system/logger.js';
 import { emitEvent } from '../system/event-bus.js';
@@ -292,9 +294,6 @@ export class Task {
       const dmChannelId = await openDMChannel(target.new_dm);
       const existing = this.findChannelBySlackId(dmChannelId);
       if (existing) {
-        // Reply inside the linked DM thread. Send first, then log on success
-        // so a rejected message (e.g. exceeding the markdown limit) is not
-        // persisted to the knowledge log or emitted to the event bus.
         await postSlackMessage({
           channel: existing.channel.channel_id,
           threadTs: existing.channel.thread_id,
@@ -340,9 +339,6 @@ export class Task {
       ? this.metadata.channels[this.metadata.default_channel]
       : null;
     if (!defaultCh) {
-      // No channel linked. Caller (tool wrapper) is expected to have caught this
-      // and returned a clear error to the agent. Internal callers reach here too
-      // (e.g. mute_thread's farewell) — stay defensive, log a warning, no-op.
       logger.warn('task', `postToUser called on task ${this.taskId} with no default channel — message dropped`);
       return null;
     }
@@ -353,6 +349,39 @@ export class Task {
       this.logOutgoingMessage(sender, message, 'cli');
     }
     return null;
+  }
+
+  /**
+   * Upload one or more files to the user via Slack's `files.uploadV2`.
+   *
+   * Posts to the default channel or to an already-linked channel via
+   * `target.channel`. New thread / DM creation is intentionally not supported —
+   * agents must call `postToUser` first to open and link a thread, then call
+   * this to attach files.
+   */
+  async postFilesToUser(filePaths: readonly string[], agentName?: string, channelKey?: string): Promise<void> {
+    if (filePaths.length === 0) return;
+    const sender = agentName || 'system';
+    const files = filePaths.map((p) => ({ path: p, filename: basename(p) }));
+
+    const target = channelKey
+      ? this.metadata.channels[channelKey]
+      : (this.metadata.default_channel ? this.metadata.channels[this.metadata.default_channel] : null);
+
+    if (!target) {
+      logger.warn(
+        'task',
+        `postFilesToUser on task ${this.taskId}: ${channelKey ? `channel ${channelKey} not linked` : 'no default channel'} — files dropped`,
+      );
+      return;
+    }
+    if (target.type === 'slack') {
+      await postSlackFiles({ channel: target.channel_id, threadTs: target.thread_id, files });
+      this.logFilesUpload(sender, filePaths, Task.formatSlackDest(target).display, target);
+    } else if (target.type === 'cli') {
+      // CLI channel can't render Slack uploads — log the file list so it surfaces.
+      this.logFilesUpload(sender, filePaths, 'cli');
+    }
   }
 
   /**
@@ -376,6 +405,20 @@ export class Task {
     logger.agentToSlack(sender, message, { destination: display });
     emitEvent('message', this.taskId, { from: sender, to: 'user', destination: display, message });
     appendMessageToUser(this.taskId, sender, message, logDest);
+  }
+
+  /**
+   * Log a file-upload action to the user. Mirrors `logOutgoingMessage` but the
+   * "message" body is the rendered `[Attachments: …]` suffix only, since
+   * `postFilesToUser` posts files without accompanying text.
+   */
+  private logFilesUpload(sender: string, filePaths: readonly string[], destination: string, slackChannel?: SlackChannel): void {
+    const display = destination;
+    const logDest = slackChannel ? Task.formatSlackDest(slackChannel).log : destination;
+    const rendered = renderAttachmentsSuffix(filePaths).trimStart();
+    logger.agentToSlack(sender, rendered, { destination: display });
+    emitEvent('message', this.taskId, { from: sender, to: 'user', destination: display, message: rendered });
+    appendMessageToUser(this.taskId, sender, '', logDest, filePaths);
   }
 
   /**

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -10,7 +10,7 @@ export type CoreAgentName = 'pm-agent' | 'triage-agent';
 /** Agent name - core agents or any repo agent (e.g., 'backend-agent', 'mobile-agent', 'web-agent') */
 export type AgentName = CoreAgentName | `${string}-agent`;
 
-export type FindingType = 'discovery' | 'decision' | 'completion' | 'blocker';
+export type FindingType = 'discovery' | 'decision' | 'completion' | 'blocker' | 'artifact';
 
 /** Tracking record for a Slack thread linked to a task */
 export interface SlackThreadRef {


### PR DESCRIPTION
## Summary
- New `share_artifact` tool publishes an immutable, content-versioned snapshot of an agent-produced document to `shared/artifacts/<basename>.<8hex>.<ext>` so other agents can `Read` it instead of receiving the whole body inlined into `send_message_to_agent`. Identical bytes dedupe; revisions create a new versioned snapshot alongside the previous one — review history is preserved.
- New `post_files_to_user` tool uploads files via `files.uploadV2` to an already-linked Slack thread. Pairs with `post_to_user`: narrative goes through the markdown-block path, files attach in the same thread. Tool intentionally does not open new threads or DMs.
- Path validation for both tools reuses the agent's sandbox read scope (now exposed on `Agent.sandbox`), so agents cannot publish or upload files they could not have read.
- Slack manifest gains `files:write`.
- Plan: [docs/plans/v26-artifact-sharing.md](docs/plans/v26-artifact-sharing.md)

## Test plan
- [x] Backend agent writes a doc, calls `share_artifact`, sends path to mobile via `send_message_to_agent` — mobile reads it
- [x] Re-share same bytes → returns existing path (dedup)
- [x] Edit + re-share → new versioned filename, both visible in `shared/artifacts/`
- [x] PM calls `post_to_user` then `post_files_to_user` — message + file appear in same Slack thread
- [x] PM tries to upload a path outside its sandbox → tool returns clear error, nothing uploaded
- [x] Knowledge log shows `[artifact]` entries for shares and `[Attachments: …]` suffix for uploads
- [x] CLI live view renders both via existing `agent:log` and `message` event branches
- [x] `npm run typecheck` and `npm test` stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)