### PR TITLE
fix(docker): set bash as archie user's login shell

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -40,7 +40,7 @@ ENV GIT_ASKPASS=/app/scripts/git-askpass.sh
 
 # Create non-root user (required: bypassPermissions refuses to run as root)
 RUN groupadd -g 1001 archie && \
-    useradd -u 1001 -g archie -m archie
+    useradd -u 1001 -s /bin/bash -g archie -m archie
 
 # Create directories for volumes and set ownership
 RUN mkdir -p /workdir /app/secrets && \

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -42,7 +42,7 @@ RUN npm prune --production
 
 # Create non-root user (required: bypassPermissions refuses to run as root)
 RUN groupadd -g 1001 archie && \
-    useradd -u 1001 -g archie -m archie
+    useradd -u 1001 -s /bin/bash -g archie -m archie
 
 # Create directories and set ownership
 RUN mkdir -p /workdir /app/secrets && \


### PR DESCRIPTION
## Summary

The `archie` user inside the dev/prod containers gets `/bin/bash` as its login shell instead of the default `/bin/sh` (dash on `node:24-slim`). Suggested by @pznamensky in [this review](https://github.com/sweatco/archie-hq/pull/52#discussion_r3208236444).

## Why

While debugging a TeamCity MCP issue (Cloudflare Access service tokens not reaching the wire) we noticed Debian's `dash` silently drops env vars whose names fall outside POSIX identifier rules — e.g. `TEAMCITY_HEADER_CF-Access-Client-Id`. Hyphenated names work in `npm run dev` (macOS bash) but get filtered in `npm run docker:dev` (Debian dash) anywhere a `/bin/sh -c "…"` step appears.

Empirical test inside `node:24-slim` running the actual `@daghis/teamcity-mcp@2.12.0` binary the same way the SDK launches stdio MCP servers (direct `execve`, no shell), with hyphenated CF-Access env vars — captured the request at a localhost listener:

```
=== captured requests: 1 ===
/app/rest/projects?... → CF-Access-Client-Id: cf-id-value / Secret: (present)
```

The current archie → SDK → Claude Code → MCP chain is direct-`execve` end-to-end, so the env survives without touching `/bin/sh`. Setting bash as archie's login shell is a defensive default that helps anything that *does* consult the user's login shell (interactive `gosu archie`, anything reading `getent passwd`), without the system-wide blast radius of repointing `/bin/sh`.

## Test plan

- [ ] `npm run docker:dev` builds, container is healthy
- [ ] Trigger a TeamCity MCP tool through PM agent — Cloudflare Access doesn't reject the request
- [ ] `docker compose exec archie getent passwd archie` shows `…:/bin/bash`