### PR TITLE
feat: agent visibility scoping (global / local)

### DIFF
--- a/docs/plans/v29-agent-visibility-scoping.md
+++ b/docs/plans/v29-agent-visibility-scoping.md
@@ -1,0 +1,133 @@
+# Agent Visibility Scoping (global / local)
+
+## Context
+
+Today every agent loaded from any plugin is globally addressable. The registry holds a flat list keyed by agent id (`registry.ts:19`), and `send_message_to_agent` (`tools.ts:157`) builds a static enum from `['pm-agent', ...getAgentIds()]` — every agent appears in every other agent's peer list, regardless of which plugin they belong to.
+
+This forces plugins to expose all of their helpers as part of their public surface. A plugin can't have private internal agents, and the PM agent ends up routing through a flat namespace that grows linearly with every plugin's internals.
+
+We're adding a `visibility: global | local` field to agent frontmatter so a plugin can declare internal agents that only its own agents can address. PM becomes "just a plugin" (`pluginName: 'pm'`) so the rule applies uniformly with no special bypass.
+
+**Naming model: flat IDs with strict global uniqueness.** An evaluated alternative — qualified internal keys (`plugin/agent`) so two plugins can each ship a `local helper-agent` — was rejected because it requires migrating `agent_sessions` persistence keys *and* per-task on-disk paths (`agents/<key>`, `claude/<key>` in `spawn.ts:93,144`), neither of which is worth the convenience of duplicate short names. Plugin authors prefix their internal agent filenames instead (e.g. `analytics-helper-agent.md`).
+
+A separate `subagent` (ephemeral) mode is deferred.
+
+## Design summary
+
+- **Id format unchanged**: `${key}-agent`. The registry array, `agentProcesses` map, `agent_sessions` persistence, and on-disk paths all stay flat.
+- **One startup invariant**: agent IDs are globally unique across all plugins, regardless of visibility. (Today's collision check already enforces this; we only need to ensure the rule survives the addition of `visibility`.)
+- **Per-sender `send_message_to_agent` enum** built at agent spawn (sender's `AgentDef` is already in scope): same-plugin agents (any visibility) ∪ other-plugin agents with `visibility === 'global'` ∪ `pm-agent`. Enum members are just the ids — no resolution layer needed.
+- **PM is just a plugin**: `pluginName: 'pm'`. PM's enum includes `pm`-plugin locals + all globals. PM cannot address other plugins' locals.
+- **Repo agents may declare `visibility: local`.** Webhook routing via `getAgentDefByGithubRepo` (`registry.ts:141`) is an external entry that bypasses peer-list visibility — a local repo agent still receives webhooks for its repo. PM cannot `assign_task_owner` to a local repo agent; same-plugin agents can message it directly.
+- **Default visibility**: `global` for backward compatibility. Existing agents without the field behave as today.
+
+## Implementation milestones
+
+Each milestone leaves the tree compiling and tests passing.
+
+### M1 — Frontmatter + type field (no behavior change)
+
+Files:
+- `src/system/plugin-loader.ts` (parse `visibility` from frontmatter ~line 195; add to `PluginAgentDef` interface ~line 73)
+- `src/types/agent.ts` (add `visibility: 'global' | 'local'` to `AgentDef`)
+- `src/agents/registry.ts` (default `visibility = 'global'` in both branches of `scanAgentDefs`)
+
+Parsing pattern matches the existing manual-check style at `plugin-loader.ts:194-195`:
+```
+const visibility = data.visibility === 'local' ? 'local' : 'global';
+```
+
+### M2 — Collision check survives the new field; PM moves to `pm` plugin
+
+File: `src/agents/registry.ts`
+
+- The existing `checkCollision` (line 170) already enforces global id uniqueness, which is exactly the invariant we want. No change to the rule itself; just verify the new `visibility` field doesn't loosen it inadvertently.
+- `buildPmDef` at line 224: change `pluginName: 'core'` → `pluginName: 'pm'`. PM now belongs to the `pm` plugin for visibility purposes; the `pm` plugin's locals become addressable by PM, and locals elsewhere don't.
+- The skip rule at line 47 (`if (plugin.name === 'pm' && agent.key === 'pm') continue;`) remains correct.
+- Add `buildPeerListForSender(senderDef)` that returns the visibility-filtered peer set (same-plugin any visibility ∪ other-plugin globals, excluding sender + PM). Render as the same `- ${d.id}: ${d.role}` format `buildPeerList` uses today.
+- Keep existing `buildPeerList(excludeAgentId)` as a back-compat wrapper, or update its two callers in this milestone — see M4.
+
+### M3 — Per-sender enum in `send_message_to_agent` (and `assign_task_owner`)
+
+Files:
+- `src/agents/tools.ts:157-176` — replace `allAgents()` with a function that takes the sender `AgentDef` and returns `buildPeerIdsForSender(senderDef) ∪ ['pm-agent']`. The tool factory already runs per-agent at spawn time (`spawn.ts:233`), so the sender is in scope. Guard against degenerate empty sets by always including `pm-agent`.
+- `src/agents/tools.ts:360` (PM's `assign_task_owner`) — narrow to global agents + `pm`-plugin locals using the same filter (effectively `buildPeerIdsForSender(pmDef)` minus `pm-agent`).
+- `src/tasks/task.ts:619-646` (`toolSendMessage`) — no resolution needed (ids are unique), but add a defensive visibility check: if the resolved target isn't in the sender's visible set, error back with the visible list. This guards against an agent that constructs the call outside the Zod enum (jailbreak/tool-call fuzz).
+
+### M4 — Prompt-visible peer list narrowed
+
+Files: `src/agents/spawn.ts:53, 74`
+
+- Swap `buildPeerList(def.id)` → `buildPeerListForSender(def)` at both call sites. Visibility-filtered peers flow into the `PEER_LIST` template variable.
+- PM's `TEAM_LIST` / `TEAM_EXPERTISE` are currently built once in `buildPmDef` (`registry.ts:227-233`) from all teammates. Filter them through PM's visibility set (global + `pm`-plugin locals). PM's visibility set is stable across spawns, so building inside `buildPmDef` is fine.
+
+### M5 — Display and startup logging
+
+File: `src/index.ts:113-130`
+
+- In the startup team summary, render `[<pluginName>] <id> (<visibility>) — <role>` so operators can see the visibility model at a glance.
+- After registry init, for each non-`pm` plugin: if it has zero `global` agents *and* no `local` repo agents (which can still receive webhooks), log `Warning: plugin "X" has no externally reachable agents — PM cannot dispatch into it`. Don't fail.
+- Status API at `routes.ts:137` displays ids; no logic change (ids are unchanged).
+
+## Files to be modified
+
+Production code (5 files):
+- `src/system/plugin-loader.ts`
+- `src/types/agent.ts`
+- `src/agents/registry.ts` (riskiest — collision check stays, but `buildPmDef` and the new `buildPeerListForSender` land here)
+- `src/agents/tools.ts`
+- `src/agents/spawn.ts`
+- `src/tasks/task.ts` (only the defensive visibility check in `toolSendMessage`)
+- `src/index.ts`
+
+New test files (2):
+- `src/agents/__tests__/registry-visibility.test.ts`
+- `src/agents/__tests__/peer-list.test.ts`
+
+Test fixtures to update:
+- `src/agents/__tests__/tool-contract.test.ts` (add `visibility: 'global'` to `AgentDef` literals; per-sender enum assertions)
+- `src/agents/__tests__/pr-tools.test.ts` (add `visibility: 'global'` to `AgentDef` literals)
+
+## Reused existing utilities
+
+- `resolveAgentMcpServers` (`registry.ts:189`) — unchanged.
+- `getPlugins()` / `getRootMcpConfig()` / `getPmOverlay()` — unchanged plugin loader API.
+- `loadPrompt` in `spawn.ts:44-74` — unchanged; feeds the new peer-list helper output into `PEER_LIST`.
+- `checkCollision` (`registry.ts:170`) — unchanged.
+- `getAgentDef` / `getAgentDefByGithubRepo` (`registry.ts:134, 141`) — unchanged.
+- `agent_sessions` persistence (`task.ts:151,596,836`, `persistence.ts:158-172`, `recovery.ts:55`, `agent.ts:82`, `routes.ts:137,145`) — **unchanged**; flat ids continue to work.
+- Per-task on-disk paths `agents/<key>` and `claude/<key>` (`spawn.ts:93,144`) — **unchanged**; flat keys continue to work.
+
+## What's deliberately not in this plan
+
+- No persistence-key migration. `agent_sessions` keeps flat ids.
+- No on-disk path qualification or rename migration. `agents/<key>` and `claude/<key>` stay flat.
+- No name resolver. Ids are unique, so the dispatcher just looks them up directly.
+- No `subagent` mode. Separate piece of work.
+
+## Verification
+
+**Unit tests:**
+- `registry-visibility.test.ts`: collision matrix is the existing rule (any two agents with the same id → throws, regardless of visibility); `visibility` defaults to `global` when frontmatter omits it; repo agents respect declared visibility; PM is built with `pluginName: 'pm'`.
+- `peer-list.test.ts`: `buildPeerListForSender` returns expected sets for (a) PM (globals + `pm`-plugin locals), (b) a plugin agent with one local + one global sibling (sees both same-plugin agents and any external globals), (c) a plugin agent in a plugin with only locals (sees same-plugin peers + external globals, no external locals).
+- Tool-contract test: `send_message_to_agent` enum reflects per-sender filter; sender from plugin A cannot include plugin B's local in the enum.
+
+**End-to-end manual scenarios:**
+1. Create a temp plugin with one global + one local agent. Confirm via spawn-time logs that the global agent's enum contains both same-plugin peers; an agent in a different plugin sees only the global.
+2. Confirm PM dispatches to the global but cannot address the local via `assign_task_owner` or `send_message_to_agent`.
+3. Boot with an in-progress task whose `agent_sessions` contains the local agent's id; verify recovery resumes it normally (flat ids → no migration needed).
+4. Two plugins ship locals named `helper-agent` → confirm startup fails fast with the existing duplicate-id error. Rename one to `analytics-helper-agent` → confirm it loads.
+5. Mark all agents in a plugin `local`; confirm the startup warning fires (no entry point) and the system boots.
+6. Declare `visibility: local` on a repo agent; confirm webhook routing still works but PM cannot `assign_task_owner` to it.
+
+**Type check + existing test suite:**
+```
+npm run typecheck
+npm test
+```
+
+## Out of scope
+
+- `subagent` (ephemeral) visibility — separate piece of work, requires SDK Task-tool integration and a different lifecycle.
+- Qualified internal ids / persistence-key migration / on-disk path qualification — explicitly deferred. Plugin authors prefix internal agent filenames to avoid collisions.
+- Cross-plugin permission/authorization beyond visibility (signed manifests, capability tokens) — not requested.

--- a/docs/plans/v29-agent-visibility-scoping.md
+++ b/docs/plans/v29-agent-visibility-scoping.md
@@ -28,13 +28,21 @@ Each milestone leaves the tree compiling and tests passing.
 ### M1 — Frontmatter + type field (no behavior change)
 
 Files:
-- `src/system/plugin-loader.ts` (parse `visibility` from frontmatter ~line 195; add to `PluginAgentDef` interface ~line 73)
+- `src/system/plugin-loader.ts` (parse `metadata.archie.visibility` from frontmatter ~line 195; add to `PluginAgentDef` interface ~line 73)
 - `src/types/agent.ts` (add `visibility: 'global' | 'local'` to `AgentDef`)
 - `src/agents/registry.ts` (default `visibility = 'global'` in both branches of `scanAgentDefs`)
 
-Parsing pattern matches the existing manual-check style at `plugin-loader.ts:194-195`:
+Archie-specific fields live under `metadata.archie.*` to avoid colliding with the Claude Code subagent frontmatter spec (`name`, `description`, `tools`, `model`, etc. — no `visibility`). Matches the existing `metadata.archie.repo` pattern at `plugin-loader.ts:216`. Frontmatter:
+
+```yaml
+metadata:
+  archie:
+    visibility: local   # or 'global' (default)
 ```
-const visibility = data.visibility === 'local' ? 'local' : 'global';
+
+Parsing:
+```
+const visibility = data.metadata?.archie?.visibility === 'local' ? 'local' : 'global';
 ```
 
 ### M2 — Collision check survives the new field; PM moves to `pm` plugin

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -51,6 +51,8 @@ vi.mock('../../system/logger.js', () => ({
 
 vi.mock('../registry.js', () => ({
   getAgentIds: vi.fn().mockReturnValue(['backend-agent', 'mobile-agent']),
+  getVisiblePeerIdsForSender: vi.fn().mockReturnValue(['backend-agent', 'mobile-agent']),
+  getAgentDef: vi.fn().mockReturnValue(undefined),
 }));
 
 // ---- Helpers ----
@@ -82,6 +84,7 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
       expertise: 'Node.js',
       track: 'repo',
       pluginName: 'engineering',
+      visibility: 'global',
       repo: {
         githubRepo: 'org/backend',
         repoKey: 'backend',

--- a/src/agents/__tests__/registry-visibility.test.ts
+++ b/src/agents/__tests__/registry-visibility.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Visibility & per-sender peer-list tests for the registry.
+ *
+ * These tests exercise the pure registry helpers by injecting a synthetic
+ * registry state via the testing hooks. We don't load plugins from disk —
+ * we just want to verify that `getVisiblePeerIdsForSender` and
+ * `buildPeerListForSender` honour the visibility rules.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { AgentDef } from '../../types/agent.js';
+import {
+  __setRegistryForTesting,
+  getVisiblePeerIdsForSender,
+  buildPeerListForSender,
+} from '../registry.js';
+
+function mkPlugin(pluginName: string, key: string, visibility: 'global' | 'local', extras: Partial<AgentDef> = {}): AgentDef {
+  return {
+    id: `${key}-agent`,
+    key,
+    role: `${key} role`,
+    expertise: `${key} expertise`,
+    track: 'plugin',
+    pluginName,
+    visibility,
+    ...extras,
+  } as AgentDef;
+}
+
+function mkRepo(pluginName: string, key: string, visibility: 'global' | 'local'): AgentDef {
+  return {
+    id: `${key}-agent`,
+    key,
+    role: `${key} role`,
+    expertise: `${key} expertise`,
+    track: 'repo',
+    pluginName,
+    visibility,
+    repo: {
+      githubRepo: `org/${key}`,
+      repoKey: key,
+      defaultPath: `/repos/${key}`,
+    },
+  } as AgentDef;
+}
+
+function mkPm(): AgentDef {
+  return {
+    id: 'pm-agent',
+    key: 'pm',
+    role: 'PM',
+    expertise: 'Coordination',
+    track: 'pm',
+    pluginName: 'pm',
+    visibility: 'global',
+  } as AgentDef;
+}
+
+describe('getVisiblePeerIdsForSender', () => {
+  beforeEach(() => {
+    __setRegistryForTesting([
+      mkPm(),
+      mkPlugin('analytics', 'analytics', 'global'),
+      mkPlugin('analytics', 'analytics-helper', 'local'),
+      mkPlugin('frontend', 'frontend', 'global'),
+      mkPlugin('frontend', 'frontend-internal', 'local'),
+      mkRepo('engineering', 'backend', 'global'),
+    ]);
+  });
+
+  it('a global agent sees all globals + its own plugin locals (no other-plugin locals)', () => {
+    const sender = mkPlugin('analytics', 'analytics', 'global');
+    expect(getVisiblePeerIdsForSender(sender).sort()).toEqual([
+      'analytics-helper-agent',
+      'backend-agent',
+      'frontend-agent',
+    ]);
+  });
+
+  it('a local agent sees the same set as a sibling global', () => {
+    const sender = mkPlugin('analytics', 'analytics-helper', 'local');
+    expect(getVisiblePeerIdsForSender(sender).sort()).toEqual([
+      'analytics-agent',
+      'backend-agent',
+      'frontend-agent',
+    ]);
+  });
+
+  it('PM (in `pm` plugin) sees all globals and pm-plugin locals', () => {
+    __setRegistryForTesting([
+      mkPm(),
+      mkPlugin('analytics', 'analytics', 'global'),
+      mkPlugin('analytics', 'analytics-helper', 'local'),
+      mkPlugin('pm', 'pm-helper', 'local'),
+    ]);
+    const pm = mkPm();
+    expect(getVisiblePeerIdsForSender(pm).sort()).toEqual([
+      'analytics-agent',
+      'pm-helper-agent',
+    ]);
+  });
+
+  it('excludes the sender itself', () => {
+    const sender = mkPlugin('analytics', 'analytics', 'global');
+    expect(getVisiblePeerIdsForSender(sender)).not.toContain('analytics-agent');
+  });
+
+  it('an agent in a plugin with only locals sees its siblings + external globals', () => {
+    __setRegistryForTesting([
+      mkPm(),
+      mkPlugin('isolated', 'iso-a', 'local'),
+      mkPlugin('isolated', 'iso-b', 'local'),
+      mkPlugin('other', 'other', 'global'),
+    ]);
+    const sender = mkPlugin('isolated', 'iso-a', 'local');
+    expect(getVisiblePeerIdsForSender(sender).sort()).toEqual([
+      'iso-b-agent',
+      'other-agent',
+    ]);
+  });
+
+  it('a local repo agent is invisible to other plugins', () => {
+    __setRegistryForTesting([
+      mkPm(),
+      mkRepo('engineering', 'private-repo', 'local'),
+      mkPlugin('frontend', 'frontend', 'global'),
+    ]);
+    const sender = mkPlugin('frontend', 'frontend', 'global');
+    expect(getVisiblePeerIdsForSender(sender)).not.toContain('private-repo-agent');
+  });
+});
+
+describe('buildPeerListForSender', () => {
+  beforeEach(() => {
+    __setRegistryForTesting([
+      mkPm(),
+      mkPlugin('analytics', 'analytics', 'global'),
+      mkPlugin('analytics', 'analytics-helper', 'local'),
+      mkPlugin('frontend', 'frontend-internal', 'local'),
+      mkRepo('engineering', 'backend', 'global'),
+    ]);
+  });
+
+  it('renders repo peers and plugin peers in their respective formats', () => {
+    const sender = mkPlugin('analytics', 'analytics', 'global');
+    const list = buildPeerListForSender(sender);
+    expect(list).toContain('- backend-agent: backend role (backend repository)');
+    expect(list).toContain('- analytics-helper-agent: analytics-helper role [analytics]');
+    expect(list).not.toContain('frontend-internal-agent');
+  });
+
+  it('a plugin with only locals shows external globals + same-plugin siblings', () => {
+    const sender = mkPlugin('frontend', 'frontend-internal', 'local');
+    const list = buildPeerListForSender(sender);
+    expect(list).toContain('backend-agent');
+    expect(list).toContain('analytics-agent');
+    expect(list).not.toContain('analytics-helper-agent');
+  });
+});

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -44,6 +44,8 @@ vi.mock('../../system/logger.js', () => ({
 
 vi.mock('../registry.js', () => ({
   getAgentIds: vi.fn().mockReturnValue(['backend-agent', 'mobile-agent']),
+  getVisiblePeerIdsForSender: vi.fn().mockReturnValue(['backend-agent', 'mobile-agent']),
+  getAgentDef: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock('../../connectors/slack/client.js', () => ({
@@ -57,7 +59,7 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
   return {
     def: {
       id: 'backend-agent', key: 'backend', role: 'Backend', expertise: 'Node',
-      track: 'repo', pluginName: 'engineering',
+      track: 'repo', pluginName: 'engineering', visibility: 'global',
       repo: { githubRepo: 'org/backend', repoKey: 'backend', defaultPath: '/repos/backend' },
       ...overrides,
     },

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -52,6 +52,8 @@ export function scanAgentDefs(): AgentDef[] {
       // Resolve MCP servers and tool permissions from frontmatter
       const resolvedMcp = resolveAgentMcpServers(agent, rootMcp);
 
+      const visibility: 'global' | 'local' = agent.visibility ?? 'global';
+
       if (agent.repo) {
         // Repo agent — has repo metadata in frontmatter
         defs.push({
@@ -64,6 +66,7 @@ export function scanAgentDefs(): AgentDef[] {
           maxTurns: agent.maxTurns,
           track: 'repo',
           pluginName: plugin.name,
+          visibility,
           agentPrompt: agent.prompt || undefined,
           repo: {
             githubRepo: agent.repo.github,
@@ -88,6 +91,7 @@ export function scanAgentDefs(): AgentDef[] {
           maxTurns: agent.maxTurns,
           track: 'plugin',
           pluginName: plugin.name,
+          visibility,
           agentPrompt: agent.prompt,
           pluginPath: plugin.dir,
           pluginDataPath: join(PLUGINS_DATA_DIR, plugin.name),
@@ -112,6 +116,15 @@ export function scanAgentDefs(): AgentDef[] {
  */
 export function getAllAgentDefs(): AgentDef[] {
   return registry;
+}
+
+/**
+ * Test-only: override the in-memory registry. Used by unit tests that exercise
+ * the pure helpers (visibility filtering, peer-list construction) without
+ * loading plugins from disk. Do not call from production code.
+ */
+export function __setRegistryForTesting(defs: AgentDef[]): void {
+  registry = defs;
 }
 
 /**
@@ -150,16 +163,33 @@ export function getPmDef(): AgentDef | undefined {
 }
 
 /**
- * Build a formatted peer list string for agent prompts.
- * Includes all agents except the excluded one (and PM).
+ * Return the set of agent ids the sender is allowed to address.
+ * Filter rules:
+ *   - Same-plugin peers are always visible (any visibility).
+ *   - Other-plugin peers are visible only if visibility === 'global'.
+ *   - PM is excluded (the send_message_to_agent enum adds it back as a fallback).
+ *   - The sender itself is excluded.
  */
-export function buildPeerList(excludeAgentId: string): string {
+export function getVisiblePeerIdsForSender(senderDef: AgentDef): string[] {
+  return registry
+    .filter((d) => d.track !== 'pm')
+    .filter((d) => d.id !== senderDef.id)
+    .filter((d) => d.pluginName === senderDef.pluginName || d.visibility === 'global')
+    .map((d) => d.id);
+}
+
+/**
+ * Build a formatted peer list for the sender's prompt, applying visibility rules.
+ */
+export function buildPeerListForSender(senderDef: AgentDef): string {
+  const visibleIds = new Set(getVisiblePeerIdsForSender(senderDef));
+
   const repoPeers = registry
-    .filter((d) => d.track === 'repo' && d.id !== excludeAgentId)
+    .filter((d) => d.track === 'repo' && visibleIds.has(d.id))
     .map((d) => `- ${d.id}: ${d.role} (${d.repo!.repoKey} repository)`);
 
   const pluginPeers = registry
-    .filter((d) => d.track === 'plugin' && d.id !== excludeAgentId)
+    .filter((d) => d.track === 'plugin' && visibleIds.has(d.id))
     .map((d) => `- ${d.id}: ${d.role} [${d.pluginName}]`);
 
   return [...repoPeers, ...pluginPeers].join('\n');
@@ -224,11 +254,17 @@ function resolveAgentMcpServers(
 function buildPmDef(teamDefs: AgentDef[], rootMcp: LoadedMcpConfig): AgentDef {
   const pmPlugin = getPlugins().find((p) => p.name === 'pm');
 
-  const teamList = teamDefs
+  // PM belongs to the "pm" plugin for visibility purposes — agents marked `local`
+  // in the pm plugin are addressable by PM, locals elsewhere are not.
+  const visibleTeam = teamDefs.filter(
+    (d) => d.pluginName === 'pm' || d.visibility === 'global',
+  );
+
+  const teamList = visibleTeam
     .map((d) => `- ${d.id}: ${d.role}`)
     .join('\n');
 
-  const teamExpertise = teamDefs
+  const teamExpertise = visibleTeam
     .map((d) => `- ${d.id}: ${d.expertise}`)
     .join('\n');
 
@@ -245,7 +281,8 @@ function buildPmDef(teamDefs: AgentDef[], rootMcp: LoadedMcpConfig): AgentDef {
     effort: overlay?.effort,
     maxTurns: overlay?.maxTurns,
     track: 'pm',
-    pluginName: 'core',
+    pluginName: 'pm',
+    visibility: 'global',
     pluginDataPath: join(PLUGINS_DATA_DIR, 'pm'),
     pmConfig: { teamList, teamExpertise },
     pmOverlayPrompt: overlay?.prompt || undefined,

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -21,7 +21,7 @@ import {
 } from './tools.js';
 import { hydrateBranchState } from '../connectors/github/branch-state.js';
 import { createResearchMcpServer, createResearchPostToolHook, createResearchDefenseTagHook } from '../mcp/research-tools.js';
-import { buildPeerList } from './registry.js';
+import { buildPeerListForSender } from './registry.js';
 import {
   getSharedPath,
   getTaskPath,
@@ -50,7 +50,7 @@ async function generatePMPrompt(task: Task): Promise<string> {
 
 async function generateRepoAgentPrompt(agent: Agent): Promise<string> {
   const def = agent.def;
-  const peerList = buildPeerList(def.id);
+  const peerList = buildPeerListForSender(def);
 
   const corePrompt = await loadPrompt('agent-core', {
     AGENT_ID: def.id,
@@ -71,7 +71,7 @@ async function generateRepoAgentPrompt(agent: Agent): Promise<string> {
 
 async function generatePluginAgentPrompt(agent: Agent): Promise<string> {
   const def = agent.def;
-  const peerList = buildPeerList(def.id);
+  const peerList = buildPeerListForSender(def);
 
   const corePrompt = await loadPrompt('agent-core', {
     AGENT_ID: def.id,

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
 import type { AgentName, FindingType } from '../types/task.js';
 import type { Task } from '../tasks/task.js';
 import type { Agent } from './agent.js';
-import { getAgentIds } from './registry.js';
+import { getAgentIds, getVisiblePeerIdsForSender, getAgentDef } from './registry.js';
 import { getGitHubClient } from '../connectors/github/client.js';
 import { gitExec } from '../connectors/github/repo-clone.js';
 import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
@@ -154,8 +154,17 @@ export interface PRChecksReport {
 
 // ---- Tool creation helpers ----
 
-function allAgents(): [string, ...string[]] {
-  return ['pm-agent', ...getAgentIds()] as [string, ...string[]];
+/**
+ * Build the enum of agents the given sender can message.
+ * Always includes 'pm-agent' as a fallback target so an isolated local helper
+ * can still escalate. Excludes the sender itself.
+ */
+function visibleTargetsForSender(senderDef: import('../types/agent.js').AgentDef): [string, ...string[]] {
+  const visible = new Set<string>(getVisiblePeerIdsForSender(senderDef));
+  // PM is always reachable (escalation channel), except when the sender is PM itself.
+  if (senderDef.id !== 'pm-agent') visible.add('pm-agent');
+  const list = Array.from(visible);
+  return (list.length > 0 ? list : ['pm-agent']) as [string, ...string[]];
 }
 
 // ---- Base tools (all agents) ----
@@ -165,7 +174,7 @@ function createSendMessageTool(agent: Agent, task: Task) {
     'send_message_to_agent',
     'Send a message to another agent and wait for their response. Use this to coordinate with peer agents.',
     {
-      target: z.enum(allAgents()).describe('The agent to send the message to'),
+      target: z.enum(visibleTargetsForSender(agent.def)).describe('The agent to send the message to'),
       message: z.string().describe('The message content to send'),
     },
     async (args) => {
@@ -357,7 +366,12 @@ function createFindSlackChannelTool(_agent: Agent, _task: Task) {
 }
 
 function createAssignTaskOwnerTool(agent: Agent, task: Task) {
-  const taskOwnerAgents = getAgentIds() as [string, ...string[]];
+  // PM can only assign to agents it can see — globals + same-plugin (pm) locals.
+  const visibleIds = getVisiblePeerIdsForSender(agent.def);
+  // Defensive fallback: if no visible peers (misconfigured deployment), expose
+  // the legacy full list so the tool still type-checks and PM gets a clear
+  // runtime error instead of a Zod construction crash.
+  const taskOwnerAgents = (visibleIds.length > 0 ? visibleIds : getAgentIds()) as [string, ...string[]];
   return tool(
     'assign_task_owner',
     'Assign a task owner who will lead the investigation. Call this before sending the initial assignment message.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ async function main(): Promise<void> {
       logger.plain(`    overlay: pm plugin`);
     }
     for (const def of repoDefs) {
-      logger.plain(`  [${def.pluginName}] ${def.id} — ${def.role}`);
+      logger.plain(`  [${def.pluginName}] ${def.id} (${def.visibility}) — ${def.role}`);
       const gitName = await configureGitIdentity(def.repo!.defaultPath);
       logger.plain(`    repo: ${def.repo!.defaultPath} (${def.repo!.githubRepo})`);
       if (gitName) {
@@ -141,12 +141,32 @@ async function main(): Promise<void> {
       }
     }
     for (const def of agentDefs.filter((d) => d.track === 'plugin')) {
-      logger.plain(`  [${def.pluginName}] ${def.id} — ${def.role}`);
+      logger.plain(`  [${def.pluginName}] ${def.id} (${def.visibility}) — ${def.role}`);
       if (def.mcpServers) {
         logger.plain(`    mcp: ${Object.keys(def.mcpServers).join(', ')}`);
       }
     }
     logger.plain('');
+
+    // Warn about plugins that have no externally reachable agents.
+    // Repo agents can still be addressed via webhooks even when local, so they
+    // count as external entry points; plugin agents must be `global` for PM
+    // (or another plugin) to dispatch into them.
+    const pluginNames = new Set(plugins.map((p) => p.name));
+    pluginNames.delete('pm');
+    for (const pluginName of pluginNames) {
+      const pluginAgents = agentDefs.filter((d) => d.pluginName === pluginName && d.track !== 'pm');
+      if (pluginAgents.length === 0) continue;
+      const hasEntryPoint = pluginAgents.some(
+        (d) => d.visibility === 'global' || d.track === 'repo',
+      );
+      if (!hasEntryPoint) {
+        logger.warn(
+          'system',
+          `Plugin "${pluginName}" has no externally reachable agents — PM cannot dispatch into it (all agents are local).`,
+        );
+      }
+    }
 
     // ---- HTTP Server Setup ----
 

--- a/src/system/plugin-loader.ts
+++ b/src/system/plugin-loader.ts
@@ -83,6 +83,12 @@ export interface PluginAgentDef {
   effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   /** Maximum agentic turns from frontmatter */
   maxTurns?: number;
+  /**
+   * Visibility from frontmatter (default 'global').
+   * 'local' agents are only addressable by other agents in the same plugin;
+   * external entries (webhooks) still reach repo agents regardless.
+   */
+  visibility?: 'global' | 'local';
   /** Markdown body (domain-specific instructions) */
   prompt: string;
   /** Repo metadata from frontmatter (if present, agent is a repo agent) */
@@ -193,6 +199,7 @@ function scanPlugins(): LoadedPlugin[] {
 
         const effort = ['low', 'medium', 'high', 'xhigh', 'max'].includes(data.effort) ? data.effort : undefined;
         const maxTurns = typeof data.maxTurns === 'number' && data.maxTurns > 0 ? data.maxTurns : undefined;
+        const visibility: 'global' | 'local' = data.visibility === 'local' ? 'local' : 'global';
 
         const agentDef: PluginAgentDef = {
           key,
@@ -201,6 +208,7 @@ function scanPlugins(): LoadedPlugin[] {
           model: data.model || undefined,
           effort,
           maxTurns,
+          visibility,
           prompt: substitutePluginVars(content.trim()),
         };
 

--- a/src/system/plugin-loader.ts
+++ b/src/system/plugin-loader.ts
@@ -84,9 +84,11 @@ export interface PluginAgentDef {
   /** Maximum agentic turns from frontmatter */
   maxTurns?: number;
   /**
-   * Visibility from frontmatter (default 'global').
+   * Visibility from `metadata.archie.visibility` (default 'global').
    * 'local' agents are only addressable by other agents in the same plugin;
    * external entries (webhooks) still reach repo agents regardless.
+   * Namespaced under metadata.archie because `visibility` isn't part of the
+   * Claude Code subagent frontmatter spec.
    */
   visibility?: 'global' | 'local';
   /** Markdown body (domain-specific instructions) */
@@ -199,7 +201,11 @@ function scanPlugins(): LoadedPlugin[] {
 
         const effort = ['low', 'medium', 'high', 'xhigh', 'max'].includes(data.effort) ? data.effort : undefined;
         const maxTurns = typeof data.maxTurns === 'number' && data.maxTurns > 0 ? data.maxTurns : undefined;
-        const visibility: 'global' | 'local' = data.visibility === 'local' ? 'local' : 'global';
+        // Archie-specific fields are namespaced under metadata.archie to avoid
+        // colliding with the Claude Code subagent frontmatter spec (which has
+        // no `visibility` field). Same pattern as `metadata.archie.repo` below.
+        const visibility: 'global' | 'local' =
+          data.metadata?.archie?.visibility === 'local' ? 'local' : 'global';
 
         const agentDef: PluginAgentDef = {
           key,

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -52,7 +52,7 @@ import {
 } from './persistence.js';
 import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
-import { scanAgentDefs } from '../agents/registry.js';
+import { scanAgentDefs, getVisiblePeerIdsForSender } from '../agents/registry.js';
 import { refreshPlugins } from '../system/workdir.js';
 import { postSlackMessage, postSlackFiles, postInteractiveToThreads, removeReaction, buildThreadUrl, openDMChannel, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
 import { basename } from 'path';
@@ -617,6 +617,18 @@ export class Task {
    * Stays on Task because it involves lazy spawn + budget tracking + queue routing.
    */
   async toolSendMessage(fromAgent: AgentName, target: AgentName, message: string): Promise<string> {
+    // Defensive visibility gate — Zod enum on the tool already filters the targets,
+    // but if the agent constructs a call outside that enum (jailbreak / fuzz),
+    // reject the message and surface the visible set so it can recover.
+    const senderDef = this.team.find((d) => d.id === fromAgent);
+    if (senderDef && target !== 'pm-agent') {
+      const visible = new Set(getVisiblePeerIdsForSender(senderDef));
+      if (!visible.has(target)) {
+        const list = Array.from(visible).sort().join(', ') || '(none)';
+        return `Error: ${target} is not addressable from ${fromAgent} (visibility rules). Visible peers: ${list}, pm-agent`;
+      }
+    }
+
     logger.agentMessage(fromAgent, target, message, { truncate: 100 });
     this.lastActivity = new Date();
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -119,6 +119,14 @@ export interface AgentDef {
   /** Plugin name this agent belongs to */
   pluginName: string;
 
+  /**
+   * Addressing scope.
+   * - 'global': any agent (in any plugin) can address this agent and PM can dispatch to it.
+   * - 'local': only same-plugin agents can address it via send_message_to_agent.
+   *   Repo agents marked 'local' still receive webhook-routed events (external entry).
+   */
+  visibility: 'global' | 'local';
+
   /** Domain-specific prompt body (Layer 3) from agents/<key>.md */
   agentPrompt?: string;
 


### PR DESCRIPTION
## Summary

Adds a `visibility: global | local` field to agent frontmatter so plugins can declare internal helpers that aren't addressable from other plugins. Defaults to `global` — existing agents behave exactly as before.

Before this change, every agent loaded from any plugin was globally addressable. The registry was a flat list keyed by agent id, and `send_message_to_agent` exposed a static enum of all agents to every agent — every plugin's internals were part of its public surface, and the PM agent routed through a namespace that grew linearly with every plugin's helpers.

Now a plugin can mark agents `local` to hide them from outsiders while keeping them addressable from within the same plugin.

## Frontmatter

`visibility` isn't part of the Claude Code subagent frontmatter spec, so it lives under `metadata.archie.*` — same pattern as the existing `metadata.archie.repo` field:

```yaml
---
role: Internal helper
expertise: ...
metadata:
  archie:
    visibility: local   # 'global' (default) or 'local'
---
```

## Design

- **Per-sender enum** for `send_message_to_agent`, built at agent spawn (sender's `AgentDef` is in scope): same-plugin agents (any visibility) ∪ other-plugin agents with `visibility === 'global'` ∪ `pm-agent` fallback.
- **PM is just a plugin**: `pluginName` changes from `'core'` to `'pm'`. PM has no special bypass — a `local` agent not in the `pm` plugin is unreachable by PM. The pm-overlay loading and `pluginDataPath` already keyed on `'pm'`, so no prompt-content regression.
- **`assign_task_owner`** narrowed to PM's visible set (globals + `pm`-plugin locals).
- **Defensive visibility gate** in `Task.toolSendMessage` for tool calls constructed outside the Zod enum.
- **Repo agents may be `local`.** Webhook routing via `getAgentDefByGithubRepo` bypasses peer-list visibility, so a `local` repo agent still receives webhook events; PM cannot `assign_task_owner` to it, but its plugin's siblings can message it directly.
- **Startup logging** tags each agent with `(visibility)`; warns when a plugin has no externally reachable agents (no globals, no repo agents).

### Naming model — flat IDs, strict global uniqueness

An alternative (qualified internal keys `plugin/agent`, allowing two plugins to each ship a `local helper-agent`) was evaluated and rejected because it would require migrating `agent_sessions` persistence keys *and* per-task on-disk paths (`agents/<key>`, `claude/<key>`) — costs that outweigh the convenience of duplicate short names. The existing collision check already enforces global ID uniqueness, which is exactly the invariant the design relies on. Plugin authors prefix their internal agent filenames (`analytics-helper-agent.md`) to avoid cross-plugin collisions.

Full design rationale: `docs/plans/v29-agent-visibility-scoping.md`.

## Out of scope

- `subagent` (ephemeral) visibility mode — separate piece of work, needs SDK Task-tool integration and a different lifecycle.
- Qualified internal IDs / persistence migration.
- Retroactively moving other archie-specific frontmatter fields (`role`, `expertise`, `allowedNetworkDomains`) under `metadata.archie.*` — they predate the convention and changing them would touch every existing agent file.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 94 passing (86 existing + 8 new visibility tests)
- [x] `npm run build`
- [x] Manual: spin up a plugin with one `global` + one `local` agent; confirm via spawn-time logs that the global agent's enum contains both same-plugin peers, an agent in a different plugin sees only the global.
- [x] Manual: confirm PM dispatches to the global but cannot address the local via `assign_task_owner` or `send_message_to_agent`.
- [ ] Manual: boot with an in-progress task whose `agent_sessions` contains a local agent's id; verify recovery resumes it normally (flat ids → no migration needed).
- [ ] Manual: two plugins ship `helper-agent` → confirm startup fails fast with the existing duplicate-id error.
- [ ] Manual: mark all agents in a plugin `local`; confirm the startup warning fires and the system boots.
- [ ] Manual: declare `visibility: local` on a repo agent; confirm webhook routing still works but PM cannot `assign_task_owner` to it.

## Files changed

Production (8):
- `src/system/plugin-loader.ts` — parse `metadata.archie.visibility`
- `src/types/agent.ts` — `visibility` on `AgentDef`
- `src/agents/registry.ts` — `getVisiblePeerIdsForSender`, `buildPeerListForSender`, PM moves to `pm` plugin, PM's team list filtered to its visible set
- `src/agents/tools.ts` — per-sender enums for `send_message_to_agent` and `assign_task_owner`
- `src/agents/spawn.ts` — peer list now sender-aware
- `src/tasks/task.ts` — defensive visibility check in `toolSendMessage`
- `src/index.ts` — visibility shown in startup summary; entry-point warning

Tests (3):
- `src/agents/__tests__/registry-visibility.test.ts` (new) — visibility filtering + peer-list construction
- `src/agents/__tests__/tool-contract.test.ts`, `src/agents/__tests__/pr-tools.test.ts` — `visibility: 'global'` added to AgentDef fixtures; registry mock extended

Docs:
- `docs/plans/v29-agent-visibility-scoping.md` (new)