### PR TITLE
Plugin runtime substitution, allowedNetworkDomains, secrets ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ build/
 # Runtime OAuth tokens (encrypted, but never commit)
 secrets/oauth/
 
+# Plugin-supplied credential files in the secrets volume
+secrets/*-credentials.json
+
 # Runtime data
 workdir/
 claude-data/

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -73,6 +73,7 @@ export function scanAgentDefs(): AgentDef[] {
           },
           pluginDataPath: join(PLUGINS_DATA_DIR, plugin.name),
           pluginHooks: plugin.hooks || undefined,
+          allowedNetworkDomains: agent.allowedNetworkDomains,
           ...resolvedMcp,
         });
       } else {
@@ -92,6 +93,7 @@ export function scanAgentDefs(): AgentDef[] {
           pluginDataPath: join(PLUGINS_DATA_DIR, plugin.name),
           skillsPath: plugin.skillsPath || undefined,
           pluginHooks: plugin.hooks || undefined,
+          allowedNetworkDomains: agent.allowedNetworkDomains,
           ...resolvedMcp,
         });
       }

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -263,6 +263,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
         join(pmWorkspace, '.claude', 'hooks'),
         join(pmWorkspace, 'CLAUDE.md'),
       ],
+      allowedNetworkDomains: def.allowedNetworkDomains,
     };
   } else if (def.track === 'repo') {
     // ---- Repo track ----
@@ -417,6 +418,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
         allowReadPaths: [repoWorkspace, repoPath, ...(useClaudeDirs ? [claudeConfigDir, claudeTmpDir] : []), ...readOnlyPaths],
         allowWritePaths: [repoWorkspace, repoPath, ...(useClaudeDirs ? [claudeTmpDir] : [])],
         denyWritePaths: [...readOnlyPaths, ...denyWriteProtected],
+        allowedNetworkDomains: def.allowedNetworkDomains,
       };
     } else {
       sandboxOpts = {
@@ -425,6 +427,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
         allowReadPaths: [repoWorkspace, repoPath, ...(useClaudeDirs ? [claudeConfigDir, claudeTmpDir] : []), ...readOnlyPaths],
         allowWritePaths: [repoWorkspace, ...(useClaudeDirs ? [claudeTmpDir] : [])],
         denyWritePaths: [repoPath, ...readOnlyPaths],
+        allowedNetworkDomains: def.allowedNetworkDomains,
       };
     }
   } else {
@@ -486,6 +489,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
         join(agentWorkspace, '.claude', 'hooks'),
         join(agentWorkspace, 'CLAUDE.md'),
       ],
+      allowedNetworkDomains: def.allowedNetworkDomains,
     };
   }
 
@@ -517,6 +521,8 @@ Shared folder: ${sharedPath} [READ-ONLY]
         CLAUDE_CONFIG_DIR: claudeConfigDir,
         CLAUDE_CODE_TMPDIR: claudeTmpDir,
       } : {}),
+      ...(def.pluginPath ? { CLAUDE_PLUGIN_ROOT: def.pluginPath } : {}),
+      ...(def.pluginDataPath ? { CLAUDE_PLUGIN_DATA: def.pluginDataPath } : {}),
     },
     resume: sessionId,
     maxTurns: def.maxTurns ?? 100,

--- a/src/system/plugin-loader.ts
+++ b/src/system/plugin-loader.ts
@@ -20,10 +20,10 @@
  * Consumers (repo-configs, task-manager) pull what they need from loaded plugins.
  */
 
