### PR TITLE
Bump Docker base to node:24-trixie-slim for glibc 2.41

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # Development Dockerfile with hot reload support
 
-FROM node:24-slim
+FROM node:24-trixie-slim
 
 # uv/uvx for Python tool execution
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,6 +1,6 @@
 # Production Dockerfile
 
-FROM node:24-slim
+FROM node:24-trixie-slim
 
 # uv/uvx for Python tool execution
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/


### PR DESCRIPTION
## Summary

The ops plugin's \`@googleworkspace/cli\` ships a precompiled \`gws\` binary linked against glibc 2.39 (Ubuntu 24.04+ / Debian 13). Our previous \`node:24-slim\` base image is built on Debian 12 (bookworm) with glibc 2.36 — so the binary crashes on every invocation with \`GLIBC_2.39 not found\` and the ops plugin can't read Google Sheets at all.

\`node:24-trixie-slim\` is built on Debian 13 (trixie) with glibc 2.41. Same slim variant, same apt tooling — drop-in replacement.

## Test plan

- [ ] Build the image locally and run \`docker compose up\`
- [ ] Confirm container starts cleanly
- [ ] Inside the container, run \`\${CLAUDE_PLUGIN_DATA}/node_modules/.bin/gws --version\` and verify it doesn't error with the glibc warning
- [ ] Run an ops audit against the brand list spreadsheet and verify gws returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)