### PR TITLE
feat: auto-normalize PR titles with Jira/Skip prefix for configured repositories

### DIFF
--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -170,7 +170,7 @@ Fields:
 - **`model`** (string, optional): Model override. Defaults applied at spawn time in `src/agents/spawn.ts`: `opus` for the PM track, `sonnet` for repo and plugin tracks
 - **`effort`** (`'low' | 'medium' | 'high' | 'xhigh' | 'max'`, optional): Reasoning effort level passed to the SDK
 - **`maxTurns`** (number, optional): Cap on agentic turns per query (defaults to 100)
-- **`metadata.archie.repo`** (object, optional): If present with a `github` field, classifies the agent as a repo agent with `github` (repo identifier) and optional `baseBranch`
+- **`metadata.archie.repo`** (object, optional): If present with a `github` field, classifies the agent as a repo agent with `github` (repo identifier), optional `baseBranch`, and optional `prTitlePolicy` (`'jira-or-skip'` — auto-normalizes PR titles to `[PROJ-123]` or `[Skip]` prefix)
 - **`mcpServers`** (string[], optional): MCP server names from the root `.mcp.json` that this agent should have access to
 - **`tools`** (string[], optional): Tool allowlist. When omitted, the SDK runs with `bypassPermissions` and all built-in/MCP tools are available; when set, it restricts the agent to exactly the listed entries (so MCP wildcards must be added explicitly)
 - **`disallowedTools`** (string[], optional): Tool denylist (always applied on top of the allowlist)

--- a/docs/guides/pr-title-policy-jira-or-skip.md
+++ b/docs/guides/pr-title-policy-jira-or-skip.md
@@ -1,0 +1,76 @@
+# Enabling Jira / `[Skip]` PR title normalization (`jira-or-skip`)
+
+After the **archie-hq** change that adds `prTitlePolicy` is merged and deployed, normalization runs only for repo agents that opt in via plugin frontmatter. Nothing else in this repository is required for activation.
+
+## What it does
+
+For agents with `prTitlePolicy: jira-or-skip`:
+
+- `create_pull_request` and `update_pr` normalize titles to **`[PROJ-123] …`** or **`[Skip] …`**.
+- If the model omits a prefix, **`[Skip]`** is prepended automatically so the PR still opens.
+- Repos without this policy are unchanged.
+
+## Step 1: Deploy archie-hq
+
+Ship the revision that includes `prTitlePolicy` support (build, release, restart workers or whichever processes run Archie). Use your normal deployment path (see [deployment.md](./deployment.md) if applicable).
+
+Until this code is live, frontmatter changes in plugins have no effect.
+
+## Step 2: Edit the plugins repository
+
+Plugins are loaded from the git URL in **`ARCHIE_PLUGINS`** (see [plugin system](../architecture/plugin-system.md)). You must change the **engineering** (or equivalent) plugin checkout that defines your **mobile** repo agent.
+
+### Find the correct file
+
+Locate the **repo agent** markdown whose frontmatter already binds the mobile GitHub repository, for example:
+
+- Path pattern: `agents/<key>.md` (e.g. `agents/mobile.md`)
+- It must contain `metadata.archie.repo.github` pointing at the mobile app repo (e.g. `sweatco/sweatcoin-mobile`).
+
+Do **not** add this to PM or plugin-only agents; only repo agents have `metadata.archie.repo` with `github`.
+
+### Add the policy
+
+Under **`metadata.archie.repo`**, add **`prTitlePolicy: jira-or-skip`** alongside existing keys:
+
+```yaml
+metadata:
+  archie:
+    repo:
+      github: sweatco/sweatcoin-mobile   # use your real org/repo
+      baseBranch: main                   # optional; keep if already present
+      prTitlePolicy: jira-or-skip        # add this
+```
+
+Indentation: `prTitlePolicy` must be a sibling of `github` (and `baseBranch` if present), not nested under `github`.
+
+Commit and push to the branch your runtime uses (often the default branch configured with `ARCHIE_PLUGINS_BRANCH`, if set).
+
+## Step 3: Pick up the new plugin revision
+
+Depending on your setup:
+
+- **Production:** restart Archie or wait for the plugin refresh / next boot so `bootstrapWorkdir()` fetches the latest plugin commit; or redeploy so a fresh pull runs.
+- **Local dev:** ensure `$ARCHIE_WORKDIR/plugins/…` reflects your push (pull, symlink refresh, or clean workdir as you usually do).
+
+If plugins are a **symlink** to a local clone, update that clone and restart the app.
+
+## Verification
+
+1. Start a task that uses the mobile repo agent in **edit mode** and create a PR with a title **without** a prefix (e.g. `Fix typo`).
+2. Confirm the GitHub PR title is **`[Skip] Fix typo`** (or similar).
+3. Create another PR with an explicit Jira-style title (e.g. `[SWEAT-123] Fix typo`) and confirm it is unchanged (aside from trim/spacing normalization if applicable).
+4. Check logs for lines like `PR title normalized (jira-or-skip): …` when adjustment happens.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|--------|----------------|
+| No normalization | `prTitlePolicy` missing or wrong indent in frontmatter; or old archie-hq binary still running |
+| Wrong repo affected | Policy added to the wrong `agents/*.md` file (not the mobile repo agent) |
+| Plugins not updating | Branch mismatch, refresh cooldown, or symlinked plugins not pulled |
+
+## Rollback
+
+- Remove **`prTitlePolicy`** from the agent frontmatter and redeploy plugins; behavior returns to plain titles for that agent only.
+- Reverting the archie-hq merge removes the feature globally; then frontmatter keys are ignored.

