### PR TITLE
Add force-push support to push_branch tool with rebase guidance

### DIFF
--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -71,6 +71,7 @@ When you have Edit tools available, you also have access to:
 - `git commit` - Commit staged changes
 - `git status` - Check working tree status
 - `git merge` - Merge branches (for conflict resolution)
+- `git rebase` - Rebase current branch (non-interactive only — see "Rebasing" below)
 - `git rm` - Delete tracked files and stage the deletion
 - `git restore` - Unstage files (`git restore --staged <file>`) or discard changes (`git restore <file>`)
 
@@ -90,13 +91,24 @@ When you have Edit tools available, you also have access to:
 5. Use `git commit -m "Resolve merge conflicts"` to complete the merge
 6. `push_branch` to push the resolved branch
 
+**Rebasing:**
+
+Use rebase only when the user (or a reviewer) explicitly asks for it — otherwise prefer `git merge` for catching up to base.
+
+1. Call `fetch()` first — rebase is a local operation, so `origin/<base>` must be fresh before you start
+2. Run `git rebase origin/{{BASE_BRANCH}}` (or another target ref). Never use `-i`/`--interactive` — your shell has no editor, the command will hang
+3. If conflicts appear: read the conflicted files, edit to resolve markers, `git add` the resolved files, then `git rebase --continue`. Repeat per commit until rebase finishes
+4. If you get stuck or need to back out: `git rebase --abort` returns the branch to its pre-rebase state
+5. Push with `push_branch(force=true)` — rebase rewrites history, so a normal push will be rejected. The `force` flag uses `--force-with-lease`, which is safe (it refuses to overwrite remote work you haven't seen)
+
 **What NOT to Do:**
 
 - Do NOT chain shell commands with `&&`, `||`, or `;` — each command must be a separate Bash call (permission checks apply per command, chaining will be denied)
 - Your cwd is your workspace, NOT the repo. For git CLI commands, `cd` into your repo directory first (shown in your context as "Repository: <path>"). MCP tools (`fetch`, `switch_branch`, etc.) handle repo paths internally.
 - Do NOT use `git checkout`, `git switch`, or `git branch` — use `switch_branch` and `create_branch` tools instead
 - Do NOT use `git push`, `git fetch`, `git pull` — use `push_branch`, `fetch` tools instead
-- Do NOT use `git reset --hard` or `git rebase` (avoid destructive operations)
+- Do NOT use `git rebase -i` or `--interactive` — there is no editor, the command will hang
+- Do NOT use `git reset --hard` (destructive — drops uncommitted work)
 - Do NOT commit unrelated changes or secrets
 - Do NOT use any git or shell commands not listed above — only the listed commands are available
 

--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -93,7 +93,7 @@ When you have Edit tools available, you also have access to:
 
 **Rebasing:**
 
-Use rebase only when the user (or a reviewer) explicitly asks for it — otherwise prefer `git merge` for catching up to base.
+Default: use rebase only when the user (or a reviewer) explicitly asks for it — otherwise prefer `git merge` for catching up to base. If your repo-specific instructions (appended below this prompt) prescribe a different workflow (e.g., "always rebase before pushing"), follow those instead.
 
 1. Call `fetch()` first — rebase is a local operation, so `origin/<base>` must be fresh before you start
 2. Run `git rebase origin/{{BASE_BRANCH}}` (or another target ref). Never use `-i`/`--interactive` — your shell has no editor, the command will hang

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -564,7 +564,7 @@ function createPushBranchTool(agent: Agent, task: Task) {
   const repoKey = agent.def.repo!.repoKey;
   return tool(
     'push_branch',
-    'Push commits from the local clone to the remote origin. Set force=true after a rebase to force-push with lease (safe against overwriting concurrent updates).',
+    'Push commits from the local clone to the remote origin. Set force=true after a rebase to force-push with lease (safe against overwriting concurrent updates). Do not use force=true just because a normal push was rejected — investigate why first.',
     {
       force: z.boolean().optional().describe('Use --force-with-lease. Required after rebasing a pushed branch.'),
     },

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -564,11 +564,14 @@ function createPushBranchTool(agent: Agent, task: Task) {
   const repoKey = agent.def.repo!.repoKey;
   return tool(
     'push_branch',
-    'Push commits from the local clone to the remote origin.',
-    {},
-    async () => {
+    'Push commits from the local clone to the remote origin. Set force=true after a rebase to force-push with lease (safe against overwriting concurrent updates).',
+    {
+      force: z.boolean().optional().describe('Use --force-with-lease. Required after rebasing a pushed branch.'),
+    },
+    async (args) => {
       const agentName = agent.def.id as AgentName;
-      logger.agentAction(agentName, 'Pushing branch', repoKey);
+      const force = args.force === true;
+      logger.agentAction(agentName, force ? 'Force-pushing branch (with lease)' : 'Pushing branch', repoKey);
 
       const repoInfo = task.metadata.repositories[repoKey];
       if (!repoInfo?.clone_path) {
@@ -583,12 +586,13 @@ function createPushBranchTool(agent: Agent, task: Task) {
       }
 
       try {
-        await execAsync(`git push -u origin HEAD:${branch}`, { cwd: repoInfo.clone_path });
+        const forceFlag = force ? '--force-with-lease ' : '';
+        await execAsync(`git push ${forceFlag}-u origin HEAD:${branch}`, { cwd: repoInfo.clone_path });
 
         mirrorLegacyFields(repoInfo);
         task.debouncedSave();
 
-        const message = `Pushed ${branch} to origin`;
+        const message = `${force ? 'Force-pushed' : 'Pushed'} ${branch} to origin`;
         logger.system(`GitHub: ${message}`);
         return ok(`Successfully pushed: ${message}`);
       } catch (error) {


### PR DESCRIPTION
## Summary

Adds optional `force` parameter to the `push_branch` tool to support force-pushing with lease after rebasing, along with comprehensive documentation on rebasing workflows in the repo agent prompt.

## Changes

### Tool Enhancement (`src/agents/tools.ts`)
- Added optional `force: boolean` parameter to `push_branch` tool
- Updated tool description to explain when force-push is needed (after rebase) and when it should NOT be used
- Modified implementation to use `git push --force-with-lease` when `force=true`
- Updated logging to distinguish between normal and force-push operations
- Updated success message to reflect the push type

### Documentation (`prompts/repo-agent.md`)
- Added `git rebase` to the list of available git commands (non-interactive only)
- Added comprehensive "Rebasing" section with step-by-step workflow:
  - When to use rebase (explicit user request, or per repo-specific instructions)
  - How to safely rebase with conflict resolution
  - How to abort if needed
  - Requirement to use `push_branch(force=true)` after rebase
  - Explanation of `--force-with-lease` safety guarantees
- Updated "What NOT to Do" section to:
  - Prohibit `git rebase -i/--interactive` (no editor available)
  - Clarify that `git reset --hard` is destructive (not just rebase)

## Implementation Details

- Uses `--force-with-lease` instead of `--force` for safety—it refuses to overwrite remote work not yet fetched locally
- Force-push is only enabled when explicitly requested via the `force` parameter; normal push rejection is not automatically escalated
- Rebase workflow requires explicit `fetch()` call first to ensure `origin/<base>` is current before rebasing

https://claude.ai/code/session_01F1YCmMsrDVnp9drsWG1qbr