-import { readFileSync, existsSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import matter from 'gray-matter';
-import { PLUGINS_DIR } from './workdir.js';
+import { PLUGINS_DIR, PLUGINS_DATA_DIR } from './workdir.js';
 import { logger } from './logger.js';
 
 export { PLUGINS_DIR };
@@ -96,6 +96,8 @@ export interface PluginAgentDef {
   tools?: string[];
   /** Tool denylist from frontmatter */
   disallowedTools?: string[];
+  /** Hostnames the sandbox should allow outbound HTTPS to from Bash. Empty/undefined = deny all. */
+  allowedNetworkDomains?: string[];
 }
 
 export interface PluginManifest {
@@ -156,6 +158,21 @@ function scanPlugins(): LoadedPlugin[] {
 
     const pluginName = manifest.name;
 
+    // Ensure per-plugin persistent data dir exists (referenced as
+    // ${CLAUDE_PLUGIN_DATA} from hooks and as `pluginDataPath` from sandbox).
+    const pluginDataDir = join(PLUGINS_DATA_DIR, pluginName);
+    mkdirSync(pluginDataDir, { recursive: true });
+
+    // Helper: substitute Claude Code plugin runtime variables.
+    //   ${CLAUDE_PLUGIN_ROOT} — read-only plugin source directory
+    //   ${CLAUDE_PLUGIN_DATA} — per-plugin persistent data directory
+    // Applied to anything authored at the plugin level (agent prompts, hooks.json).
+    // Skills are NOT substituted — skill bash commands resolve via env vars at runtime.
+    const substitutePluginVars = (text: string): string =>
+      text
+        .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginDir)
+        .replace(/\$\{CLAUDE_PLUGIN_DATA\}/g, pluginDataDir);
+
     // Load repo-config.json if present
     let repoConfigs: Record<string, PluginRepoConfig> | null = null;
     const repoConfigPath = join(pluginDir, 'repo-config.json');
@@ -184,7 +201,7 @@ function scanPlugins(): LoadedPlugin[] {
           model: data.model || undefined,
           effort,
           maxTurns,
-          prompt: content.trim(),
+          prompt: substitutePluginVars(content.trim()),
         };
 
         // If frontmatter has repo metadata, this is a repo agent
@@ -206,6 +223,11 @@ function scanPlugins(): LoadedPlugin[] {
         if (Array.isArray(data.disallowedTools)) {
           agentDef.disallowedTools = data.disallowedTools;
         }
+        if (Array.isArray(data.allowedNetworkDomains)) {
+          agentDef.allowedNetworkDomains = data.allowedNetworkDomains.filter(
+            (d: unknown): d is string => typeof d === 'string' && d.length > 0,
+          );
+        }
 
         agents.push(agentDef);
       }
@@ -221,8 +243,7 @@ function scanPlugins(): LoadedPlugin[] {
     if (existsSync(hooksPath)) {
       try {
         const raw = readFileSync(hooksPath, 'utf-8');
-        // Substitute ${CLAUDE_PLUGIN_ROOT} with the actual plugin directory path
-        const substituted = raw.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginDir);
+        const substituted = substitutePluginVars(raw);
         const parsed = JSON.parse(substituted);
         hooks = parsed.hooks ?? null;
         if (hooks) {

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -149,6 +149,9 @@ export interface AgentDef {
   /** Tools to disallow (from agent frontmatter) */
   disallowedTools?: string[];
 
+  /** Sandbox outbound-network whitelist (from agent frontmatter). Empty/undefined = deny all. */
+  allowedNetworkDomains?: string[];
+
   /** Plugin hooks config (from plugin's hooks/hooks.json), written to .claude/settings.json */
   pluginHooks?: Record<string, any>;
 }


### PR DESCRIPTION
## Summary

Three small additions to the plugin loader and agent spawn pipeline to support plugins that run external CLIs (e.g. ops plugin's `gws`):

- **`\${CLAUDE_PLUGIN_DATA}` substitution.** Now expanded alongside `\${CLAUDE_PLUGIN_ROOT}` in plugin `hooks.json` and agent prompts at plugin-load time. The per-plugin data directory (`\$ARCHIE_WORKDIR/plugins-data/<name>/`) is auto-created during plugin scan so hooks can `cd` / write there.
- **Runtime env vars.** `CLAUDE_PLUGIN_ROOT` and `CLAUDE_PLUGIN_DATA` are injected into the agent runtime when `def.pluginPath` / `def.pluginDataPath` are set, so skill Bash commands can resolve those paths at invocation time.
- **`allowedNetworkDomains` frontmatter.** Agent frontmatter accepts an optional `string[]` whitelisting outbound HTTPS hosts. Threaded into the sandbox config for all three tracks (PM, repo, plugin).
- **`.gitignore`.** Adds `secrets/*-credentials.json` so deploy-time credential files (e.g. the ops plugin's `gws-credentials.json`) never land in git.

## Test plan

- [ ] Plugin with `hooks.json` referencing `\${CLAUDE_PLUGIN_DATA}` substitutes correctly at load
- [ ] Plugin agent's Bash sees `\$CLAUDE_PLUGIN_ROOT` and `\$CLAUDE_PLUGIN_DATA` env vars
- [ ] Plugin agent with `allowedNetworkDomains: [host.example.com]` can reach that host from Bash; other hosts blocked
- [ ] `secrets/foo-credentials.json` ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)