--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -129,7 +129,7 @@ Write:
 1. Commit all changes with `git commit`
 2. `push_branch()` to push
 3. Read `metadata.json` from the shared folder to find the originating channel (look for the `default_channel` key, then find that channel in `channels`). If the `channel_name` starts with `DM with`, do NOT include the URL — instead write `Requested by <name>` using the name from `channel_name`. Otherwise, include a link at the bottom of the PR body using the channel name (e.g. `Slack thread in #channel-name: <url>`)
-4. `create_pull_request(title, body)` with a clear description
+4. `create_pull_request(title, body)` with a clear description{{PR_TITLE_POLICY_HINT}}
 5. Notify pm-agent: "PR #123 created: <url>"
 
 ### Handling Reviews

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -12,6 +12,7 @@ import {
   mirrorLegacyFields,
   hydrateBranchState,
   findBranchStateByPR,
+  normalizeJiraOrSkipTitle,
 } from '../tools.js';
 import type { Agent } from '../agent.js';
 import type { Task } from '../../tasks/task.js';
@@ -93,6 +94,37 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
     queue: {} as any,
     session: { active: false },
   } as Agent;
+}
+
+function makePolicyAgent(): Agent {
+  return makeAgent({
+    id: 'mobile-agent',
+    key: 'mobile',
+    repo: {
+      githubRepo: 'org/mobile',
+      repoKey: 'mobile',
+      defaultPath: '/repos/mobile',
+      baseBranch: 'main',
+      prTitlePolicy: 'jira-or-skip',
+    },
+  });
+}
+
+function makePolicyTask(): Task {
+  return makeTask({
+    repositories: {
+      mobile: {
+        path: '/repos/mobile',
+        clone_path: '/clones/mobile',
+        feature_branch: 'feature/task-123',
+        base_branch: 'main',
+        current_branch: 'feature/task-123',
+        branch_states: {
+          'feature/task-123': { base_branch: 'main' },
+        },
+      },
+    },
+  });
 }
 
 function makeTask(overrides: Partial<Task['metadata']> = {}): Task {
@@ -267,6 +299,119 @@ describe('get_pr_status (read-only server)', () => {
     expect(result.content[0].text).toContain('State: open');
     expect(result.content[0].text).toContain('Mergeable: true');
     expect(result.content[0].text).toContain('Approved: true');
+  });
+});
+
+describe('normalizeJiraOrSkipTitle', () => {
+  it('leaves compliant titles as-is (after trim)', () => {
+    expect(normalizeJiraOrSkipTitle('[SWEAT-1] Fix thing')).toBe('[SWEAT-1] Fix thing');
+    expect(normalizeJiraOrSkipTitle('  [AB-999] Edge case  ')).toBe('[AB-999] Edge case');
+    expect(normalizeJiraOrSkipTitle('[Skip] Chore only')).toBe('[Skip] Chore only');
+  });
+
+  it('prepends [Skip] when prefix is missing, fixes [skip] casing and empty title', () => {
+    expect(normalizeJiraOrSkipTitle('Fix thing')).toBe('[Skip] Fix thing');
+    expect(normalizeJiraOrSkipTitle('[skip] lower case')).toBe('[Skip] lower case');
+    expect(normalizeJiraOrSkipTitle('[Skip]')).toBe('[Skip] Pull request');
+    expect(normalizeJiraOrSkipTitle('')).toBe('[Skip] Pull request');
+  });
+
+  it('wraps bare Jira keys at the start', () => {
+    expect(normalizeJiraOrSkipTitle('WEB-12 Fix')).toBe('[WEB-12] Fix');
+    expect(normalizeJiraOrSkipTitle('WEB-12')).toBe('[WEB-12] Pull request');
+  });
+
+  it('does not treat malformed bracket keys as Jira', () => {
+    expect(normalizeJiraOrSkipTitle('[SWEAT-x] bad number')).toBe('[Skip] [SWEAT-x] bad number');
+  });
+});
+
+describe('create_pull_request (prTitlePolicy: jira-or-skip)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getGitHubClient).mockReturnValue(mockGitHubClient as any);
+    mockGitHubClient.createPullRequest.mockResolvedValue({ pr_number: 55, pr_url: 'https://gh/pr/55' });
+  });
+
+  it('normalizes missing prefix and still creates PR', async () => {
+    const tool = getRepoTool(makePolicyAgent(), makePolicyTask(), 'create_pull_request');
+    const result = await tool({ title: 'No prefix', body: 'hi' }, {});
+
+    expect(result.content[0].text).not.toMatch(/^Error:/);
+    expect(mockGitHubClient.createPullRequest).toHaveBeenCalledWith(
+      'org/mobile',
+      'feature/task-123',
+      'main',
+      '[Skip] No prefix',
+      'hi',
+    );
+    expect(result.content[0].text).toContain('Title adjusted');
+  });
+
+  it('passes compliant Jira/Skip titles through unchanged', async () => {
+    const tool = getRepoTool(makePolicyAgent(), makePolicyTask(), 'create_pull_request');
+    await tool({ title: '[WEB-12] Fix', body: 'b' }, {});
+    expect(mockGitHubClient.createPullRequest).toHaveBeenCalledWith(
+      'org/mobile',
+      'feature/task-123',
+      'main',
+      '[WEB-12] Fix',
+      'b',
+    );
+
+    await tool({ title: '  [Skip] Trim me  ', body: 'c' }, {});
+    expect(mockGitHubClient.createPullRequest).toHaveBeenLastCalledWith(
+      'org/mobile',
+      'feature/task-123',
+      'main',
+      '[Skip] Trim me',
+      'c',
+    );
+  });
+
+  it('does not normalize when repo has no prTitlePolicy', async () => {
+    const tool = getRepoTool(makeAgent(), makeTask(), 'create_pull_request');
+    const result = await tool({ title: 'Plain title', body: 'x' }, {});
+
+    expect(result.content[0].text).not.toMatch(/^Error:/);
+    expect(mockGitHubClient.createPullRequest).toHaveBeenCalledWith(
+      'org/backend',
+      'feature/task-123',
+      'main',
+      'Plain title',
+      'x',
+    );
+  });
+});
+
+describe('update_pr (prTitlePolicy: jira-or-skip)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getGitHubClient).mockReturnValue(mockGitHubClient as any);
+    mockGitHubClient.updatePR.mockResolvedValue(undefined);
+  });
+
+  it('normalizes title when prTitlePolicy is set', async () => {
+    const tool = getRepoTool(makePolicyAgent(), makePolicyTask(), 'update_pr');
+    const result = await tool({ pr_number: 1, title: 'Missing prefix' }, {});
+
+    expect(mockGitHubClient.updatePR).toHaveBeenCalledWith('org/mobile', 1, {
+      title: '[Skip] Missing prefix',
+      body: undefined,
+      base: undefined,
+    });
+    expect(result.content[0].text).toContain('Title adjusted');
+  });
+
+  it('skips normalization for body-only updates', async () => {
+    const tool = getRepoTool(makePolicyAgent(), makePolicyTask(), 'update_pr');
+    await tool({ pr_number: 2, body: 'only body' }, {});
+
+    expect(mockGitHubClient.updatePR).toHaveBeenCalledWith('org/mobile', 2, {
+      title: undefined,
+      body: 'only body',
+      base: undefined,
+    });
   });
 });
 

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -70,6 +70,7 @@ export function scanAgentDefs(): AgentDef[] {
             baseBranch: agent.repo.baseBranch,
             defaultPath: join(REPOS_DIR, agent.key),
             repoKey: agent.key,
+            prTitlePolicy: agent.repo.prTitlePolicy,
           },
           pluginDataPath: join(PLUGINS_DATA_DIR, plugin.name),
           pluginHooks: plugin.hooks || undefined,

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -59,9 +59,13 @@ async function generateRepoAgentPrompt(agent: Agent): Promise<string> {
     PEER_LIST: peerList,
   });
 
