### PR TITLE
Propagate workdir/plugins symlink across worktrees + fix wt 0.32 hook rename

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,5 +1,5 @@
 # Copy .env from base worktree, then assign a unique PORT
-[post-create]
+[pre-start]
 env-copy = "cp {{ base_worktree_path }}/.env .env 2>/dev/null || true"
 env-port = """
 if [ -f .env ] && grep -q '^PORT=' .env; then

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -8,3 +8,9 @@ else
     echo 'PORT={{ branch | hash_port }}' >> .env
 fi
 """
+# If base worktree has a workdir/plugins symlink (local plugins dev), recreate it here
+plugins-link = """
+target=$(readlink "{{ base_worktree_path }}/workdir/plugins" 2>/dev/null) && \
+    mkdir -p workdir && \
+    ln -sfn "$target" workdir/plugins || true
+"""


### PR DESCRIPTION
## Summary
- Add a worktrunk `pre-start` hook that recreates the base worktree's `workdir/plugins` symlink in newly created worktrees, so a one-time local plugins setup propagates automatically. Path-agnostic — each developer's own target carries over, and the hook no-ops when no symlink exists.
- Rename the existing `[post-create]` table to `[pre-start]`. Worktrunk 0.32.0 renamed the hook and removed the silent rewrite, so the current config fails to load on recent `wt`.

## Test plan
- [x] `wt hook show` lists all three project hooks under `pre-start` without errors
- [x] `wt switch --create test-symlink-hook` from a worktree whose `workdir/plugins` is a symlink → new worktree has the same symlink
- [x] `wt switch --create test-no-symlink` from a worktree with no `workdir/plugins` → hook is a no-op, worktree creates fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)