+  const repo = def.repo!;
   const repoPrompt = await loadPrompt('repo-agent', {
-    REPO_KEY: def.repo!.repoKey,
-    BASE_BRANCH: def.repo!.baseBranch || 'main',
+    REPO_KEY: repo.repoKey,
+    BASE_BRANCH: repo.baseBranch || 'main',
+    PR_TITLE_POLICY_HINT: repo.prTitlePolicy === 'jira-or-skip'
+      ? ' — prefer `[PROJ-123] Title` when tied to a Jira ticket, or `[Skip] Title` when not (missing prefix is added automatically)'
+      : '',
   });
 
   const layers = [corePrompt, repoPrompt];

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -14,6 +14,7 @@ import { promisify } from 'util';
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { AgentName, FindingType } from '../types/task.js';
+import type { AgentRepoDef } from '../types/agent.js';
 import type { Task } from '../tasks/task.js';
 import type { Agent } from './agent.js';
 import { getAgentIds } from './registry.js';
@@ -118,6 +119,50 @@ export interface PRComment {
   body: string;
   createdAt: string;
   url: string;
+}
+
+// ---- PR title normalization (jira-or-skip policy) ----
+
+const JIRA_OR_SKIP_COMPLIANT = /^\[([A-Z][A-Z0-9]+-\d+|Skip)\]\s+\S/;
+
+/**
+ * Normalize a PR title to `[PROJ-123] …` or `[Skip] …` for repos with
+ * `prTitlePolicy: 'jira-or-skip'`. Never fails — missing prefix gets `[Skip]`.
+ */
+export function normalizeJiraOrSkipTitle(rawTitle: string): string {
+  const t = rawTitle.trim();
+  if (!t) return '[Skip] Pull request';
+  if (JIRA_OR_SKIP_COMPLIANT.test(t)) return t;
+
+  const skipBracket = t.match(/^\[(skip)\]\s*(.*)$/i);
+  if (skipBracket) {
+    const rest = skipBracket[2].trim();
+    return rest ? `[Skip] ${rest}` : '[Skip] Pull request';
+  }
+
+  const bracketJira = t.match(/^\[([A-Z][A-Z0-9]+-\d+)\]\s*(.*)$/);
+  if (bracketJira) {
+    const rest = bracketJira[2].trim();
+    return rest ? `[${bracketJira[1]}] ${rest}` : `[${bracketJira[1]}] Pull request`;
+  }
+
+  const bare = t.match(/^([A-Z][A-Z0-9]+-\d+)(?:\s+(.*))?$/);
+  if (bare) {
+    const rest = (bare[2] ?? '').trim();
+    return rest ? `[${bare[1]}] ${rest}` : `[${bare[1]}] Pull request`;
+  }
+
+  return `[Skip] ${t}`;
+}
+
+/**
+ * Apply the repo's prTitlePolicy (if any). Returns the possibly-normalized title.
+ */
+function applyPrTitlePolicy(repo: AgentRepoDef, rawTitle: string): string {
+  if (repo.prTitlePolicy === 'jira-or-skip') {
+    return normalizeJiraOrSkipTitle(rawTitle);
+  }
+  return rawTitle;
 }
 
 // ---- Tool creation helpers ----
@@ -569,18 +614,29 @@ function createPushBranchTool(agent: Agent, task: Task) {
 }
 
 function createPullRequestTool(agent: Agent, task: Task) {
-  const repoKey = agent.def.repo!.repoKey;
-  const githubRepo = agent.def.repo!.githubRepo;
+  const repo = agent.def.repo!;
+  const repoKey = repo.repoKey;
+  const githubRepo = repo.githubRepo;
+  const hasPolicy = !!repo.prTitlePolicy;
+  const titleFieldDesc = hasPolicy
+    ? 'PR title. Prefer [PROJECT-123] when tied to a Jira ticket, or [Skip] when not; missing prefix is added automatically.'
+    : 'PR title';
   return tool(
     'create_pull_request',
     'Create a pull request on GitHub.',
     {
-      title: z.string().describe('PR title'),
+      title: z.string().describe(titleFieldDesc),
       body: z.string().describe('PR description body'),
     },
     async (args) => {
       const agentName = agent.def.id as AgentName;
-      logger.agentAction(agentName, 'Creating PR', args.title);
+      const original = args.title.trim();
+      const title = applyPrTitlePolicy(repo, args.title);
+      if (title !== original) {
+        logger.system(`PR title normalized (${repo.prTitlePolicy}): ${JSON.stringify(original)} → ${JSON.stringify(title)}`);
+      }
+
+      logger.agentAction(agentName, 'Creating PR', title);
 
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
@@ -589,9 +645,9 @@ function createPullRequestTool(agent: Agent, task: Task) {
       const branch = repoInfo?.current_branch;
       const state = branch ? repoInfo?.branch_states?.[branch] : undefined;
       const head = branch || `feature/task-${task.taskId}`;
-      const base = state?.base_branch || agent.def.repo!.baseBranch || 'main';
+      const base = state?.base_branch || repo.baseBranch || 'main';
 
-      const result = await client.createPullRequest(githubRepo, head, base, args.title, args.body);
+      const result = await client.createPullRequest(githubRepo, head, base, title, args.body);
 
       if (state) {
         state.pr_number = result.pr_number;
@@ -602,7 +658,10 @@ function createPullRequestTool(agent: Agent, task: Task) {
       }
 
       await appendAgentFinding(task.taskId, agentName, `Created PR #${result.pr_number}: ${result.pr_url}`, 'decision');
-      return ok(`Created PR #${result.pr_number}: ${result.pr_url}`);
+      const message = title !== original
+        ? `Created PR #${result.pr_number}: ${result.pr_url}\n(Title adjusted: ${title})`
+        : `Created PR #${result.pr_number}: ${result.pr_url}`;
+      return ok(message);
     },
   );
 }
@@ -757,25 +816,42 @@ function createGetPRTool(agent: Agent, task: Task) {
 }
 
 function createUpdatePRTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
+  const repo = agent.def.repo!;
+  const githubRepo = repo.githubRepo;
+  const hasPolicy = !!repo.prTitlePolicy;
+  const titleFieldDesc = hasPolicy
+    ? 'New PR title. Same automatic normalization as create_pull_request for this repository.'
+    : 'New PR title';
   return tool(
     'update_pr',
     'Update the title, description, and/or base branch of a pull request. All fields are optional — include only what needs to change.',
     {
       pr_number: z.number().describe('The PR number'),
-      title: z.string().optional().describe('New PR title'),
+      title: z.string().optional().describe(titleFieldDesc),
       body: z.string().optional().describe('New PR description body'),
       base: z.string().optional().describe('New base branch (retarget the PR, e.g. "main" → "release-1.2")'),
     },
     async (args) => {
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
+      let title = args.title;
+      let adjusted = false;
+      if (title !== undefined) {
+        const original = title.trim();
+        title = applyPrTitlePolicy(repo, title);
+        adjusted = title !== original;
+        if (adjusted) {
+          logger.system(`PR title normalized (${repo.prTitlePolicy}): ${JSON.stringify(original)} → ${JSON.stringify(title)}`);
+        }
+      }
       await client.updatePR(githubRepo, args.pr_number, {
-        title: args.title,
+        title,
         body: args.body,
         base: args.base,
       });
-      return { content: [{ type: 'text' as const, text: `Updated PR #${args.pr_number}` }] };
+      return ok(adjusted
+        ? `Updated PR #${args.pr_number}. Title adjusted: ${title}`
+        : `Updated PR #${args.pr_number}`);
     },
   );
 }

--- a/src/system/plugin-loader.ts
+++ b/src/system/plugin-loader.ts
@@ -89,6 +89,7 @@ export interface PluginAgentDef {
   repo?: {
     github: string;
     baseBranch?: string;
+    prTitlePolicy?: 'jira-or-skip';
   };
   /** MCP server names this agent should have access to (from plugin's .mcp.json) */
   mcpServers?: string[];
@@ -193,6 +194,7 @@ function scanPlugins(): LoadedPlugin[] {
           agentDef.repo = {
             github: repoMeta.github,
             baseBranch: repoMeta.baseBranch || undefined,
+            prTitlePolicy: repoMeta.prTitlePolicy || undefined,
           };
         }
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -73,6 +73,11 @@ export interface AgentRepoDef {
   defaultPath: string;
   /** Key in TaskMetadata.repositories, e.g., 'backend', 'mobile' */
   repoKey: string;
+  /**
+   * PR title prefix policy. When set, PR titles are auto-normalized at tool level:
+   * - 'jira-or-skip': title must start with `[PROJ-123]` or `[Skip]`; missing prefix gets `[Skip]` prepended.
+   */
+  prTitlePolicy?: 'jira-or-skip';
 }
 
 /**


### PR DESCRIPTION
## feat: auto-normalize PR titles with Jira/Skip prefix for configured repos

### Problem

Repo agents could open GitHub PRs without a predictable prefix: either a Jira key (`[XX-123]`) when work is tied to a ticket, or `[Skip]` when it is not. This leads to Danger checks job failure and necessity for manual re-run.

### Solution

- Add optional **`prTitlePolicy: 'jira-or-skip'`** on **`AgentRepoDef`**, sourced from plugin frontmatter **`metadata.archie.repo.prTitlePolicy`** (loaded in **`plugin-loader`**, passed through **`registry`**).
- In **`create_pull_request`** and **`update_pr`** (`tools.ts`), when the policy is set, run **`normalizeJiraOrSkipTitle`** via **`applyPrTitlePolicy`**: compliant titles pass through; missing prefix gets **`[Skip]`** prepended; bare keys like `PROJ-123 …` are normalized to bracket form. PR creation is never rejected for title shape.
- Log normalization with **`logger.system`** when the title changes; tool success text notes **Title adjusted** when applicable.
- Repo prompt: **`PR_TITLE_POLICY_HINT`** in **`spawn.ts`**, inline on step 4 in **`prompts/repo-agent.md`**.
- Document the field in **`docs/architecture/plugin-system.md`**.
- Tests in **`src/agents/__tests__/pr-tools.test.ts`** (normalizer + both tools, with and without policy).


### Linked PRs

In `archie-plugins` repo: https://github.com/sweatco/archie-plugins/pull/19