### PR TITLE
Multi-repo agents: declare and eager-mount multiple repos per agent

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -10,7 +10,7 @@ Archie uses three active agent types (plus a disabled triage classifier). Each i
 |---|---|---|---|
 | ~~Triage Agent~~ | Haiku | — | Event classifier (**currently disabled** — see below) |
 | PM Agent | Opus (default) | 1 per task | Task manager, user interface, agent coordinator |
-| Repo Agents | Sonnet (default, configurable) | 1 per repository per task | Codebase investigation and modification |
+| Repo Agents | Sonnet (default, configurable) | 1 per plugin-defined repo agent per task | Codebase investigation and modification; declares one or more repos in frontmatter, all mounted at spawn |
 | Plugin Agents | Sonnet (default, configurable) | 1 per plugin agent per task | Lightweight, read-only domain specialists |
 
 Models for repo and plugin agents come from each agent's plugin frontmatter (`model` field, with `effort` and `maxTurns` also supported); `Sonnet` is the fallback when frontmatter is silent. The PM agent defaults to Opus but can be overridden by the `pm` plugin overlay's frontmatter (see `src/agents/registry.ts` `buildPmDef()` and `src/agents/spawn.ts`).
@@ -82,9 +82,13 @@ PR lifecycle tools (push, create PR, merge, etc.) live on repo agents via the `r
 
 **Source**: `src/agents/agent.ts`, `src/agents/spawn.ts`
 
-Repo agents are specialized for a single repository. They investigate code, make changes (in edit mode), and coordinate with other agents. Configuration comes from plugins via `src/agents/registry.ts`.
+Repo agents declare one or more repositories in their plugin frontmatter (`metadata.archie.repos: [...]` plus optional `primary`). **Every declared repo is mounted at spawn** — there is no runtime attach. The primary is the default target for `repo-tools` when the `github` arg is omitted. They investigate code, make changes (in edit mode), and coordinate with other agents. Configuration comes from plugins via `src/agents/registry.ts`.
+
+The pre-v30 singular shape (`metadata.archie.repo: {github, baseBranch}`) is still accepted — the plugin loader synthesizes the plural shape on load.
 
 **Model**: Sonnet by default (`def.model || 'sonnet'` in `spawn.ts`). Overridable per-agent via plugin frontmatter.
+
+**Multi-repo mounts**: Each spawn iterates the agent's declared `repos` list, ensures an `AttachedRepo` record exists in `metadata.repositories[agentId]` for each (preserving the clone/branch state of repos already present), runs `setupSharedClone` per repo, and aggregates all clone paths into `additionalDirectories` and the sandbox `allowReadPaths`/`allowWritePaths`/`denyWritePaths`. Each repo gets its own task-local clone at `sessions/{taskId}/repos/{agentId}/{org}/{repo}/` — two agents that declare the same github get two independent clones with independent branch state. Because the loop iterates the *declared* list, adding a repo to an agent's frontmatter makes it mount on the next spawn (so an old task picks it up on recovery), and removing one simply stops mounting it (a stale metadata record is harmless).
 
 **Tools** (via MCP servers `repo-agent-tools`, `repo-tools`, and `research-tools`):
 
@@ -121,9 +125,11 @@ Repo agents are specialized for a single repository. They investigate code, make
 
 `WebSearch` and `WebFetch` are explicitly disallowed for repo agents. In read-only mode the write-side `repo-tools` entries above are added to `disallowedTools` in `spawn.ts`, and the OS-level sandbox + `createFilesystemGuardHooks` together block `Write`/`Edit` to the clone.
 
-**Dual mode system**: The agent's mode is set per-task by `metadata.edit_allowed`. In read-only mode the sandbox makes the clone read-only and write-side MCP tools are disallowed; in edit mode the clone is writable and all `repo-tools` entries are exposed. The agent observes its mode through the available tool set and the injected `READ-ONLY` / `READ-WRITE` annotation in its system prompt.
+**Multi-repo `github` arg**: every `repo-tools` entry that targets a specific repo accepts an optional `github: "org/repo"` argument. Omitted, the tool acts on the agent's primary repo. The handler validates the github is in the agent's declared `repos` list (via `resolveGithub`); local-clone tools additionally require the repo to have a local clone present (via `requireAttached`), which it always does post-spawn.
 
-**Working directory**: The agent's cwd is its per-agent workspace at `sessions/{taskId}/agents/{key}/`. The repository itself lives at a task-local shared clone under `sessions/{taskId}/repos/{repoKey}` and is exposed via `additionalDirectories`. In read-only mode the clone is checked out on the base branch; in edit mode it carries an `archie/{taskId}` branch (or a previously persisted one). Shared task state at `sessions/{taskId}/shared/` is also mounted read-only.
+**Dual mode system**: The agent's mode is set per-task by `metadata.edit_allowed`. In read-only mode the sandbox makes every attached clone read-only and write-side MCP tools are disallowed; in edit mode every attached clone is writable and all `repo-tools` entries are exposed. The agent observes its mode through the available tool set and the injected `READ-ONLY` / `READ-WRITE` annotation in its system prompt. Edit mode is global to the task — when approved, RW applies to the primary and to every attached repo.
+
+**Working directory**: The agent's cwd is its per-agent workspace at `sessions/{taskId}/agents/{agentId}/` — a pure scratch space that never contains repo state. Each mounted repo lives at `sessions/{taskId}/repos/{agentId}/{org}/{repo}/` (sibling of the agent's cwd, not nested inside it) and is exposed via `additionalDirectories`. Per-agent clone paths mean two agents that declare the same github get fully independent working trees. In read-only mode each clone is checked out on its base branch; in edit mode each carries an `archie/{taskId}` branch (or a previously persisted one). Shared task state at `sessions/{taskId}/shared/` is also mounted read-only.
 
 ### Plugin Agents
 
@@ -220,12 +226,13 @@ Template variables: `{{AGENT_ID}}`, `{{AGENT_ROLE}}`, `{{EXPERTISE}}`, `{{PEER_L
 Different for each agent track:
 
 **Repo agents** (`prompts/repo-agent.md`):
-- Repository responsibility
+- Repository responsibility (primary + any other declared repos, all mounted at spawn)
+- Multi-repo working model (the optional `github` arg on repo-tools, default = primary)
 - Task lifecycle context (Research, Implement, Review, Conflicts)
 - Dual mode system (Read-Only vs Edit, determined by available tools)
 - Git workflow: branch management (`switch_branch`, `create_branch`, `fetch`), staging, committing, PR lifecycle
 - Honesty and transparency guidelines
-- Template variables: `{{REPO_KEY}}`, `{{BASE_BRANCH}}`
+- No template variables — per-repo data (github, clone path, current/base branch, RO/RW mode) is surfaced through the dynamic Current Context block built at spawn, not via static substitution. This keeps the prompt structurally correct for any number of repos.
 
 **Plugin agents** (`prompts/plugin-agent.md`):
 - Read-only mode declaration
@@ -258,7 +265,7 @@ The PM agent uses a separate prompt (`prompts/pm-agent.md`) that is not layered.
 ```
 Repo Agent:
   agent-core.md(AGENT_ID, AGENT_ROLE, EXPERTISE, PEER_LIST)
-  + repo-agent.md(REPO_KEY, BASE_BRANCH)
+  + repo-agent.md()
   + plugins/<name>/agents/<key>.md body (optional)
 
 Plugin Agent:
@@ -298,15 +305,16 @@ hasRetried = true;
 
 ### Peer Awareness
 
-Every repo and plugin agent's prompt includes a dynamically generated peer list. This is built by `buildPeerList()` in `src/agents/registry.ts`:
+Every repo and plugin agent's prompt includes a dynamically generated peer list. This is built by `buildPeerList()` in `src/agents/registry.ts`, called from `spawn.ts` with the current task's team:
 
 ```typescript
-export function buildPeerList(excludeAgentId: string): string {
-  const repoPeers = registry
+export function buildPeerList(excludeAgentId: string, team?: AgentDef[]): string {
+  const source = team ?? registry;
+  const repoPeers = source
     .filter((d) => d.track === 'repo' && d.id !== excludeAgentId)
-    .map((d) => `- ${d.id}: ${d.role} (${d.repo!.repoKey} repository)`);
+    .map((d) => `- ${d.id}: ${d.role} (${d.repo!.primary} repository)`);
 
-  const pluginPeers = registry
+  const pluginPeers = source
     .filter((d) => d.track === 'plugin' && d.id !== excludeAgentId)
     .map((d) => `- ${d.id}: ${d.role} [${d.pluginName}]`);
 
@@ -314,7 +322,7 @@ export function buildPeerList(excludeAgentId: string): string {
 }
 ```
 
-The list excludes the current agent and the PM (which is hardcoded in the agent-core prompt). This ensures agents know who they can communicate with and what each peer specializes in.
+Spawn passes `task.team` (registry agents plus any PM-spawned dynamic agents merged in at `Task.get` / `Task.create` time) so dynamic peers are visible. The list excludes the current agent and the PM (which is hardcoded in the agent-core prompt). This ensures agents know who they can communicate with and what each peer specializes in.
 
 ### Streaming Input
 

--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -71,7 +71,7 @@ plugins/
       pm.md                       # Body appended to PM prompt; frontmatter configures MCP/tools
 ```
 
-An agent is classified as a **repo agent** if its frontmatter contains `metadata.archie.repo.github`. Otherwise it is a **plugin agent**. (The legacy `repo-config.json` file is still parsed and exposed on `LoadedPlugin.repoConfigs` for backward compatibility, but the live registry in `src/agents/registry.ts` derives every repo agent from frontmatter — `repo-config.json` is no longer the source of truth for cloning or agent registration.)
+An agent is classified as a **repo agent** if its frontmatter contains `metadata.archie.repos` (or the legacy singular `metadata.archie.repo`). Otherwise it is a **plugin agent**. (The legacy `repo-config.json` file is still parsed and exposed on `LoadedPlugin.repoConfigs` for backward compatibility, but the live registry in `src/agents/registry.ts` derives every repo agent from frontmatter — `repo-config.json` is no longer the source of truth for cloning or agent registration.)
 
 ### Plugin Manifest (`plugin.json`)
 
@@ -181,7 +181,7 @@ The markdown body (everything after the frontmatter) becomes the Layer 3 domain-
 
 ## Repo Agent Configuration
 
-Repo agents are identified by the `metadata.archie.repo` field in their frontmatter. The `github` field is required and specifies the GitHub repository identifier:
+Repo agents declare one or more GitHub repositories in their frontmatter. The preferred shape is the plural `metadata.archie.repos: [...]` plus an optional `primary` selector:
 
 ```markdown
 ---
@@ -189,19 +189,28 @@ role: Senior backend engineer
 expertise: Ruby on Rails, PostgreSQL
 metadata:
   archie:
-    repo:
-      github: org/backend-repo
-      baseBranch: main
+    repos:
+      - github: org/backend-repo
+        baseBranch: main
+      - github: org/shared-libs
+        baseBranch: main
+    primary: org/backend-repo   # optional; defaults to repos[0].github
 ---
 ```
 
+- Every entry in `repos` is mounted at spawn (eager — there is no runtime attach).
+- `primary` is the default target for `repo-tools` when their `github` arg is omitted. If omitted, the first entry is used. If set, must match exactly one entry's `github`.
+- The legacy singular shape (`metadata.archie.repo: { github, baseBranch }`) is still accepted — the plugin loader auto-migrates it to the plural form: `repos: [{github, baseBranch}], primary: github`.
+- Both shapes in the same frontmatter is an error.
+
 ### Agent Derivation
 
-Each agent `.md` file with repo metadata produces an `AgentDef` with `track: 'repo'`:
+Each agent `.md` file with repo metadata produces an `AgentDef` carrying repo access (`def.repo` set):
 - Agent ID: `{key}-agent` (e.g., filename `backend.md` becomes `backend-agent`)
-- Repository path: `$ARCHIE_WORKDIR/repos/{key}` by default — this base clone is created at startup by `cloneRepos()` based on the frontmatter `github` field
-- GitHub repo: from `metadata.archie.repo.github`
-- Base branch: from `metadata.archie.repo.baseBranch` (defaults to `"main"` at spawn time)
+- Base cache paths: `$ARCHIE_WORKDIR/repos/{github}/` per declared repo (nested `org/repo` directories). All declared repos are pre-warmed by `cloneRepos()` at startup, deduplicated across all repo agents; a repo whose base cache is missing (e.g. added to frontmatter after startup) is lazy-cloned on first spawn.
+- Per-task clone paths: `sessions/<taskId>/repos/<agentId>/<github>/` (created by `setupSharedClone` at spawn). These are siblings of the agent's cwd (`sessions/<taskId>/agents/<agentId>/`), not nested inside it.
+- GitHub repos: from `metadata.archie.repos[*].github`
+- Base branches: from `metadata.archie.repos[*].baseBranch` (defaults to `"main"`)
 - Identity (role, expertise): from frontmatter
 - Domain prompt (Layer 3): from markdown body
 

--- a/docs/plans/v30-multi-repo-agents.md
+++ b/docs/plans/v30-multi-repo-agents.md
@@ -1,0 +1,410 @@
+# Multi-repo agents and dynamic repo-agent spawning
+
+> **Shipped scope (this PR): multi-repo agents, eager-mount only.**
+> A repo agent declares one or more repos in frontmatter and **all of them are
+> mounted at spawn**. There is no on-demand attach and no respawn machinery —
+> the simplest model that delivers "an agent controls 2+ repos."
+>
+> **Deferred to a follow-up PR** (design retained below for reference, full
+> implementation preserved on branch `claude/multi-repo-full-backup`):
+> - On-demand `attach_repo` (mount a declared repo mid-conversation via a
+>   turn-ending tool + sessionId-resume respawn). Dropped in favour of eager
+>   mounting; would only return if lazy mounting becomes a real need.
+> - PM dynamic spawning (`spawn_repo_agent` / `list_available_repos`). Will be
+>   rebuilt on the eager-mount foundation — a PM-spawned agent just eager-mounts
+>   its repos at spawn, no respawn needed.
+>
+> The sections below describe the original fuller design; treat the two deferred
+> capabilities as not-yet-implemented.
+
+## Context
+
+Today every repo agent is bound 1:1 to a single GitHub repo (`metadata.archie.repo` in plugin frontmatter → `AgentDef.repo: { githubRepo, baseBranch, defaultPath, repoKey }`). This forces:
+
+1. **Cross-repo investigations are awkward.** A backend agent can't easily look at `org/shared-libs` to understand a callsite — there's no agent for it, and even if there were, coordination overhead defeats the purpose for quick lookups.
+2. **Every agent must be pre-declared in the plugins repo.** Standing up Archie against a new GitHub installation requires editing/redeploying plugins for every repo you want covered. Slow on-ramp.
+
+This plan adds two capabilities, both grounded in a shared "task-local clone" primitive:
+
+- **Repo agents declare a list of repos in frontmatter** (one is primary, mounted at spawn). They can call `attach_repo({github})` at runtime to mount additional declared repos. After the call, the agent's turn ends; the runtime respawns the agent (sessionId resume) with the new clone added to its mount set.
+- **PM can spawn ad-hoc repo agents** via `spawn_repo_agent({shortname, repos})`. The synthesized `AgentDef` is stored in task metadata, becomes a peer for the rest of the task, and behaves identically to a plugin-defined repo agent. Plus `list_available_repos` so PM can discover what the GitHub App can reach.
+
+Outcome: Archie can be productive on a new GitHub installation with minimal plugin work, and existing agents can pull in related repos on-demand without orchestration.
+
+---
+
+## Approach
+
+### Frontmatter shape (plugins repo)
+
+Replace singular `repo` with plural `repos` and an optional `primary` selector.
+
+```yaml
+metadata:
+  archie:
+    repos:
+      - github: org/backend
+        baseBranch: main
+      - github: org/shared-libs
+        baseBranch: main
+    primary: org/backend   # optional; defaults to repos[0].github
+```
+
+- `repos[]` is the agent's whitelist for `attach_repo`.
+- `primary` mounts at spawn and is the default for `repo-tools` when `github?` arg omitted.
+- If both `repo` (singular) and `repos` (plural) appear → fail loudly at load.
+- Old singular `repo: {github, baseBranch}` is auto-migrated by the loader (see Migration).
+
+### Per-agent clone paths
+
+Move the per-task clone directory from `sessions/{taskId}/repos/{repoKey}/` (one entry per repo, keyed by short repo name) to `sessions/{taskId}/repos/{agentId}/{org}/{repo}/` (per-agent grouping, github nested as a directory). This isolates clones per-agent so two agents with overlapping whitelists (or PM-spawned dynamic agents that overlap with a plugin agent's secondary repo) don't collide on the same working tree in RW mode. `git clone --shared` keeps disk cost bounded — only working-tree + refs are duplicated. Clones are siblings of the agent's cwd (`sessions/{taskId}/agents/{agentId}/`) rather than nested under it — the workspace stays a pure RW scratch space, and clone permissions are controlled solely via sandbox allow/deny mounts (no deny-inside-allow carve-outs).
+
+Base cache stays at `$ARCHIE_WORKDIR/repos/{org}/{repo}/` (shared across all tasks via alternates, as today).
+
+New helper in `src/tasks/persistence.ts`: `getAgentClonePath(taskId, agentId, github)` builds `sessions/{taskId}/repos/{agentId}/{github}` (the slash in `org/repo` nests naturally; `mkdir -p` the parent before `git clone`).
+
+### Type changes (`src/types/agent.ts`)
+
+```ts
+interface RepoEntry {
+  github: string;       // 'org/repo' — also serves as the key
+  baseBranch: string;
+}
+interface RepoConfig {
+  repos: RepoEntry[];
+  primary: string;      // resolved at load: explicit or repos[0].github
+}
+interface AgentDef {
+  // ...
+  repo?: RepoConfig;    // shape changes; field name unchanged for minimal churn
+}
+```
+
+`PluginAgentDef.repo` (in `src/system/plugin-loader.ts`) gets the same shape change.
+
+Helper: `getRepoEntry(def, github) → RepoEntry | undefined` for tools that need to look up an entry's baseBranch.
+
+### Metadata changes (`src/types/task.ts`)
+
+Concrete before/after for `metadata.json`:
+
+```jsonc
+// BEFORE — today
+{
+  "task_id": "task-…",
+  "edit_allowed": false,
+  "task_owner": "backend-agent",
+  "participants": ["backend-agent"],
+  "agent_sessions": {
+    "backend-agent": { "session_id": "…", "active": true }
+  },
+  "repositories": {
+    "backend": {                                 // ← keyed by short repoKey
+      "path": "/workdir/repos/backend",          //   base cache (derivable)
+      "clone_path": "/sessions/<id>/repos/backend",
+      "current_branch": "feature/task-…",
+      "branch_states": { "feature/task-…": { "base_branch": "main", "pr_number": 42 } }
+    }
+  }
+}
+```
+
+```jsonc
+// AFTER
+{
+  "task_id": "task-…",
+  "edit_allowed": false,
+  "task_owner": "backend-agent",
+  "participants": ["backend-agent", "frontend-agent", "explorer-a3f9-agent"],
+  "agent_sessions": {
+    "backend-agent":         { "session_id": "…", "active": true },
+    "frontend-agent":        { "session_id": "…", "active": true },
+    "explorer-a3f9-agent":   { "session_id": "…", "active": true }
+  },
+  // `repositories` keeps the name but the shape changes: it's now keyed by
+  // agentId, and each value is a list of AttachedRepo records — the per-agent
+  // clone state moved here. The base-cache path used to live in `RepositoryInfo`
+  // is gone; it's derivable as `join(REPOS_DIR, github)`.
+
+  "repositories": {
+    "backend-agent": [
+      {
+        "github": "org/backend",
+        "clone_path": "/sessions/<id>/agents/backend-agent/clones/org/backend",
+        "current_branch": "feature/task-…",
+        "branch_states": { "feature/task-…": { "base_branch": "main", "pr_number": 42 } }
+      },
+      {
+        "github": "org/shared-libs",
+        "clone_path": "/sessions/<id>/agents/backend-agent/clones/org/shared-libs",
+        "current_branch": "main",
+        "branch_states": {}
+      }
+    ],
+    "frontend-agent": [
+      {
+        "github": "org/shared-libs",                                      // ← same repo
+        "clone_path": "/sessions/<id>/agents/frontend-agent/clones/org/shared-libs",  // ← independent clone
+        "current_branch": "main",                                         // ← independent state
+        "branch_states": {}
+      }
+    ],
+    "explorer-a3f9-agent": [
+      {
+        "github": "org/payments",
+        "clone_path": "/sessions/<id>/agents/explorer-a3f9-agent/clones/org/payments",
+        "current_branch": "main",
+        "branch_states": {}
+      }
+    ]
+  },
+
+  "dynamic_agents": [
+    {
+      "id": "explorer-a3f9-agent",
+      "shortname": "explorer",
+      "repos": [{ "github": "org/payments", "baseBranch": "main" }],
+      "role": "Generic engineer for org/payments",
+      "expertise": "Investigation"
+    }
+  ]
+}
+```
+
+Key shape decisions (committed, not open):
+
+- **`repositories` keeps its name but the keying flips from repo to agent.** Today `RepositoryInfo` mixes two concerns: base-cache path (derivable from `github`, never agent-specific) and per-clone state (`clone_path`, `current_branch`, `branch_states`, which are inherently per-agent in the multi-repo world). The per-clone state moves to be the *value* of the map, keyed by agentId. The base-cache path drops (computed on demand as `join(REPOS_DIR, github)`).
+- **New type:** `AttachedRepo = { github, clone_path, current_branch, branch_states }`. Reuses the existing `BranchState` type for `branch_states`. The legacy `RepositoryInfo` type and its 14+ call sites are migrated in lockstep.
+- **`metadata.repositories: Record<agentId, AttachedRepo[]>`** — same field name, new shape. Two agents attaching the same `github` have two independent records, each with their own branch/PR state — which is exactly what per-agent clone paths require.
+- **`dynamic_agents` stores spec inputs only, not derived `AgentDef`s.** What PM passed (`shortname`, `repos`, `role`, `expertise`) plus the assigned `id`. A new helper `synthesizeDynamicAgentDef(spec)` in `registry.ts` rebuilds the full `AgentDef` deterministically on each `Task.get` — keeps the metadata small and never stale.
+
+**Migration of existing on-disk metadata.** Same field name, different shape — discriminate by structure. In `Task.get`, after JSON parse:
+1. Detect old shape: any value in `metadata.repositories` is an object with `clone_path` (vs. new shape which is an array).
+2. For each old `repoKey` entry, look up `getAgentDef(`${repoKey}-agent`)?.repo?.primary` to get the github. Synthesize one `AttachedRepo` and assign it to `repositories[`${repoKey}-agent`] = [attached]` (single agent owning the clone, matching the 1:1 world).
+3. Move the old `clone_path` from `sessions/<id>/repos/<key>/` to `sessions/<id>/repos/<agentId>/<org>/<repo>/` — on first access. If the clone dir doesn't exist yet, just record the new path; `setupSharedClone` recreates it as needed.
+4. Persist on next `debouncedSave`.
+
+### Spawn flow (`src/agents/spawn.ts`, repo track)
+
+Loop over `metadata.agent_attachments[agentId]` (default to `[primary]` when empty):
+- For each github, run existing `setupSharedClone` against `getAgentClonePath(taskId, agentId, github)`.
+- Read/write mode follows the single global `metadata.edit_allowed` flag (RW applies to all attached repos when granted — explicit user decision; not adding per-repo carve-outs).
+- Aggregate clone paths into `additionalDirectories`. Aggregate sandbox `allowReadPaths`/`allowWritePaths`.
+- The system prompt's "Current Context" block lists every attached repo with its current branch and mode.
+- `feature/{taskId}` branch convention works per-repo unchanged (each `branch_states` map is per-RepositoryInfo).
+
+### Why `attach_repo` requires a respawn
+
+The straightforward question: can't we just `git clone` the new repo into a directory the agent already has mounted, and let the agent discover it without restarting?
+
+Two SDK constraints force a respawn:
+
+1. **Sandbox `allowReadPaths` is baked at `query()` time.** The OS-level sandbox (`src/agents/sandbox.ts`) and the filesystem-guard hooks (`createFilesystemGuardHooks` in `src/agents/sandbox.ts`) get a fixed list of allowed read/write paths at SDK init. There is no live API to add a path. If we drop a clone into an unallowed location, the agent gets EACCES on read. We could work around this by pre-mounting the whole `sessions/<id>/agents/<id>/clones/` parent directory at spawn time — but then we hit the next constraint.
+2. **Skills (`.claude/skills/`) are discovered at SDK init.** The user specifically wants agent skills shipped *inside* each repo to be picked up (e.g., a backend repo's debugging skills). The SDK scans `additionalDirectories` for `.claude/skills/` during `query()` startup; new skills added after init are invisible until the next `query()`. There's no runtime skill-reload API.
+
+So: even if (1) is worked around, (2) still forces respawn whenever we want the attached repo's skills to count. Since we do want the skills, respawn is unavoidable.
+
+The respawn itself is cheap: SDK session resume (`resume: sessionId` in `buildQueryOptions`) means the model keeps its conversation context. The agent doesn't "forget" anything — just gets re-initialized with new mounts and new skills, then a continuation message ("Repo X mounted at Y, continue.") wakes it up where it left off. From the agent's point of view it's a brief pause, not a fresh start.
+
+### `attach_repo` is a turn-ending tool (completion-style)
+
+Modeled on `report_completion`: calling it ends the agent's current turn. The agent doesn't have to "remember to stop" — the runtime forces the turn to end. Agent prompt language treats it as a turn-ending tool alongside `report_completion`.
+
+Signature: `attach_repo({ github: string }) → string`
+
+Synchronous validation (rejects in tool):
+- `github` not in agent's `repos[]` whitelist → reject with whitelist contents.
+- already in `metadata.agent_attachments[agentId]` → reject.
+- GitHub App can't reach the repo (only checked if not already in base cache) → reject.
+
+On success:
+- Set `agent.pendingAttach = github`.
+- Set `agent.respawning = true` (suppresses idle detection — see below).
+- Return success string: "Repo `{github}` will be mounted on your next turn. Turn ending now."
+
+Then the SDK Stop hook does the rest — the agent doesn't need any "remember to stop" instruction in its prompt:
+
+- Stop hook in `spawn.ts:539-544` already fires when the model's turn ends naturally (after the tool result is processed). It checks `agent.pendingAttach`:
+  - If set: returns `{continue: false}` to terminate the SDK iterator cleanly. Does **not** call `task.updateAgentState(def.id, false)` — keeps `session.active = true` so idle detection ignores this agent during the respawn window.
+  - If not set: normal path — `task.updateAgentState(false)` then `{continue: true}` (today's behavior).
+- The `handle.running.then(...)` watcher in `agent.ts:101-105` checks `pendingAttach`:
+  - Run `setupSharedClone` against `getAgentClonePath(taskId, agentId, github)`. `mkdir -p` the `org/` parent.
+  - Push the new `AttachedRepo` record onto `metadata.repositories[agentId]`. Persist via `task.debouncedSave()`.
+  - Drop continuation message into the queue: "Repo {github} mounted at {path}. Continue from where you left off."
+  - Clear `pendingAttach`.
+  - Call `spawnAgent(this, task)` again. Existing `session.session_id` drives SDK resume; `buildQueryOptions` is rebuilt fresh per spawn (confirmed at `spawn.ts:503`) — `additionalDirectories`, `sandboxOpts`, `mcpServers` all recomputed from the updated `metadata.repositories[agentId]`.
+  - Clear `respawning` after the new `spawnAgent` call returns (handle.isRunning flips back to true). Now idle detection works normally again.
+- Failure during respawn: drop a failure message into the queue, clear `pendingAttach` and `respawning`, fall through to normal inactive marking.
+
+### Recovery / idle-detection interaction
+
+The existing flow in `src/tasks/recovery.ts`:
+- Every time `task.updateAgentState(id, false)` runs, `scheduleIdleCheck(task)` queues a 3s timer (`task.ts:768`).
+- The timer fires `checkAllAgentsInactive(task)` (`recovery.ts:91-98`) which iterates `task.agentProcesses` and returns `true` if every `agent.session.active === false`.
+- If all inactive: `triggerRecovery` sends a reinforcement nudge to the lead agent (attempt 1-2) or nukes via `task.stop()` + `recoverTaskAgents` (attempt 3+). The nudge re-activates the agent and the next idle check sees it active.
+
+Without intervention, the respawn window (Stop hook fires → respawn finishes) would be flagged as idle. The 3s timer might fire mid-respawn and push `AGENT_PROMPTS.reinforceAgent` into the queue — that nudge would then be the first thing the respawned agent sees, ahead of our intended continuation message. Worst case after three such cycles: nuclear restart.
+
+**Fix (two small changes):**
+
+1. In `spawn.ts` Stop hook: when `agent.pendingAttach` is set, **do not** call `task.updateAgentState(def.id, false)`. The Stop hook returns `{continue: false}` and the SDK exits, but `session.active` stays true. Watcher in `agent.ts:101` (which also calls `updateAgentState(false)` after `handle.running` resolves) gets a `pendingAttach`-aware branch — when set, do the respawn instead of marking inactive.
+2. In `recovery.ts` `checkAllAgentsInactive`: treat agents with `agent.respawning === true` as active — `if (agent.session.active || agent.respawning) return false;`. This is belt-and-suspenders in case the watcher hasn't run yet but the SDK iterator has already exited.
+
+With both, `scheduleIdleCheck` simply never fires triggerRecovery during a respawn. Once respawn completes and `respawning` flips back to false, the system returns to normal idle behavior — if the respawned agent goes idle again later (e.g., after processing the continuation message), the existing flow handles it.
+
+A `agent.attaching: Promise<void> | undefined` guard on `agent.spawn()` prevents a peer-triggered `ensureAgentSpawned` from racing the respawn — `agent.spawn()` awaits the in-flight respawn promise rather than starting a second SDK process against the same queue. Peer messages still enqueue safely (`MessageQueue.addMessage` works whether or not the queue is being consumed).
+
+### `spawn_repo_agent` PM tool (new)
+
+Signature:
+```ts
+spawn_repo_agent({
+  shortname: string,                                       // [a-z][a-z0-9-]*
+  repos: Array<{github: string, baseBranch?: string}>,    // first = primary
+  role?: string,
+  expertise?: string,
+}) → { agentId: string }
+```
+
+Behavior:
+1. **Anti-duplication on primary only.** Reject if any plugin-defined repo agent has any of the requested githubs as its `primary`. Whitelist overlap is fine — per-agent clones make it safe in RW too.
+2. ID: `{shortname}-{4charHex}-agent`. Validate shortname matches `^[a-z][a-z0-9-]*$`.
+3. Synthesize `AgentDef`: `track: 'repo'`, repo from args (`primary = repos[0].github`, baseBranches default to `'main'` when omitted), generic role/expertise defaults if PM omits, no Layer-3 prompt, no skills, no plugin MCP servers.
+4. Lazy-clone any uncached repos (gated by GitHub App reachability — fail tool synchronously if unreachable).
+5. Append to `metadata.dynamic_agents`. Persist. Add to `task.team`.
+6. Return `{agentId}`. PM calls `send_message_to_agent(agentId, ...)` next turn.
+
+Dynamic agent's `repos[]` = exactly what PM supplied → its `attach_repo` rejects anything outside that list. Cleanly consistent.
+
+### `list_available_repos` PM tool (new)
+
+Wraps `apps.listReposAccessibleToInstallation` via existing `getOctokit()` in `src/connectors/github/client.ts`. Returns `[{github, default_branch, description?}]`. Cached for the task lifetime to avoid hammering the API.
+
+### `repo-tools` `github?` arg
+
+Every tool that operates on a clone or GitHub repo gains optional `github?: string`. All resolution happens **per-call** (not closure capture):
+- Default to `agent.def.repo!.primary` when omitted.
+- Validate `github ∈ task.metadata.agent_attachments[agent.def.id]`.
+- For local-clone tools (`fetch`, `switch_branch`, `create_branch`, `list_branches`, `push_branch`): resolve via `getAgentClonePath(taskId, agentId, github)`.
+- For GitHub-API tools (`list_prs`, `get_pr`, `create_pull_request`, …): pass `github` directly to `githubClient`.
+
+20 tool definitions touched in `src/agents/tools.ts`.
+
+### Team & peer list
+
+- `buildPeerList(excludeAgentId, team)` in `src/agents/registry.ts` — accepts a team list, defaults to global `registry`. Repo-track peers list their primary github in the formatted line.
+- `Task.get` / `Task.create` merge `metadata.dynamic_agents` into the freshly-scanned team **before** returning the Task instance — must happen before `recoverTaskAgents` runs, otherwise dynamic agents fail `task.team.find(...)` lookup in `ensureAgentSpawned`.
+- `allAgents()` in `src/agents/tools.ts` rewritten to take `task` and read `task.team` instead of the global `getAgentIds()`. This is the source for the `send_message_to_agent` Zod enum (rebuilt per spawn since `createSendMessageTool` is invoked inside `createPMAgentMcpServer`/`createBaseAgentMcpServer`, both called fresh in `spawnAgent`).
+- `generateRepoAgentPrompt` / `generatePluginAgentPrompt` pass `task.team` to `buildPeerList`.
+
+### Migration
+
+**Frontmatter (`src/system/plugin-loader.ts`):**
+- If `metadata.archie.repo` (singular) present and `metadata.archie.repos` (plural) absent → synthesize `repos: [{github, baseBranch}]`, `primary: github`.
+- If both present → fail at load with the agent's filename.
+
+**On-disk metadata (`Task.get`):**
+- After JSON parse, walk `metadata.repositories`. For each key without `/`, look up `getAgentDef(`${key}-agent`)?.repo?.primary` (the migrated singular case maps cleanly). Re-key the entry. Persist on next `debouncedSave`.
+- Orphan keys (plugin removed) get logged and left alone.
+
+**Call site fixup (`src/connectors/github/merge.ts:213`):** replace `getAgentDef(`${repoKey}-agent`)` with `getAgentDefByGithubRepo(github)`. Update `linkedPRs` typing in `branch-state.ts` if it carries `repoKey`.
+
+**Other read sites** (14 across `src/`): update each to read `def.repo.primary` (when defaulting) or iterate `def.repo.repos[]`. Most are mechanical.
+
+### Prompt updates
+
+**`prompts/repo-agent.md`** Layer-2 — `{{REPO_KEY}}` becomes `{{REPO}}` (now the primary repo's github identifier, e.g. `org/backend`); `{{BASE_BRANCH}}` keeps its name and resolves to the primary's base branch. Add a section:
+> You may have a primary repo (mounted at spawn) and additional declared repos available via `attach_repo`. Most repo-tools accept a `github` argument; omitted, they target your primary. To work in a related declared repo, call `attach_repo({github})`, then stop your turn — you'll be respawned with the repo mounted, then continue from where you left off.
+
+The "Current Context" block injected at spawn lists all currently-attached repos with paths, branches, and mode.
+
+**`prompts/pm-agent.md`** — new section:
+> **Repo agent selection.** Prefer plugin-defined specialists. Use `list_available_repos` to discover what the GitHub App can reach. Use `spawn_repo_agent` only when no plugin agent covers the relevant repo — the runtime rejects spawn against repos that already have a plugin specialist as their primary.
+
+---
+
+## Edge cases addressed
+
+- **Stop-hook race.** Returning `{continue: false}` exits the SDK iterator so `handle.running` resolves; no concurrent SDK processes on the same queue.
+- **Idle nudge during respawn.** Covered by the "Recovery / idle-detection interaction" section above — `agent.respawning` keeps `checkAllAgentsInactive` from returning true; Stop hook also skips `updateAgentState(false)` so `session.active` stays true.
+- **Peer message during respawn.** `MessageQueue.addMessage` is unaffected; messages enqueue and are consumed when the respawned SDK starts. `agent.attaching` promise gates `agent.spawn()` to prevent a third spawn racing the respawn.
+- **Recovery of dynamic agents.** Merge `metadata.dynamic_agents` into `team` inside `Task.get` synchronously, before `new Task(...)` returns, so `recoverTaskAgents` and `ensureAgentSpawned` find them.
+- **MCP server stale captures.** Tools resolve clone path per-call via `metadata.repositories[agentId]`. Closure captures `agent`/`task`, not a baked-in `repoKey`. After respawn (which rebuilds the MCP server), tools see the updated attachments.
+- **Edit mode is global.** Approving edit mode RWs all attached repos. Explicit decision per user — not adding per-repo carve-outs.
+
+## Out of scope (v1)
+
+- Dynamic agents attaching repos beyond their initial spawn list.
+- Wildcard whitelists (`org/*`).
+- Mid-conversation peer-list updates to already-running agents (existing agents see new dynamic peers on next respawn).
+- Per-repo edit-mode approval.
+
+## Files modified
+
+- `src/types/agent.ts` — `RepoEntry`, `RepoConfig` shapes
+- `src/types/task.ts` — `agent_attachments`, `dynamic_agents`, repositories key change
+- `src/system/plugin-loader.ts` — frontmatter parsing + singular→plural migration
+- `src/agents/registry.ts` — `buildPeerList(excludeId, team)` overload, `getAgentDefByGithubRepo` helper if not already present
+- `src/agents/agent.ts` — `pendingAttach`, `suppressIdleCheck`, `attaching` fields; respawn from `handle.running.then` watcher
+- `src/agents/spawn.ts` — multi-repo mount loop in repo track; Stop hook checks `pendingAttach`; prompt context lists all attachments
+- `src/agents/tools.ts` — `attach_repo`, `spawn_repo_agent`, `list_available_repos`; `github?` arg on all 20 repo-tools with per-call resolution; `allAgents(task)` reading task team
+- `src/agents/message-queue.ts` — no change expected (verify `addMessage` doesn't throw mid-respawn)
+- `src/tasks/task.ts` — merge `dynamic_agents` into team in `Task.get`/`Task.create`; `ensureAgentSpawned` already team-driven; `cleanupClones` updated for nested `org/repo` paths and per-agent layout
+- `src/tasks/persistence.ts` — `getAgentClonePath(taskId, agentId, github)`; lazy migration of `metadata.repositories` keys
+- `src/tasks/recovery.ts` — `scheduleIdleCheck` honors `agent.suppressIdleCheck`
+- `src/system/workdir.ts` — `cloneRepos` iterates all `repos[]` across all repo agents (deduped by github)
+- `src/connectors/github/client.ts` — `listAccessibleRepos()` helper
+- `src/connectors/github/repo-clone.ts` — `mkdir -p` parent before `git clone`; path nesting for `org/repo` keys
+- `src/connectors/github/events.ts` — uses `getAgentDefByGithubRepo` (likely already does); verify
+- `src/connectors/github/merge.ts` — replace `getAgentDef(`${repoKey}-agent`)` with `getAgentDefByGithubRepo`
+- `prompts/pm-agent.md` — repo-agent selection guidance
+- `prompts/repo-agent.md` — multi-repo working model + variable rename
+- `docs/architecture/agents.md`, `docs/architecture/plugin-system.md` — doc updates
+
+## Implementation order
+
+1. **Types + frontmatter migration** (`src/types/agent.ts`, `plugin-loader.ts`, `registry.ts`) + unit tests for migration.
+2. **Per-agent clone path** (`getAgentClonePath`, update `setupSharedClone` callers) — single-repo behavior preserved.
+3. **`metadata.repositories` rekey + lazy migration** (`Task.get`, fix `merge.ts:213`, update 14 read sites mechanically).
+4. **Multi-repo spawn** (`spawn.ts` repo track mount loop, sandbox aggregation, prompt context) — preserves single-repo behavior when `agent_attachments[id]` has only the primary.
+5. **`repo-tools` `github?` arg** with per-call resolution against `agent_attachments`.
+6. **`attach_repo` tool + Stop-hook respawn flow** (`agent.ts` watcher, `recovery.ts` suppression flag, `agent.attaching` guard) + tests.
+7. **`list_available_repos` PM tool** + `listAccessibleRepos` GitHub client helper.
+8. **`spawn_repo_agent` PM tool** + `metadata.dynamic_agents` + Task.team merge + anti-duplication + `allAgents(task)` + `buildPeerList(excludeId, team)`.
+9. **Prompt updates** + architecture doc updates.
+10. **Plugins repo migration** (lockstep) — switch existing plugins to new `repos`/`primary` shape, though the loader's compat shim means no urgent break.
+
+## Verification
+
+**Unit tests:**
+- Frontmatter migration: singular `repo` → plural `repos` + `primary`. Both shapes present → load fails. Plural with no `primary` → defaults to `repos[0].github`.
+- `metadata.repositories` lazy rekey: pre-existing task with old `repoKey` keys, `Task.get` rewrites to `github` keys.
+- `buildPeerList` with task-team override returns dynamic agents that aren't in global registry.
+- `attach_repo` rejects: not-in-whitelist, already-attached, App-unreachable.
+- `spawn_repo_agent` rejects: shortname format, primary collides with plugin agent.
+
+**Integration tests:**
+- Spawn a repo agent declared with two repos → primary mounts at spawn → agent calls `attach_repo` for the secondary → Stop hook fires → runtime respawns → secondary mount visible → `repo-tools` with `github` arg routes to the right clone.
+- PM tool flow: `list_available_repos` → `spawn_repo_agent` against an installation repo → PM `send_message_to_agent` to the new agent → agent reads files in its primary → reports back to PM. Verify peer-list visibility in a sibling agent's prompt after respawn.
+- Recovery: stop+restart with a `metadata.dynamic_agents` entry → `Task.get` rehydrates the team → `ensureAgentSpawned` finds the dynamic agent.
+
+**Manual:**
+- Run `npm run dev`, exercise an end-to-end Slack flow that spans two repos via `attach_repo`. Confirm continuation message appears, agent picks up where it left off, no spurious idle nudge.
+- Confirm RW mode after edit-mode approval works on both primary and attached repos (separate `feature/{taskId}` branches per repo).
+- Confirm `npm run typecheck` and existing test suite still pass.
+
+## Critical files to reference
+
+- `src/agents/agent.ts:101–105` — `handle.running.then` watcher; respawn-on-pendingAttach plugs in here.
+- `src/agents/spawn.ts:267–429` — repo track spawn block; mount loop replaces single-repo `setupSharedClone` call.
+- `src/agents/spawn.ts:539–544` — Stop hook; checks `pendingAttach` to return `{continue: false}`.
+- `src/agents/spawn.ts:503` — `buildQueryOptions` rebuilt fresh per spawn (verified safe for new `additionalDirectories`).
+- `src/agents/tools.ts:125–144` — `allAgents()` and `createSendMessageTool`; switch enum source to `task.team`.
+- `src/agents/tools.ts:1126–1184` — `createPMAgentMcpServer` / `createRepoToolsMcpServer`; new tools register here.
+- `src/agents/registry.ts:154–164` — `buildPeerList`; add `team` param.
+- `src/tasks/task.ts:172–185` — `Task.get`; merge `dynamic_agents` into team here.
+- `src/tasks/task.ts:775–788` — `ensureAgentSpawned`; already team-driven, no change beyond team source.
+- `src/tasks/recovery.ts:77` — `scheduleIdleCheck`; honor `suppressIdleCheck`.
+- `src/connectors/github/repo-clone.ts:87–142` — `setupSharedClone`; verify `mkdir -p` parent for nested `org/` dir.
+- `src/connectors/github/merge.ts:213` — broken `getAgentDef(`${repoKey}-agent`)` lookup; replace with github-based lookup.
+- `src/system/plugin-loader.ts:190–196` — frontmatter parsing; add migration shim.

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,9 +111,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -126,9 +123,6 @@
       "integrity": "sha512-WvwiQBWt3tdu5EwqjpDZszI6p2uetYsw4Cxc6ptO/SmLIYXcDienP8nmirZdsZrS+Gzk6imgY0IY5mmNaRhelQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -143,9 +137,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -158,9 +149,6 @@
       "integrity": "sha512-kFH6RC2YJbPc8XWRNy/wL4YU7LzdJjSwAdH488sVzIif3q+TrvVrV5y/IW0+MLmta+CKIqtFYpGaucsJYvj7Eg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1609,9 +1597,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1629,9 +1614,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1649,9 +1631,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1669,9 +1648,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1689,9 +1665,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1709,9 +1682,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3982,9 +3952,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4006,9 +3973,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4030,9 +3994,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4054,9 +4015,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -1,10 +1,14 @@
 ## Repository Responsibility
 
-You are responsible for the {{REPO_KEY}} repository.
+Your Current Context lists the repositories mounted for this task — github identifier, clone path, current branch, base branch, and read/write mode. One is tagged `(primary)`: that's the default target for `repo-tools` when their `github` arg is omitted. All declared repos are mounted at spawn; there is nothing to attach at runtime.
 
 ## Your Mission
 
-You investigate and/or modify code in your assigned repository. You collaborate with other repository agents and coordinate with pm-agent, who interfaces with human users.
+You investigate and/or modify code in your assigned repositories. You collaborate with other repository agents and coordinate with pm-agent, who interfaces with human users.
+
+## Working With Multiple Repos
+
+When you have more than one repository mounted, most `repo-tools` accept an optional `github: "org/repo"` argument to target a specific one. When omitted, the tool operates on your **primary** repository. All your mounted repos are available immediately — there's nothing to mount or attach at runtime. To act on a different repo, just pass its `github` (it must be one of your mounted repos, listed in your Current Context).
 
 ## Task Lifecycle Context
 
@@ -84,7 +88,7 @@ When you have Edit tools available, you also have access to:
 
 **Resolving Merge Conflicts:**
 
-1. Run `git merge origin/{{BASE_BRANCH}}` - this will show conflict markers in files
+1. Run `git merge origin/<base>` (substitute `<base>` with the base branch shown for this repo in your Current Context) — this will show conflict markers in files
 2. Read the conflicted files to understand both versions
 3. Edit files to resolve conflicts (remove `<<<<<<<`, `=======`, `>>>>>>>` markers)
 4. Use `git add` to stage resolved files
@@ -96,7 +100,7 @@ When you have Edit tools available, you also have access to:
 Default: use rebase only when the user (or a reviewer) explicitly asks for it — otherwise prefer `git merge` for catching up to base. If your repo-specific instructions (appended below this prompt) prescribe a different workflow (e.g., "always rebase before pushing"), follow those instead.
 
 1. Call `fetch()` first — rebase is a local operation, so `origin/<base>` must be fresh before you start
-2. Run `git rebase origin/{{BASE_BRANCH}}` (or another target ref). Never use `-i`/`--interactive` — your shell has no editor, the command will hang
+2. Run `git rebase origin/<base>` (substitute `<base>` with the base branch shown for this repo in your Current Context, or another target ref). Never use `-i`/`--interactive` — your shell has no editor, the command will hang
 3. If conflicts appear: read the conflicted files, edit to resolve markers, `git add` the resolved files, then `git rebase --continue`. Repeat per commit until rebase finishes
 4. If you get stuck or need to back out: `git rebase --abort` returns the branch to its pre-rebase state
 5. Push with `push_branch(force=true)` — rebase rewrites history, so a normal push will be rejected. The `force` flag uses `--force-with-lease`, which is safe (it refuses to overwrite remote work you haven't seen)
@@ -165,5 +169,5 @@ If you don't have the id from the log (e.g. working on an arbitrary PR), call `g
 ### Handling Conflicts (after PR is open)
 
 1. `get_pr_status` shows `mergeableState: dirty`
-2. `git merge origin/{{BASE_BRANCH}}`, resolve markers, commit
+2. `git merge origin/<base>` (the repo's base branch from your Current Context), resolve markers, commit
 3. `push_branch()`

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -11,14 +11,13 @@ import {
   createCommsMcpServer,
   createOrchestrationMcpServer,
   createSchedulingMcpServer,
-  mirrorLegacyFields,
   hydrateBranchState,
   findBranchStateByPR,
 } from '../tools.js';
 import type { Agent } from '../agent.js';
 import type { Task } from '../../tasks/task.js';
 import type { AgentDef } from '../../types/agent.js';
-import type { RepositoryInfo } from '../../types/task.js';
+import type { AttachedRepo } from '../../types/task.js';
 
 // ---- Module mocks ----
 
@@ -42,6 +41,9 @@ vi.mock('../../connectors/github/repo-clone.js', () => ({
 
 vi.mock('../../tasks/persistence.js', () => ({
   appendAgentFinding: vi.fn().mockResolvedValue(undefined),
+  getAgentClonePath: vi.fn((_taskId: string, agentId: string, github: string) =>
+    `/sessions/task-123/agents/${agentId}/clones/${github}`,
+  ),
   getReposPath: vi.fn().mockReturnValue('/sessions/task-123/repos'),
 }));
 
@@ -94,10 +96,8 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
       pluginName: 'engineering',
       visibility: 'global',
       repo: {
-        githubRepo: 'org/backend',
-        repoKey: 'backend',
-        defaultPath: '/repos/backend',
-        baseBranch: 'main',
+        repos: [{ github: 'org/backend', baseBranch: 'main' }],
+        primary: 'org/backend',
       },
       ...overrides,
     },
@@ -109,20 +109,32 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
 function makeTask(overrides: Partial<Task['metadata']> = {}): Task {
   return {
     taskId: 'task-123',
+    team: [
+      {
+        id: 'backend-agent', key: 'backend', role: 'Backend engineer', expertise: 'Node.js',
+        pluginName: 'engineering', visibility: 'global',
+        repo: { repos: [{ github: 'org/backend', baseBranch: 'main' }], primary: 'org/backend' },
+      },
+      {
+        id: 'mobile-agent', key: 'mobile', role: 'Mobile engineer', expertise: 'Mobile',
+        pluginName: 'engineering', visibility: 'global',
+        repo: { repos: [{ github: 'org/mobile', baseBranch: 'main' }], primary: 'org/mobile' },
+      },
+    ],
     metadata: {
       repositories: {
-        backend: {
-          path: '/repos/backend',
-          clone_path: '/clones/backend',
-          feature_branch: 'feature/task-123',
-          base_branch: 'main',
-          current_branch: 'feature/task-123',
-          branch_states: {
-            'feature/task-123': {
-              base_branch: 'main',
+        'backend-agent': [
+          {
+            github: 'org/backend',
+            clone_path: '/clones/backend',
+            current_branch: 'feature/task-123',
+            branch_states: {
+              'feature/task-123': {
+                base_branch: 'main',
+              },
             },
           },
-        },
+        ],
       },
       edit_allowed: true,
       status: 'active',
@@ -228,7 +240,10 @@ describe('merge_pull_request', () => {
       success: true, message: 'PR #7 merged successfully',
     });
 
-    const agent = makeAgent({ repo: { githubRepo: 'org/mobile', repoKey: 'mobile', defaultPath: '/repos/mobile' } });
+    const agent = makeAgent({
+      id: 'mobile-agent',
+      repo: { repos: [{ github: 'org/mobile', baseBranch: 'main' }], primary: 'org/mobile' },
+    });
     const tool = getRepoTool(agent, makeTask(), 'merge_pull_request');
     await tool({ pr_number: 7 }, {});
 
@@ -399,159 +414,57 @@ describe('PM agent tools', () => {
 
 // ---- Branch state helper tests ----
 
-describe('mirrorLegacyFields', () => {
-  it('mirrors current branch state to top-level fields', () => {
-    const repoInfo: RepositoryInfo = {
-      path: '/repos/backend',
-      current_branch: 'feature/task-1',
-      branch_states: {
-        'feature/task-1': {
-          base_branch: 'main', pr_number: 42, last_processed_comment_id: 10,
-        },
-      },
-    };
-    mirrorLegacyFields(repoInfo);
-    expect(repoInfo.feature_branch).toBe('feature/task-1');
-    expect(repoInfo.base_branch).toBe('main');
-    expect(repoInfo.pr_number).toBe(42);
-    expect(repoInfo.last_processed_comment_id).toBe(10);
-  });
-
-  it('mirrors only current branch when multiple exist', () => {
-    const repoInfo: RepositoryInfo = {
-      path: '/repos/backend',
-      current_branch: 'fix/bug',
-      branch_states: {
-        'feature/task-1': { pr_number: 42 },
-        'fix/bug': { pr_number: 99, base_branch: 'develop' },
-      },
-    };
-    mirrorLegacyFields(repoInfo);
-    expect(repoInfo.pr_number).toBe(99);
-    expect(repoInfo.base_branch).toBe('develop');
-    expect(repoInfo.feature_branch).toBe('fix/bug');
-  });
-
-  it('does nothing when no current branch', () => {
-    const repoInfo: RepositoryInfo = { path: '/repos/backend' };
-    mirrorLegacyFields(repoInfo);
-    expect(repoInfo.feature_branch).toBeUndefined();
-    expect(repoInfo.pr_number).toBeUndefined();
-  });
-});
-
 describe('hydrateBranchState', () => {
   it('creates branch_states from a branch name', () => {
-    const repoInfo: RepositoryInfo = { path: '/repos/backend' };
-    hydrateBranchState(repoInfo, 'feature/task-1', 'main');
+    const attached: AttachedRepo = { github: 'org/backend' };
+    hydrateBranchState(attached, 'feature/task-1', 'main');
 
-    expect(repoInfo.current_branch).toBe('feature/task-1');
-    expect(repoInfo.branch_states).toBeDefined();
-    expect(repoInfo.branch_states!['feature/task-1']).toEqual({
+    expect(attached.current_branch).toBe('feature/task-1');
+    expect(attached.branch_states).toBeDefined();
+    expect(attached.branch_states!['feature/task-1']).toEqual({
       base_branch: 'main',
     });
-    // Legacy fields mirrored
-    expect(repoInfo.feature_branch).toBe('feature/task-1');
-    expect(repoInfo.base_branch).toBe('main');
   });
 
   it('preserves existing branch_states', () => {
-    const repoInfo: RepositoryInfo = {
-      path: '/repos/backend',
+    const attached: AttachedRepo = {
+      github: 'org/backend',
       branch_states: { 'existing': { } },
     };
-    hydrateBranchState(repoInfo, 'feature/task-2', 'main');
+    hydrateBranchState(attached, 'feature/task-2', 'main');
 
-    expect(repoInfo.branch_states!['existing']).toBeDefined();
-    expect(repoInfo.branch_states!['feature/task-2']).toBeDefined();
+    expect(attached.branch_states!['existing']).toBeDefined();
+    expect(attached.branch_states!['feature/task-2']).toBeDefined();
   });
 });
 
 describe('findBranchStateByPR', () => {
   it('finds branch state by PR number', () => {
-    const repoInfo: RepositoryInfo = {
-      path: '/repos/backend',
+    const attached: AttachedRepo = {
+      github: 'org/backend',
       branch_states: {
         'feat/a': { pr_number: 42 },
         'feat/b': { pr_number: 99 },
       },
     };
-    const result = findBranchStateByPR(repoInfo, 99);
+    const result = findBranchStateByPR(attached, 99);
     expect(result).toBeDefined();
     expect(result!.branch).toBe('feat/b');
     expect(result!.state.pr_number).toBe(99);
   });
 
   it('returns undefined when no match', () => {
-    const repoInfo: RepositoryInfo = {
-      path: '/repos/backend',
+    const attached: AttachedRepo = {
+      github: 'org/backend',
       branch_states: {
         'feat/a': { pr_number: 42 },
       },
     };
-    expect(findBranchStateByPR(repoInfo, 999)).toBeUndefined();
+    expect(findBranchStateByPR(attached, 999)).toBeUndefined();
   });
 
   it('returns undefined when no branch_states', () => {
-    const repoInfo: RepositoryInfo = { path: '/repos/backend' };
-    expect(findBranchStateByPR(repoInfo, 42)).toBeUndefined();
-  });
-});
-
-describe('legacy hydration', () => {
-  it('old metadata with feature_branch hydrates into branch_states', () => {
-    const repoInfo: RepositoryInfo = {
-      path: '/repos/backend',
-      feature_branch: 'feature/task-old',
-      base_branch: 'master',
-      pr_number: 55,
-      last_processed_comment_id: 20,
-    };
-
-    // Simulate the hydration from spawn.ts
-    if (repoInfo.feature_branch && !repoInfo.branch_states) {
-      hydrateBranchState(repoInfo, repoInfo.feature_branch, repoInfo.base_branch);
-      const state = repoInfo.branch_states![repoInfo.feature_branch];
-      state.pr_number = repoInfo.pr_number;
-      state.last_processed_comment_id = repoInfo.last_processed_comment_id;
-    }
-
-    expect(repoInfo.current_branch).toBe('feature/task-old');
-    expect(repoInfo.branch_states!['feature/task-old']).toEqual({
-      base_branch: 'master',
-      pr_number: 55,
-      last_processed_comment_id: 20,
-    });
-  });
-
-  it('new metadata with branch_states skips hydration', () => {
-    const repoInfo: RepositoryInfo = {
-      path: '/repos/backend',
-      feature_branch: 'feature/task-new',
-      current_branch: 'feature/task-new',
-      branch_states: {
-        'feature/task-new': { base_branch: 'main', pr_number: 10 },
-      },
-    };
-
-    // Hydration guard
-    if (repoInfo.feature_branch && !repoInfo.branch_states) {
-      hydrateBranchState(repoInfo, repoInfo.feature_branch, repoInfo.base_branch);
-    }
-
-    // Should be unchanged
-    expect(repoInfo.branch_states!['feature/task-new'].pr_number).toBe(10);
-    expect(repoInfo.branch_states!['feature/task-new'].base_branch).toBe('main');
-  });
-
-  it('empty metadata without feature_branch does not crash', () => {
-    const repoInfo: RepositoryInfo = { path: '/repos/backend' };
-
-    if (repoInfo.feature_branch && !repoInfo.branch_states) {
-      hydrateBranchState(repoInfo, repoInfo.feature_branch, repoInfo.base_branch);
-    }
-
-    expect(repoInfo.branch_states).toBeUndefined();
-    expect(repoInfo.current_branch).toBeUndefined();
+    const attached: AttachedRepo = { github: 'org/backend' };
+    expect(findBranchStateByPR(attached, 42)).toBeUndefined();
   });
 });

--- a/src/agents/__tests__/registry-visibility.test.ts
+++ b/src/agents/__tests__/registry-visibility.test.ts
@@ -36,9 +36,8 @@ function mkRepo(pluginName: string, key: string, visibility: 'global' | 'local')
     pluginName,
     visibility,
     repo: {
-      githubRepo: `org/${key}`,
-      repoKey: key,
-      defaultPath: `/repos/${key}`,
+      repos: [{ github: `org/${key}`, baseBranch: 'main' }],
+      primary: `org/${key}`,
     },
   } as AgentDef;
 }
@@ -143,7 +142,7 @@ describe('buildPeerListForSender', () => {
   it('renders repo peers and plugin peers in their respective formats', () => {
     const sender = mkPlugin('analytics', 'analytics', 'global');
     const list = buildPeerListForSender(sender);
-    expect(list).toContain('- backend-agent: backend role (backend repository)');
+    expect(list).toContain('- backend-agent: backend role (org/backend repository)');
     expect(list).toContain('- analytics-helper-agent: analytics-helper role [analytics]');
     expect(list).not.toContain('frontend-internal-agent');
   });

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -63,7 +63,7 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
     def: {
       id: 'backend-agent', key: 'backend', role: 'Backend', expertise: 'Node',
       pluginName: 'engineering', visibility: 'global',
-      repo: { githubRepo: 'org/backend', repoKey: 'backend', defaultPath: '/repos/backend' },
+      repo: { repos: [{ github: 'org/backend', baseBranch: 'main' }], primary: 'org/backend' },
       ...overrides,
     },
     queue: {} as any,
@@ -74,18 +74,23 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
 function makeTask(): Task {
   return {
     taskId: 'task-123',
+    team: [
+      {
+        id: 'backend-agent', key: 'backend', role: 'r', expertise: 'e',
+        pluginName: 'engineering',
+        repo: { repos: [{ github: 'org/backend', baseBranch: 'main' }], primary: 'org/backend' },
+      },
+    ],
     metadata: {
       repositories: {
-        backend: {
-          path: '/repos/backend',
+        'backend-agent': [{
+          github: 'org/backend',
           clone_path: '/wt/backend',
-          feature_branch: 'feat/x',
-          base_branch: 'main',
           current_branch: 'feat/x',
           branch_states: {
             'feat/x': { base_branch: 'main' },
           },
-        },
+        }],
       },
       edit_allowed: true, status: 'active', channels: {}, participants: [], agent_sessions: {},
     },

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -134,14 +134,14 @@ export class Agent {
     // Spawn the SDK process
     await spawnAgent(this, task);
 
-    // Wire crash detection: when agent exits, mark inactive
+    // Wire crash detection: when the SDK iterator exits, mark inactive.
     if (this.handle) {
       this.handle.running.then(() => {
         task.updateAgentState(this.def.id, false);
       });
     }
 
-    // Persist (participant added, repo agent may have mutated worktree info)
+    // Persist (participant added, repo agent may have mutated attached repos)
     task.debouncedSave();
 
     // Log

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -10,7 +10,7 @@
 
 import { type AgentDef, isRepoAgent, isPmAgent } from '../types/agent.js';
 import { getPlugins, getRootMcpConfig, getPmOverlay, type LoadedMcpConfig, type PluginAgentDef } from '../system/plugin-loader.js';
-import { REPOS_DIR, PLUGINS_DATA_DIR } from '../system/workdir.js';
+import { PLUGINS_DATA_DIR } from '../system/workdir.js';
 import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -76,10 +76,11 @@ export function scanAgentDefs(): AgentDef[] {
           visibility,
           agentPrompt: agent.prompt || undefined,
           repo: {
-            githubRepo: agent.repo.github,
-            baseBranch: agent.repo.baseBranch,
-            defaultPath: join(REPOS_DIR, agent.key),
-            repoKey: agent.key,
+            repos: agent.repo.repos.map((r) => ({
+              github: r.github,
+              baseBranch: r.baseBranch || 'main',
+            })),
+            primary: agent.repo.primary,
           },
           pluginDataPath: join(PLUGINS_DATA_DIR, plugin.name),
           pluginHooks: plugin.hooks || undefined,
@@ -155,10 +156,12 @@ export function getAgentDef(id: string): AgentDef | undefined {
 }
 
 /**
- * Get repo AgentDef by GitHub repository identifier (e.g., 'sweatco/backend')
+ * Get repo AgentDef whose **primary** is the given GitHub repository identifier
+ * (e.g., 'sweatco/backend'). Matches on the primary only; an agent that merely
+ * lists the repo as a secondary is not returned.
  */
 export function getAgentDefByGithubRepo(githubRepo: string): AgentDef | undefined {
-  return registry.find((d) => d.repo?.githubRepo === githubRepo);
+  return registry.find((d) => isRepoAgent(d) && d.repo!.primary === githubRepo);
 }
 
 /**
@@ -192,7 +195,7 @@ export function buildPeerListForSender(senderDef: AgentDef): string {
 
   const repoPeers = registry
     .filter((d) => isRepoAgent(d) && visibleIds.has(d.id))
-    .map((d) => `- ${d.id}: ${d.role} (${d.repo!.repoKey} repository)`);
+    .map((d) => `- ${d.id}: ${d.role} (${d.repo!.primary} repository)`);
 
   // Non-repo peers (visibleIds already excludes the PM).
   const pluginPeers = registry

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -31,13 +31,13 @@ import { buildPeerListForSender } from './registry.js';
 import {
   getSharedPath,
   getTaskPath,
-  getReposPath,
+  getAgentClonePath,
 } from '../tasks/persistence.js';
-import { WORKDIR, getPluginsHeadInfo } from '../system/workdir.js';
+import { WORKDIR, getBaseCachePath, getPluginsHeadInfo } from '../system/workdir.js';
 import {
   createRecoverableInputGenerator,
 } from './message-queue.js';
-import { setupSharedClone, cloneExists, isWorktree, migrateWorktreeToClone, type CloneCheckout } from '../connectors/github/repo-clone.js';
+import { setupSharedClone, cloneExists, type CloneCheckout } from '../connectors/github/repo-clone.js';
 import { configureGitIdentity } from '../connectors/github/client.js';
 import { loadPrompt } from '../utils/prompt-loader.js';
 import { processAgentEventForLogging, logger } from '../system/logger.js';
@@ -67,10 +67,12 @@ async function generateRepoAgentPrompt(agent: Agent): Promise<string> {
     PEER_LIST: peerList,
   });
 
-  const repoPrompt = await loadPrompt('repo-agent', {
-    REPO_KEY: def.repo!.repoKey,
-    BASE_BRANCH: def.repo!.baseBranch || 'main',
-  });
+  // Per-repo data — github, base branch, current branch, clone path, mode — is
+  // surfaced through the dynamic Current Context block (built per spawn in the
+  // repo-agent branch of spawnAgent), not via static template variables here.
+  // The repo-agent prompt is generic; instances differ only in what their
+  // Current Context lists.
+  const repoPrompt = await loadPrompt('repo-agent', {});
 
   const layers = [corePrompt, repoPrompt];
   if (def.agentPrompt) layers.push(def.agentPrompt);
@@ -153,105 +155,6 @@ async function extractTaskUsernames(taskId: string): Promise<import('../memory/t
   } catch {
     return [];
   }
-}
-
-// ---- Repo clone setup ----
-
-interface RepoCloneSetup {
-  /** Path to the task-local shared clone the agent works in */
-  repoPath: string;
-  /** Whether the agent may write/push (edit mode) */
-  editAllowed: boolean;
-  /** Path to the base repo's .git/objects (shared, read-only) */
-  baseObjectsPath: string;
-  /** Branch the clone is currently checked out on */
-  currentBranch: string;
-}
-
-/**
- * Ensure a task-local shared clone exists for the agent's repo, migrating any
- * legacy worktree and hydrating branch state. Mutates the task's repo metadata
- * by reference. Returns the paths/flags the spawner needs to build its config.
- */
-async function prepareRepoClone(agent: Agent, task: Task): Promise<RepoCloneSetup> {
-  const { def } = agent;
-  const taskId = task.taskId;
-  const metadata = task.metadata;
-
-  const repoInfo = metadata.repositories[def.repo!.repoKey];
-  const baseRepoPath = repoInfo?.path || def.repo!.defaultPath;
-  const editAllowed = metadata.edit_allowed === true;
-  const baseBranch = repoInfo?.base_branch || def.repo!.baseBranch || 'main';
-  const baseObjectsPath = join(baseRepoPath, '.git', 'objects');
-
-  // CWD: always a shared clone at task-local path
-  const taskRepoPath = join(getReposPath(taskId), def.repo!.repoKey);
-  let repoPath: string;
-
-  // Step A: Migrate legacy worktree → shared clone if needed
-  if (await isWorktree(taskRepoPath)) {
-    logger.agent(def.id, `Migrating worktree to shared clone`);
-    await migrateWorktreeToClone(
-      def.repo!.repoKey, getReposPath(taskId), baseRepoPath,
-      baseBranch, def.repo!.githubRepo, repoInfo, editAllowed,
-    );
-  }
-
-  // Step B: Reuse existing clone or create new one
-  if (await cloneExists(taskRepoPath)) {
-    repoPath = taskRepoPath;
-    logger.agent(def.id, `Reusing existing clone at ${repoPath}`, { editMode: editAllowed });
-  } else {
-    const previousBranch = repoInfo?.current_branch;
-    const wasOnBaseBranch = !previousBranch || previousBranch === baseBranch;
-
-    let checkout: CloneCheckout;
-    if (editAllowed && wasOnBaseBranch) {
-      // RW mode, was on base branch (or no branch) — create feature branch for new work
-      checkout = { type: 'new_branch', name: taskBranchName(taskId) };
-    } else if (editAllowed && !wasOnBaseBranch) {
-      // RW but was on a specific branch — restore it
-      checkout = { type: 'branch', name: previousBranch! };
-    } else {
-      // RO default: clone on base branch
-      checkout = { type: 'base' };
-    }
-
-    const result = await setupSharedClone(
-      def.repo!.repoKey, getReposPath(taskId), baseRepoPath,
-      checkout, baseBranch, def.repo!.githubRepo,
-    );
-    repoPath = result.clone_path;
-
-    if (result.branch !== result.base_branch) {
-      hydrateBranchState(repoInfo, result.branch, result.base_branch);
-    } else {
-      repoInfo.current_branch = result.branch;
-    }
-    logger.agent(def.id, `Created shared clone at ${repoPath} (${result.branch})`, { editMode: editAllowed });
-  }
-
-  // Configure git identity for the clone
-  await configureGitIdentity(repoPath);
-
-  // Update metadata
-  repoInfo.clone_path = repoPath;
-  metadata.repositories[def.repo!.repoKey] = { ...repoInfo, path: baseRepoPath };
-
-  // Legacy hydration: old tasks with feature_branch but no branch_states
-  if (repoInfo.feature_branch && !repoInfo.branch_states) {
-    hydrateBranchState(repoInfo, repoInfo.feature_branch, repoInfo.base_branch);
-    const state = repoInfo.branch_states![repoInfo.feature_branch];
-    state.pr_number = repoInfo.pr_number;
-    state.last_processed_comment_id = repoInfo.last_processed_comment_id;
-  }
-
-  return {
-    repoPath,
-    editAllowed,
-    baseObjectsPath,
-    currentBranch: repoInfo.current_branch || baseBranch,
-  };
 }
 
 // ---- Main spawner ----
@@ -413,17 +316,102 @@ Shared folder: ${sharedPath} [READ-ONLY]
     mcpServers['scheduling-tools'] = createSchedulingMcpServer(agent, task);
   } else if (isRepoAgent(def)) {
     // ---- Repo access attached ----
-    const { repoPath, editAllowed, baseObjectsPath, currentBranch } = await prepareRepoClone(agent, task);
+    const editAllowed = metadata.edit_allowed === true;
+
+    // Ensure metadata.repositories[agentId] is an array; defaults to [primary]
+    // on first spawn so single-repo behaviour matches the pre-v30 world.
+    let attached = metadata.repositories[def.id];
+    if (!Array.isArray(attached)) {
+      attached = [];
+      metadata.repositories[def.id] = attached;
+    }
+    // Eager mount: every repo the agent declares in frontmatter is mounted at
+    // spawn. Ensure each declared repo has an attachment record (preserving
+    // existing clone/branch state for repos already present — important for
+    // recovering an old task after its agent gained a new repo in frontmatter).
+    // We iterate the DECLARED list (not the metadata list) so a repo removed
+    // from frontmatter is simply no longer mounted; a stale metadata record for
+    // it is harmless and left in place.
+    for (const entry of def.repo!.repos) {
+      if (!attached.some((a) => a.github === entry.github)) {
+        attached.push({ github: entry.github });
+      }
+    }
+
+    // Set up each declared repo: prepare clone, hydrate branch state.
+    const repoMounts: Array<{ github: string; clonePath: string; baseObjectsPath: string; currentBranch: string; baseBranch: string }> = [];
+    for (const entry of def.repo!.repos) {
+      const att = attached.find((a) => a.github === entry.github)!;
+      const baseBranch = entry.baseBranch || 'main';
+      // Prefer the base path the clone was actually built against — that's
+      // what alternates points at. Migrated old tasks carry the legacy base
+      // (`$ARCHIE_WORKDIR/repos/<short-key>/`); fresh clones default to the
+      // current github-nested layout. Pin it back into metadata so the value
+      // stays the single source of truth.
+      const baseRepoPath = att.base_path || getBaseCachePath(att.github);
+      att.base_path = baseRepoPath;
+      const baseObjectsPath = join(baseRepoPath, '.git', 'objects');
+      const desiredClonePath = getAgentClonePath(taskId, def.id, att.github);
+
+      let clonePath: string;
+      if (att.clone_path && await cloneExists(att.clone_path)) {
+        clonePath = att.clone_path;
+        logger.agent(def.id, `Reusing existing clone at ${clonePath} (${att.github})`, { editMode: editAllowed });
+      } else if (await cloneExists(desiredClonePath)) {
+        clonePath = desiredClonePath;
+        att.clone_path = clonePath;
+        logger.agent(def.id, `Reusing existing clone at ${clonePath} (${att.github})`, { editMode: editAllowed });
+      } else {
+        const previousBranch = att.current_branch;
+        const wasOnBaseBranch = !previousBranch || previousBranch === baseBranch;
+
+        let checkout: CloneCheckout;
+        if (editAllowed && wasOnBaseBranch) {
+          checkout = { type: 'new_branch', name: taskBranchName(taskId) };
+        } else if (editAllowed && previousBranch) {
+          checkout = { type: 'branch', name: previousBranch };
+        } else {
+          checkout = { type: 'base' };
+        }
+
+        const result = await setupSharedClone(
+          desiredClonePath, baseRepoPath, checkout, baseBranch, att.github,
+        );
+        clonePath = result.clone_path;
+        att.clone_path = clonePath;
+
+        if (result.branch !== result.base_branch) {
+          hydrateBranchState(att, result.branch, result.base_branch);
+        } else {
+          att.current_branch = result.branch;
+        }
+        logger.agent(def.id, `Created shared clone at ${clonePath} (${att.github} @ ${result.branch})`, { editMode: editAllowed });
+      }
+
+      await configureGitIdentity(clonePath);
+      repoMounts.push({
+        github: att.github,
+        clonePath,
+        baseObjectsPath,
+        currentBranch: att.current_branch || baseBranch,
+        baseBranch,
+      });
+    }
 
     systemPrompt = await generateRepoAgentPrompt(agent);
     const repoMode = editAllowed ? 'READ-WRITE' : 'READ-ONLY';
+    const mountLines = repoMounts.map((m) =>
+      `  - ${m.github}${m.github === def.repo!.primary ? ' (primary)' : ''}\n` +
+      `    path: ${m.clonePath} [${repoMode}]\n` +
+      `    branch: ${m.currentBranch} (base: ${m.baseBranch})`
+    ).join('\n');
     const context = `
 Task: ${taskId}
 
 Working directory (cwd): ${workspace} [READ-WRITE]
 
-Repository: ${repoPath} [${repoMode}]
-  - Current branch: ${currentBranch}
+Repositories (all mounted; use the github arg on repo-tools to target one, default is your primary):
+${mountLines}
 
 Shared folder: ${sharedPath} [READ-ONLY]
   - knowledge.log — conversation history and agent findings (read ONCE per message, don't poll)
@@ -431,8 +419,8 @@ Shared folder: ${sharedPath} [READ-ONLY]
 `;
     systemPrompt = `${systemPrompt}\n\nCurrent Context:\n${context}`;
 
-    additionalDirectories = [repoPath, ...additionalDirectories];
-
+    const allClonePaths = repoMounts.map((m) => m.clonePath);
+    additionalDirectories = [...allClonePaths, ...additionalDirectories];
     mcpServers['repo-tools'] = createRepoToolsMcpServer(agent, task);
 
     disallowedTools = [
@@ -440,7 +428,6 @@ Shared folder: ${sharedPath} [READ-ONLY]
       ...(editAllowed
         ? []
         : [
-            // RO mode: block write MCP operations (Write/Edit enforced by sandbox hooks)
             'mcp__repo-tools__push_branch',
             'mcp__repo-tools__create_pull_request',
             'mcp__repo-tools__update_pr',
@@ -455,36 +442,25 @@ Shared folder: ${sharedPath} [READ-ONLY]
           ]),
     ];
 
-    // Repo agents extend the base sandbox with the clone (RW in edit mode) and
-    // a few repo-specific read-only/protected paths.
-    const readOnlyPaths = [sharedPath, baseObjectsPath, ...pluginReadPaths];
+    // Repo agents extend the base sandbox with every attached clone (RW in edit
+    // mode) plus per-repo read-only/protected paths.
+    const readOnlyPaths = [sharedPath, ...repoMounts.map((m) => m.baseObjectsPath), ...pluginReadPaths];
+    const cloneGitHeads = repoMounts.map((m) => join(m.clonePath, '.git', 'HEAD'));
     sandboxOpts = {
       cwd,
       denyReadPaths: [WORKDIR],
-      allowReadPaths: [workspace, repoPath, ...claudeReadDirs, ...readOnlyPaths],
+      allowReadPaths: [workspace, ...allClonePaths, ...claudeReadDirs, ...readOnlyPaths],
       allowWritePaths: editAllowed
-        ? [workspace, repoPath, ...claudeWriteDirs]
+        ? [workspace, ...allClonePaths, ...claudeWriteDirs]
         : [workspace, ...claudeWriteDirs],
       denyWritePaths: editAllowed
-        ? [...readOnlyPaths, ...protectedWorkspaceFiles, join(repoPath, '.git', 'HEAD')]
-        : [repoPath, ...readOnlyPaths],
+        ? [...readOnlyPaths, ...protectedWorkspaceFiles, ...cloneGitHeads]
+        : [...allClonePaths, ...readOnlyPaths],
       allowedNetworkDomains: def.allowedNetworkDomains,
     };
   } else {
     // ---- Plain plugin agent ----
     systemPrompt = await generatePluginAgentPrompt(agent);
-    const context = `
-Task: ${taskId}
-Plugin: ${def.pluginName}
-
-Working directory (cwd): ${workspace} [READ-WRITE]
-
-Shared folder: ${sharedPath} [READ-ONLY]
-  - knowledge.log — conversation history and agent findings (read ONCE per message, don't poll)
-  - metadata.json — task metadata
-`;
-    systemPrompt = `${systemPrompt}\n\nCurrent Context:\n${context}`;
-
   }
 
   // ---- Organizational memory injection (read path; gated by ARCHIE_MEMORY_INJECT, default off) ----
@@ -492,7 +468,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
   const memorySelectors = isPmAgent(def)
     ? { taskTitle }
     : isRepoAgent(def)
-      ? { repo: def.repo!.repoKey, taskTitle }
+      ? { repo: def.repo!.primary, taskTitle }
       : { plugin: def.pluginName, taskTitle };
   const memoryUsernames = await extractTaskUsernames(taskId);
   systemPrompt = await enrichPromptWithMemory(systemPrompt, memoryUsernames, memorySelectors);

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -13,13 +13,13 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { AgentName, FindingType } from '../types/task.js';
+import type { AgentName, FindingType, AttachedRepo } from '../types/task.js';
 import type { Task } from '../tasks/task.js';
 import type { Agent } from './agent.js';
-import { getAgentIds, getVisiblePeerIdsForSender, getAgentDef } from './registry.js';
+import { getVisiblePeerIdsForSender, getAgentIds } from './registry.js';
 import { getGitHubClient, parseCheckRef } from '../connectors/github/client.js';
 import { gitExec } from '../connectors/github/repo-clone.js';
-import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
+import { hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
 import { taskBranchName } from '../connectors/github/branch-naming.js';
 import { appendAgentFinding, appendArtifactShared } from '../tasks/persistence.js';
 import { copyArtifactToShared, assertReadable } from './artifacts.js';
@@ -43,7 +43,62 @@ import { scheduleReminder, cancelReminder } from '../system/reminder-scheduler.j
 import * as chrono from 'chrono-node';
 
 // Re-export branch state helpers for consumers that import from tools.ts
-export { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR };
+export { hydrateBranchState, findBranchStateByPR };
+
+/**
+ * Resolve an attached repo for a repo-track agent in a task.
+ *
+ * If `github` is omitted, returns the agent's primary repo's `AttachedRepo`.
+ * If `github` is provided, returns the matching attached repo; returns undefined
+ * when the repo is not currently mounted for this agent (or when the agent has
+ * never spawned).
+ */
+function getAttached(agent: Agent, task: Task, github?: string): AttachedRepo | undefined {
+  const target = github ?? agent.def.repo!.primary;
+  const attachments = task.metadata.repositories[agent.def.id];
+  if (!Array.isArray(attachments)) return undefined;
+  return attachments.find((a) => a.github === target);
+}
+
+/**
+ * Resolve the github identifier for a tool call. Defaults to the agent's primary.
+ *
+ * Validates the requested github is declared in the agent's `repos` whitelist —
+ * agents can only operate on repos they've declared in frontmatter. For tools
+ * that also need the repo to be currently mounted (clone access), use
+ * `requireAttached`.
+ */
+function resolveGithub(agent: Agent, requested?: string): { ok: true; github: string } | { ok: false; error: string } {
+  const github = requested ?? agent.def.repo!.primary;
+  const declared = agent.def.repo!.repos.some((r) => r.github === github);
+  if (!declared) {
+    const list = agent.def.repo!.repos.map((r) => r.github).join(', ');
+    return { ok: false, error: `Repo "${github}" is not in this agent's declared repos list (${list}).` };
+  }
+  return { ok: true, github };
+}
+
+/**
+ * Resolve and require that the github has a local clone available.
+ *
+ * Every declared repo is mounted at spawn, so a missing clone is unexpected —
+ * it means the repo wasn't declared (caught by `resolveGithub`) or its clone
+ * setup didn't complete. The error tells the agent to report rather than retry
+ * blindly.
+ */
+function requireAttached(agent: Agent, task: Task, requested?: string): { ok: true; github: string; attached: AttachedRepo } | { ok: false; error: string } {
+  const resolved = resolveGithub(agent, requested);
+  if (!resolved.ok) return resolved;
+  const attached = getAttached(agent, task, resolved.github);
+  if (!attached?.clone_path) {
+    return { ok: false, error: `Repo "${resolved.github}" has no local clone (mount may have failed). Report this rather than retrying.` };
+  }
+  return { ok: true, github: resolved.github, attached };
+}
+
+const githubArgSchema = z.string().optional().describe(
+  'Github identifier (e.g. "org/repo") of a declared repo. Defaults to the agent\'s primary repo when omitted.',
+);
 
 const execAsync = promisify(exec);
 
@@ -157,10 +212,15 @@ export interface PRChecksReport {
 
 /**
  * Build the enum of agents the given sender can message.
- * Always includes 'pm-agent' as a fallback target so an isolated local helper
- * can still escalate. Excludes the sender itself.
+ *
+ * Applies visibility rules from the sender's plugin (same-plugin always
+ * visible; other-plugin only when `visibility === 'global'`). Always includes
+ * 'pm-agent' as a fallback target so an isolated local helper can still
+ * escalate. Excludes the sender itself.
  */
-function visibleTargetsForSender(senderDef: import('../types/agent.js').AgentDef): [string, ...string[]] {
+function visibleTargetsForSender(
+  senderDef: import('../types/agent.js').AgentDef,
+): [string, ...string[]] {
   const visible = new Set<string>(getVisiblePeerIdsForSender(senderDef));
   // PM is always reachable (escalation channel), except when the sender is PM itself.
   if (senderDef.id !== 'pm-agent') visible.add('pm-agent');
@@ -372,8 +432,8 @@ function createAssignTaskOwnerTool(agent: Agent, task: Task) {
   // PM can only assign to agents it can see — globals + same-plugin (pm) locals.
   const visibleIds = getVisiblePeerIdsForSender(agent.def);
   // Defensive fallback: if no visible peers (misconfigured deployment), expose
-  // the legacy full list so the tool still type-checks and PM gets a clear
-  // runtime error instead of a Zod construction crash.
+  // the full registry list so Zod construction doesn't crash on an empty enum;
+  // PM will get a clearer runtime error from the actual delegation attempt.
   const taskOwnerAgents = (visibleIds.length > 0 ? visibleIds : getAgentIds()) as [string, ...string[]];
   return tool(
     'assign_task_owner',
@@ -714,25 +774,27 @@ function createGetAgentsStatusTool(agent: Agent, task: Task) {
 // ---- GitHub tools (repo agents in edit mode) ----
 
 function createPushBranchTool(agent: Agent, task: Task) {
-  const repoKey = agent.def.repo!.repoKey;
   return tool(
     'push_branch',
     'Push commits from the local clone to the remote origin. Set force=true after a rebase to force-push with lease (safe against overwriting concurrent updates). Do not use force=true just because a normal push was rejected — investigate why first.',
     {
       force: z.boolean().optional().describe('Use --force-with-lease. Required after rebasing a pushed branch.'),
+      github: githubArgSchema,
     },
     async (args) => {
       const agentName = agent.def.id as AgentName;
+      const resolved = requireAttached(agent, task, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const force = args.force === true;
-      logger.agentAction(agentName, force ? 'Force-pushing branch (with lease)' : 'Pushing branch', repoKey);
+      logger.agentAction(
+        agentName,
+        force ? 'Force-pushing branch (with lease)' : 'Pushing branch',
+        resolved.github,
+      );
 
-      const repoInfo = task.metadata.repositories[repoKey];
-      if (!repoInfo?.clone_path) {
-        return err('No clone found');
-      }
-
-      const branch = repoInfo.current_branch;
-      const state = branch ? repoInfo.branch_states?.[branch] : undefined;
+      const { attached } = resolved;
+      const branch = attached.current_branch;
+      const state = branch ? attached.branch_states?.[branch] : undefined;
 
       if (!branch || !state) {
         return err('No branch to push');
@@ -740,12 +802,11 @@ function createPushBranchTool(agent: Agent, task: Task) {
 
       try {
         const forceFlag = force ? '--force-with-lease ' : '';
-        await execAsync(`git push ${forceFlag}-u origin HEAD:${branch}`, { cwd: repoInfo.clone_path });
+        await execAsync(`git push ${forceFlag}-u origin HEAD:${branch}`, { cwd: attached.clone_path! });
 
-        mirrorLegacyFields(repoInfo);
         task.debouncedSave();
 
-        const message = `${force ? 'Force-pushed' : 'Pushed'} ${branch} to origin`;
+        const message = `${force ? 'Force-pushed' : 'Pushed'} ${branch} to origin (${resolved.github})`;
         logger.system(`GitHub: ${message}`);
         return ok(`Successfully pushed: ${message}`);
       } catch (error) {
@@ -758,58 +819,59 @@ function createPushBranchTool(agent: Agent, task: Task) {
 }
 
 function createPullRequestTool(agent: Agent, task: Task) {
-  const repoKey = agent.def.repo!.repoKey;
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'create_pull_request',
     'Create a pull request on GitHub.',
     {
       title: z.string().describe('PR title'),
       body: z.string().describe('PR description body'),
+      github: githubArgSchema,
     },
     async (args) => {
       const agentName = agent.def.id as AgentName;
       logger.agentAction(agentName, 'Creating PR', args.title);
 
+      const resolved = requireAttached(agent, task, args.github);
+      if (!resolved.ok) return err(resolved.error);
+
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
 
-      const repoInfo = task.metadata.repositories[repoKey];
-      const branch = repoInfo?.current_branch;
-      const state = branch ? repoInfo?.branch_states?.[branch] : undefined;
+      const { github, attached } = resolved;
+      const branch = attached.current_branch;
+      const state = branch ? attached.branch_states?.[branch] : undefined;
       const head = branch || taskBranchName(task.taskId);
-      const base = state?.base_branch || agent.def.repo!.baseBranch || 'main';
+      const entry = agent.def.repo!.repos.find((r) => r.github === github);
+      const base = state?.base_branch || entry?.baseBranch || 'main';
 
-      const result = await client.createPullRequest(githubRepo, head, base, args.title, args.body);
+      const result = await client.createPullRequest(github, head, base, args.title, args.body);
 
       if (state) {
         state.pr_number = result.pr_number;
       }
-      if (repoInfo) {
-        mirrorLegacyFields(repoInfo);
-        task.debouncedSave();
-      }
+      task.debouncedSave();
 
-      await appendAgentFinding(task.taskId, agentName, `Created PR #${result.pr_number}: ${result.pr_url}`, 'decision');
-      return ok(`Created PR #${result.pr_number}: ${result.pr_url}`);
+      await appendAgentFinding(task.taskId, agentName, `Created PR #${result.pr_number} on ${github}: ${result.pr_url}`, 'decision');
+      return ok(`Created PR #${result.pr_number} on ${github}: ${result.pr_url}`);
     },
   );
 }
 
 function createGetPRStatusTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'get_pr_status',
     'Get the current status of a pull request.',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      const status = await client.getPRStatus(githubRepo, args.pr_number);
+      const status = await client.getPRStatus(resolved.github, args.pr_number);
       return {
         content: [{
           type: 'text' as const,
-          text: `PR #${args.pr_number} status:\n- State: ${status.state}\n- Mergeable: ${status.mergeable}\n- Mergeable State: ${status.mergeableState}\n- Approved: ${status.approved}`,
+          text: `PR #${args.pr_number} (${resolved.github}) status:\n- State: ${status.state}\n- Mergeable: ${status.mergeable}\n- Mergeable State: ${status.mergeableState}\n- Approved: ${status.approved}`,
         }],
       };
     },
@@ -817,15 +879,16 @@ function createGetPRStatusTool(agent: Agent, task: Task) {
 }
 
 function createGetPRChecksTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'get_pr_checks',
     'List CI checks (check-runs + legacy commit statuses) attached to a PR\'s HEAD commit. Returns conclusion, URL, and — for failed checks — the full output (title/summary/text). Use this when a "checks updated" event arrives or get_pr_status reports mergeableState=unstable, to find which specific check broke.',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      const report = await client.listPRChecks(githubRepo, args.pr_number);
+      const report = await client.listPRChecks(resolved.github, args.pr_number);
       if (report.entries.length === 0) {
         return ok(`No checks found for PR #${args.pr_number} (head ${report.headSha.slice(0, 7)}).`);
       }
@@ -864,7 +927,6 @@ function createGetPRChecksTool(agent: Agent, task: Task) {
 }
 
 function createGetCheckRunTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'get_check_run',
     'Fetch a single CI check/run by its id or a github.com URL — no PR needed. ' +
@@ -873,8 +935,12 @@ function createGetCheckRunTool(agent: Agent, task: Task) {
     'For checks on a PR you already know, prefer get_pr_checks.',
     {
       ref: z.string().describe('A numeric check-run/job/workflow-run id, or a full github.com URL pointing at one.'),
+      github: githubArgSchema,
     },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
+      const githubRepo = resolved.github;
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
 
@@ -944,59 +1010,62 @@ function createGetCheckRunTool(agent: Agent, task: Task) {
 }
 
 function createGetPRReviewsTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'get_pr_reviews',
     'Get review-level summary for a PR (approvals, change requests, review bodies). For line-level comments, use get_review_threads.',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      const reviews = await client.getPRReviews(githubRepo, args.pr_number);
+      const reviews = await client.getPRReviews(resolved.github, args.pr_number);
       if (reviews.length === 0) {
-        return ok(`No reviews found for PR #${args.pr_number}`);
+        return ok(`No reviews found for PR #${args.pr_number} (${resolved.github})`);
       }
       const lines = reviews.map((r) =>
         `- ${r.user} [${r.state}] @ ${r.submittedAt}: ${r.body || '(no body)'}`
       );
-      return ok(`Reviews for PR #${args.pr_number}:\n${lines.join('\n')}`);
+      return ok(`Reviews for PR #${args.pr_number} (${resolved.github}):\n${lines.join('\n')}`);
     },
   );
 }
 
 function createGetPRCommentsTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'get_pr_comments',
     'Get top-level PR conversation comments (the "Conversation" tab). Does not include line-level review comments — use get_review_threads for those.',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      const comments = await client.getPRComments(githubRepo, args.pr_number);
+      const comments = await client.getPRComments(resolved.github, args.pr_number);
       if (comments.length === 0) {
-        return ok(`No conversation comments on PR #${args.pr_number}`);
+        return ok(`No conversation comments on PR #${args.pr_number} (${resolved.github})`);
       }
       const lines = comments.map((c) =>
         `- [comment_id=${c.id}] ${c.author} @ ${c.createdAt}: ${c.body}`
       );
-      return ok(`Comments on PR #${args.pr_number}:\n${lines.join('\n')}`);
+      return ok(`Comments on PR #${args.pr_number} (${resolved.github}):\n${lines.join('\n')}`);
     },
   );
 }
 
 function createGetReviewThreadsTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'get_review_threads',
     'Get every review thread on a PR with its thread_id (for resolve_review_thread) and each comment\'s comment_id (for reply_to_review_comment).',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      const threads = await client.getReviewThreads(githubRepo, args.pr_number);
+      const threads = await client.getReviewThreads(resolved.github, args.pr_number);
       if (threads.length === 0) {
-        return ok(`No review threads on PR #${args.pr_number}`);
+        return ok(`No review threads on PR #${args.pr_number} (${resolved.github})`);
       }
       const chunks = threads.map((t) => {
         const flags = [
@@ -1010,13 +1079,12 @@ function createGetReviewThreadsTool(agent: Agent, task: Task) {
         );
         return [header, ...lines].join('\n');
       });
-      return ok(`Review threads on PR #${args.pr_number}:\n${chunks.join('\n\n')}`);
+      return ok(`Review threads on PR #${args.pr_number} (${resolved.github}):\n${chunks.join('\n\n')}`);
     },
   );
 }
 
 function createListPRsTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'list_prs',
     'List pull requests with optional filters.',
@@ -1025,39 +1093,43 @@ function createListPRsTool(agent: Agent, task: Task) {
       base: z.string().optional().describe('Filter by base branch (e.g. "main")'),
       sort: z.enum(['created', 'updated', 'popularity', 'long-running']).optional().describe('Sort field (default: updated)'),
       limit: z.number().optional().describe('Max results to return (default: 10)'),
+      github: githubArgSchema,
     },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      const prs = await client.listPRs(githubRepo, {
+      const prs = await client.listPRs(resolved.github, {
         state: args.state,
         base: args.base,
         sort: args.sort,
         per_page: args.limit,
       });
       if (prs.length === 0) {
-        return ok('No PRs found matching the filters.');
+        return ok(`No PRs found in ${resolved.github} matching the filters.`);
       }
       const lines = prs.map((pr) =>
         `#${pr.number} [${pr.state}] ${pr.title} (${pr.head} → ${pr.base}) by ${pr.author} — ${pr.url}`
       );
-      return ok(lines.join('\n'));
+      return ok(`PRs in ${resolved.github}:\n${lines.join('\n')}`);
     },
   );
 }
 
 function createGetPRTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'get_pr',
     'Get full PR details: title, description, diff, state, and branches.',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      const pr = await client.getPRDetails(githubRepo, args.pr_number);
+      const pr = await client.getPRDetails(resolved.github, args.pr_number);
       const text = [
-        `PR #${pr.number}: ${pr.title}`,
+        `PR #${pr.number} (${resolved.github}): ${pr.title}`,
         `State: ${pr.state} | ${pr.head} → ${pr.base}`,
         `URL: ${pr.url}`,
         '',
@@ -1073,7 +1145,6 @@ function createGetPRTool(agent: Agent, task: Task) {
 }
 
 function createUpdatePRTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'update_pr',
     'Update the title, description, and/or base branch of a pull request. All fields are optional — include only what needs to change.',
@@ -1082,40 +1153,44 @@ function createUpdatePRTool(agent: Agent, task: Task) {
       title: z.string().optional().describe('New PR title'),
       body: z.string().optional().describe('New PR description body'),
       base: z.string().optional().describe('New base branch (retarget the PR, e.g. "main" → "release-1.2")'),
+      github: githubArgSchema,
     },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      await client.updatePR(githubRepo, args.pr_number, {
+      await client.updatePR(resolved.github, args.pr_number, {
         title: args.title,
         body: args.body,
         base: args.base,
       });
-      return { content: [{ type: 'text' as const, text: `Updated PR #${args.pr_number}` }] };
+      return ok(`Updated PR #${args.pr_number} (${resolved.github})`);
     },
   );
 }
 
 function createAddPRCommentTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'add_pr_comment',
     'Add a general comment to a pull request.',
     {
       pr_number: z.number().describe('The PR number'),
       comment: z.string().describe('The comment text'),
+      github: githubArgSchema,
     },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      await client.addPRComment(githubRepo, args.pr_number, args.comment);
-      return { content: [{ type: 'text' as const, text: `Added comment to PR #${args.pr_number}` }] };
+      await client.addPRComment(resolved.github, args.pr_number, args.comment);
+      return ok(`Added comment to PR #${args.pr_number} (${resolved.github})`);
     },
   );
 }
 
 function createAddReviewCommentTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'add_review_comment',
     'Start a NEW review thread on a specific line of code. To reply inside an existing thread, use reply_to_review_comment instead.',
@@ -1124,18 +1199,20 @@ function createAddReviewCommentTool(agent: Agent, task: Task) {
       path: z.string().describe('File path relative to repo root'),
       line: z.number().describe('Line number in the file'),
       comment: z.string().describe('The comment text'),
+      github: githubArgSchema,
     },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      await client.addReviewComment(githubRepo, args.pr_number, args.path, args.line, args.comment);
-      return ok(`Added review comment to ${args.path}:${args.line} on PR #${args.pr_number}`);
+      await client.addReviewComment(resolved.github, args.pr_number, args.path, args.line, args.comment);
+      return ok(`Added review comment to ${args.path}:${args.line} on PR #${args.pr_number} (${resolved.github})`);
     },
   );
 }
 
 function createReplyToReviewCommentTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'reply_to_review_comment',
     'Reply inside an existing review thread. Requires the comment_id of any comment in the target thread (from the knowledge log or get_review_threads).',
@@ -1143,85 +1220,93 @@ function createReplyToReviewCommentTool(agent: Agent, task: Task) {
       pr_number: z.number().describe('The PR number'),
       comment_id: z.number().describe('REST comment id of any comment in the target thread'),
       comment: z.string().describe('The reply text'),
+      github: githubArgSchema,
     },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      await client.replyToReviewComment(githubRepo, args.pr_number, args.comment_id, args.comment);
-      return ok(`Replied to review comment ${args.comment_id} on PR #${args.pr_number}`);
+      await client.replyToReviewComment(resolved.github, args.pr_number, args.comment_id, args.comment);
+      return ok(`Replied to review comment ${args.comment_id} on PR #${args.pr_number} (${resolved.github})`);
     },
   );
 }
 
 function createResolveReviewThreadTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'resolve_review_thread',
     'Mark a review thread as resolved. thread_id must be a GraphQL node id (e.g. PRRT_...) obtained from get_review_threads.',
     {
       pr_number: z.number().describe('The PR number'),
       thread_id: z.string().describe('GraphQL thread node id from get_review_threads (e.g. PRRT_...)'),
+      github: githubArgSchema,
     },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      await client.resolveReviewThread(githubRepo, args.pr_number, args.thread_id);
-      return ok(`Resolved review thread ${args.thread_id} on PR #${args.pr_number}`);
+      await client.resolveReviewThread(resolved.github, args.pr_number, args.thread_id);
+      return ok(`Resolved review thread ${args.thread_id} on PR #${args.pr_number} (${resolved.github})`);
     },
   );
 }
 
 function createRequestReReviewTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'request_re_review',
     'Request reviewers to re-review the PR after changes.',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      await client.requestReReview(githubRepo, args.pr_number);
-      return { content: [{ type: 'text' as const, text: `Requested re-review for PR #${args.pr_number}` }] };
+      await client.requestReReview(resolved.github, args.pr_number);
+      return ok(`Requested re-review for PR #${args.pr_number} (${resolved.github})`);
     },
   );
 }
 
 
 function createMergePRTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'merge_pull_request',
     'Merge a pull request. Checks mergeability first and returns the current status if not ready.',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
 
-      const status = await client.getPRStatus(githubRepo, args.pr_number);
+      const status = await client.getPRStatus(resolved.github, args.pr_number);
       if (status.state !== 'open') {
-        return { content: [{ type: 'text' as const, text: `Cannot merge: PR #${args.pr_number} is ${status.state}` }] };
+        return ok(`Cannot merge: PR #${args.pr_number} (${resolved.github}) is ${status.state}`);
       }
       if (!status.mergeable || status.mergeableState !== 'clean') {
-        return { content: [{ type: 'text' as const, text: `Cannot merge: PR #${args.pr_number} is not ready (mergeable=${status.mergeable}, state=${status.mergeableState})` }] };
+        return ok(`Cannot merge: PR #${args.pr_number} (${resolved.github}) is not ready (mergeable=${status.mergeable}, state=${status.mergeableState})`);
       }
 
-      const result = await client.mergePullRequest(githubRepo, args.pr_number);
+      const result = await client.mergePullRequest(resolved.github, args.pr_number);
       return { content: [{ type: 'text' as const, text: result.message }] };
     },
   );
 }
 
 function createClosePRTool(agent: Agent, task: Task) {
-  const githubRepo = agent.def.repo!.githubRepo;
   return tool(
     'close_pull_request',
     'Close a pull request without merging.',
-    { pr_number: z.number().describe('The PR number') },
+    { pr_number: z.number().describe('The PR number'), github: githubArgSchema },
     async (args) => {
+      const resolved = resolveGithub(agent, args.github);
+      if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
-      await client.closePullRequest(githubRepo, args.pr_number);
-      return { content: [{ type: 'text' as const, text: `Closed PR #${args.pr_number}` }] };
+      await client.closePullRequest(resolved.github, args.pr_number);
+      return ok(`Closed PR #${args.pr_number} (${resolved.github})`);
     },
   );
 }
@@ -1229,36 +1314,35 @@ function createClosePRTool(agent: Agent, task: Task) {
 // ---- Git workflow tools (repo agents) ----
 
 function createFetchTool(agent: Agent, task: Task) {
-  const repoKey = agent.def.repo!.repoKey;
   return tool(
     'fetch',
     'Fetch latest refs from origin.',
-    {},
-    async () => {
-      const repoInfo = task.metadata.repositories[repoKey];
-      const clonePath = repoInfo?.clone_path;
-      if (!clonePath) return err('No clone path');
-      await gitExec(clonePath, 'fetch origin');
-      return ok('Fetched latest from origin');
+    { github: githubArgSchema },
+    async (args) => {
+      const resolved = requireAttached(agent, task, args.github);
+      if (!resolved.ok) return err(resolved.error);
+      await gitExec(resolved.attached.clone_path!, 'fetch origin');
+      return ok(`Fetched latest from origin (${resolved.github})`);
     },
   );
 }
 
 function createSwitchBranchTool(agent: Agent, task: Task) {
-  const repoKey = agent.def.repo!.repoKey;
   return tool(
     'switch_branch',
     'Switch to a different branch. Fetches latest, auto-stashes dirty work, auto-pops on return.',
     {
       branch: z.string().describe('Branch name to switch to'),
+      github: githubArgSchema,
     },
     async (args) => {
-      const repoInfo = task.metadata.repositories[repoKey];
-      const clonePath = repoInfo.clone_path;
-      if (!clonePath) return err('No clone available');
+      const resolved = requireAttached(agent, task, args.github);
+      if (!resolved.ok) return err(resolved.error);
+      const { attached } = resolved;
+      const clonePath = attached.clone_path!;
 
       const branch = args.branch;
-      const currentBranch = repoInfo.current_branch;
+      const currentBranch = attached.current_branch;
 
       // 1. Fetch branch into clone
       await gitExec(clonePath, `fetch origin ${branch}`).catch(() => {});
@@ -1268,8 +1352,8 @@ function createSwitchBranchTool(agent: Agent, task: Task) {
       if (status.trim()) {
         const stashName = `archie:${task.taskId}:${currentBranch}`;
         await gitExec(clonePath, `stash push --include-untracked -m "${stashName}"`);
-        if (currentBranch && repoInfo.branch_states?.[currentBranch]) {
-          repoInfo.branch_states[currentBranch].stash_name = stashName;
+        if (currentBranch && attached.branch_states?.[currentBranch]) {
+          attached.branch_states[currentBranch].stash_name = stashName;
         }
       }
 
@@ -1282,16 +1366,16 @@ function createSwitchBranchTool(agent: Agent, task: Task) {
       }
 
       // 4. Track branch state
-      repoInfo.branch_states ??= {};
-      if (!repoInfo.branch_states[branch]) {
-        repoInfo.branch_states[branch] = {};
+      attached.branch_states ??= {};
+      if (!attached.branch_states[branch]) {
+        attached.branch_states[branch] = {};
       }
 
       // 5. Update current_branch
-      repoInfo.current_branch = branch;
+      attached.current_branch = branch;
 
       // 7. Auto-pop stash if exists for target branch
-      const targetState = repoInfo.branch_states[branch];
+      const targetState = attached.branch_states[branch];
       if (targetState?.stash_name) {
         const stashList = await gitExec(clonePath, 'stash list');
         const stashIndex = findStashIndex(stashList, targetState.stash_name);
@@ -1301,7 +1385,6 @@ function createSwitchBranchTool(agent: Agent, task: Task) {
         targetState.stash_name = undefined;
       }
 
-      mirrorLegacyFields(repoInfo);
       task.debouncedSave();
       return ok(`Switched to ${branch}`);
     },
@@ -1309,51 +1392,62 @@ function createSwitchBranchTool(agent: Agent, task: Task) {
 }
 
 function createCreateBranchTool(agent: Agent, task: Task) {
-  const repoKey = agent.def.repo!.repoKey;
   return tool(
     'create_branch',
     'Create a new branch and switch to it. Branch name is auto-generated from the task ID. Returns the full branch name.',
     {
       base: z.string().optional().describe('Base branch or commit (default: current HEAD)'),
+      github: githubArgSchema,
     },
     async (args) => {
-      const repoInfo = task.metadata.repositories[repoKey];
-      if (!repoInfo?.clone_path) return err('No clone');
+      const resolved = requireAttached(agent, task, args.github);
+      if (!resolved.ok) return err(resolved.error);
+      const { attached } = resolved;
 
       // Count existing branches to generate unique name
-      const existing = Object.keys(repoInfo.branch_states || {}).length;
+      const existing = Object.keys(attached.branch_states || {}).length;
       const branchName = taskBranchName(task.taskId, existing);
 
       const base = args.base || 'HEAD';
-      await gitExec(repoInfo.clone_path, `checkout -b ${branchName} ${base}`);
+      await gitExec(attached.clone_path!, `checkout -b ${branchName} ${base}`);
 
-      repoInfo.branch_states ??= {};
-      repoInfo.branch_states[branchName] = {};
-      repoInfo.current_branch = branchName;
-      mirrorLegacyFields(repoInfo);
+      attached.branch_states ??= {};
+      attached.branch_states[branchName] = {};
+      attached.current_branch = branchName;
       task.debouncedSave();
-      return ok(`Created and switched to ${branchName}`);
+      return ok(`Created and switched to ${branchName} (${resolved.github})`);
     },
   );
 }
 
 function createListBranchesTool(agent: Agent, task: Task) {
-  const repoKey = agent.def.repo!.repoKey;
   return tool(
     'list_branches',
-    'List branches created or visited by this agent in the current task.',
-    {},
-    async () => {
-      const repoInfo = task.metadata.repositories[repoKey];
-      const current = repoInfo?.current_branch || '(unknown)';
-      const states = repoInfo?.branch_states || {};
-      const branches = Object.entries(states)
-        .map(([name, s]) => `${name}${s.pr_number ? ` (PR #${s.pr_number})` : ''}`);
-      const lines = [
-        `Current: ${current}`,
-        `Branches: ${branches.join(', ') || '(none)'}`,
-      ];
-      return ok(lines.join('\n'));
+    'List branches created or visited by this agent in the current task. With no arguments, lists branches across every attached repo.',
+    { github: githubArgSchema },
+    async (args) => {
+      const attachments = task.metadata.repositories[agent.def.id];
+      if (!Array.isArray(attachments) || attachments.length === 0) {
+        return ok('No attached repos.');
+      }
+      let filtered = attachments;
+      if (args.github) {
+        const resolved = resolveGithub(agent, args.github);
+        if (!resolved.ok) return err(resolved.error);
+        filtered = attachments.filter((a) => a.github === resolved.github);
+      }
+      const blocks = filtered.map((a) => {
+        const current = a.current_branch || '(unknown)';
+        const states = a.branch_states || {};
+        const branches = Object.entries(states)
+          .map(([name, s]) => `${name}${s.pr_number ? ` (PR #${s.pr_number})` : ''}`);
+        return [
+          `[${a.github}]`,
+          `  Current: ${current}`,
+          `  Branches: ${branches.join(', ') || '(none)'}`,
+        ].join('\n');
+      });
+      return ok(blocks.join('\n\n'));
     },
   );
 }
@@ -1458,7 +1552,7 @@ export function createCommsMcpServer(agent: Agent, task: Task) {
   });
 }
 
-/** Task orchestration (ownership, completion, edit mode, team status, spawning). */
+/** Task orchestration (ownership, completion, edit mode, team status). */
 export function createOrchestrationMcpServer(agent: Agent, task: Task) {
   return createSdkMcpServer({
     name: 'orchestration-tools',

--- a/src/connectors/github/branch-state.ts
+++ b/src/connectors/github/branch-state.ts
@@ -1,47 +1,29 @@
 /**
- * Branch state helpers for RepositoryInfo.
+ * Branch state helpers for AttachedRepo.
  *
  * Pure functions that operate on branch_states metadata.
  * Used by tools, spawn, events, and merge modules.
  */
 
-import type { RepositoryInfo } from '../../types/task.js';
+import type { AttachedRepo } from '../../types/task.js';
 
 /**
- * Mirror current branch state to legacy top-level fields for rollback safety.
- * Called after any branch state change.
+ * Initialize branch_states for a newly checked-out branch.
  */
-export function mirrorLegacyFields(repoInfo: RepositoryInfo): void {
-  const current = repoInfo.current_branch;
-  const state = current ? repoInfo.branch_states?.[current] : undefined;
-  if (state) {
-    repoInfo.feature_branch = current;
-    repoInfo.base_branch = state.base_branch;
-    repoInfo.pr_number = state.pr_number;
-    repoInfo.last_processed_comment_id = state.last_processed_comment_id;
-  }
-}
-
-/**
- * Initialize branch_states from a newly created or legacy feature branch.
- */
-export function hydrateBranchState(repoInfo: RepositoryInfo, branch: string, baseBranch?: string): void {
-  repoInfo.branch_states ??= {};
-  repoInfo.branch_states[branch] = {
+export function hydrateBranchState(repo: AttachedRepo, branch: string, baseBranch?: string): void {
+  repo.branch_states ??= {};
+  repo.branch_states[branch] = {
     base_branch: baseBranch,
   };
-  repoInfo.current_branch = branch;
-  // Mirror to legacy fields
-  repoInfo.feature_branch = branch;
-  repoInfo.base_branch = baseBranch;
+  repo.current_branch = branch;
 }
 
 /**
  * Find a BranchState by its PR number (for webhook/event routing).
  */
-export function findBranchStateByPR(repoInfo: RepositoryInfo, prNumber: number) {
-  if (!repoInfo.branch_states) return undefined;
-  for (const [branch, state] of Object.entries(repoInfo.branch_states)) {
+export function findBranchStateByPR(repo: AttachedRepo, prNumber: number) {
+  if (!repo.branch_states) return undefined;
+  for (const [branch, state] of Object.entries(repo.branch_states)) {
     if (state.pr_number === prNumber) return { branch, state };
   }
   return undefined;

--- a/src/connectors/github/events.ts
+++ b/src/connectors/github/events.ts
@@ -24,7 +24,6 @@ import {
 import { Task } from '../../tasks/task.js';
 import { appendGitHubEvent } from '../../tasks/persistence.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
-import { getAgentDefByGithubRepo } from '../../agents/registry.js';
 import { findBranchStateByPR } from './branch-state.js';
 import { logger } from '../../system/logger.js';
 import { getIsShuttingDown } from '../../system/shutdown.js';
@@ -147,27 +146,33 @@ async function handleExistingTaskDirect(
   taskId: string,
   context: ReturnType<typeof formatGitHubContext>
 ): Promise<void> {
-  const repoDef = getAgentDefByGithubRepo(context.githubRepo);
-  const repoKey = repoDef?.repo?.repoKey || 'unknown';
   const task = await Task.get(taskId);
 
   if (context.eventType === 'issue_comment' && context.prNumber && context.commentId) {
-    const repoInfo = task.metadata.repositories[repoKey];
-    const branchMatch = repoInfo ? findBranchStateByPR(repoInfo, context.prNumber) : undefined;
-    const lastProcessedId = branchMatch?.state.last_processed_comment_id
-      ?? repoInfo?.last_processed_comment_id
-      ?? 0;
+    // Walk every attached repo across every agent looking for a branch state
+    // matching this PR. Update `last_processed_comment_id` on every match
+    // (two agents on the same PR should both dedup against the same id).
+    let lastProcessedId = 0;
+    const matches: Array<{ state: { last_processed_comment_id?: number } }> = [];
+    for (const attachments of Object.values(task.metadata.repositories)) {
+      if (!Array.isArray(attachments)) continue;
+      for (const attached of attachments) {
+        if (attached.github !== context.githubRepo) continue;
+        const branchMatch = findBranchStateByPR(attached, context.prNumber);
+        if (!branchMatch) continue;
+        matches.push(branchMatch);
+        const seen = branchMatch.state.last_processed_comment_id ?? 0;
+        if (seen > lastProcessedId) lastProcessedId = seen;
+      }
+    }
 
     if (context.commentId <= lastProcessedId) {
       logger.system(`GitHub: Skipping already-processed comment ${context.commentId} on PR #${context.prNumber}`);
       return;
     }
 
-    if (branchMatch) {
-      branchMatch.state.last_processed_comment_id = context.commentId;
-    }
-    if (repoInfo) {
-      repoInfo.last_processed_comment_id = context.commentId;
+    for (const m of matches) {
+      m.state.last_processed_comment_id = context.commentId;
     }
     task.debouncedSave();
   }

--- a/src/connectors/github/merge.ts
+++ b/src/connectors/github/merge.ts
@@ -21,13 +21,11 @@ import { appendAgentFinding } from '../../tasks/persistence.js';
 import { Task } from '../../tasks/task.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
 import { createGitHubClient, type GitHubClient } from './client.js';
-import { getAgentDef } from '../../agents/registry.js';
 import { logger } from '../../system/logger.js';
 import type { PRStatus } from '../../agents/tools.js';
 
 interface LinkedPRStatus {
-  repoKey: string;
-  githubRepo: string;
+  github: string;
   prNumber: number;
   status: PRStatus;
 }
@@ -69,18 +67,22 @@ export async function triggerMergeCheck(taskId: string): Promise<MergeCheckResul
     return result;
   }
 
-  // Collect all PRs linked to this task (from branch_states, with legacy fallback)
-  const linkedPRs: Array<{ repoKey: string; prNumber: number }> = [];
-  for (const [repoKey, repoInfo] of Object.entries(task.metadata.repositories)) {
-    if (repoInfo.branch_states) {
-      for (const state of Object.values(repoInfo.branch_states)) {
-        if (state.pr_number) {
-          linkedPRs.push({ repoKey, prNumber: state.pr_number });
-        }
+  // Collect all PRs linked to this task by iterating every attached repo across
+  // every agent. A PR is identified by (github, prNumber); dedupe so two agents
+  // pointing at the same PR don't generate duplicate work.
+  const linkedPRSet = new Set<string>();
+  const linkedPRs: Array<{ github: string; prNumber: number }> = [];
+  for (const attachments of Object.values(task.metadata.repositories)) {
+    if (!Array.isArray(attachments)) continue;
+    for (const attached of attachments) {
+      if (!attached.branch_states) continue;
+      for (const state of Object.values(attached.branch_states)) {
+        if (!state.pr_number) continue;
+        const key = `${attached.github}#${state.pr_number}`;
+        if (linkedPRSet.has(key)) continue;
+        linkedPRSet.add(key);
+        linkedPRs.push({ github: attached.github, prNumber: state.pr_number });
       }
-    } else if (repoInfo.pr_number) {
-      // Legacy fallback
-      linkedPRs.push({ repoKey, prNumber: repoInfo.pr_number });
     }
   }
 
@@ -160,33 +162,33 @@ export async function triggerMergeCheck(taskId: string): Promise<MergeCheckResul
     }
 
     const reasonStr = reason ? ` - ${reason}` : '';
-    logger.system(`Task ${taskId}: ${pr.repoKey}#${pr.prNumber} → ${category}${reasonStr} (${flags.join(', ')})`);
+    logger.system(`Task ${taskId}: ${pr.github}#${pr.prNumber} → ${category}${reasonStr} (${flags.join(', ')})`);
   }
 
   // Format already merged PRs
   for (const pr of alreadyMerged) {
-    result.merged.push(`${pr.repoKey}#${pr.prNumber} (already merged)`);
+    result.merged.push(`${pr.github}#${pr.prNumber} (already merged)`);
   }
 
   // Merge what's ready
   for (const pr of mergeable) {
     try {
-      const mergeResult = await githubClient.mergePullRequest(pr.githubRepo, pr.prNumber);
+      const mergeResult = await githubClient.mergePullRequest(pr.github, pr.prNumber);
       if (mergeResult.success) {
-        result.merged.push(`${pr.repoKey}#${pr.prNumber}`);
-        logger.system(`Merged ${pr.githubRepo}#${pr.prNumber}`);
+        result.merged.push(`${pr.github}#${pr.prNumber}`);
+        logger.system(`Merged ${pr.github}#${pr.prNumber}`);
       } else {
-        result.pending.push(`${pr.repoKey}#${pr.prNumber}: ${mergeResult.message}`);
+        result.pending.push(`${pr.github}#${pr.prNumber}: ${mergeResult.message}`);
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
-      result.pending.push(`${pr.repoKey}#${pr.prNumber}: ${message}`);
+      result.pending.push(`${pr.github}#${pr.prNumber}: ${message}`);
     }
   }
 
   // Record conflicts
   for (const pr of conflicted) {
-    result.conflicts.push(`${pr.repoKey}#${pr.prNumber}`);
+    result.conflicts.push(`${pr.github}#${pr.prNumber}`);
   }
 
   // Record pending PRs
@@ -194,7 +196,7 @@ export async function triggerMergeCheck(taskId: string): Promise<MergeCheckResul
     const reasons: string[] = [];
     if (!pr.status.approved) reasons.push('needs approval');
     if (pr.status.mergeableState !== 'clean') reasons.push(pr.status.mergeableState);
-    result.pending.push(`${pr.repoKey}#${pr.prNumber}: ${reasons.join(', ')}`);
+    result.pending.push(`${pr.github}#${pr.prNumber}: ${reasons.join(', ')}`);
   }
 
   return result;
@@ -205,29 +207,18 @@ export async function triggerMergeCheck(taskId: string): Promise<MergeCheckResul
  */
 async function fetchAllPRStatuses(
   githubClient: GitHubClient,
-  linkedPRs: Array<{ repoKey: string; prNumber: number }>
+  linkedPRs: Array<{ github: string; prNumber: number }>
 ): Promise<LinkedPRStatus[]> {
   const results: LinkedPRStatus[] = [];
 
-  for (const { repoKey, prNumber } of linkedPRs) {
-    const def = getAgentDef(`${repoKey}-agent`);
-    if (!def?.repo) {
-      logger.warn('merge-orchestrator', `No config found for repo key: ${repoKey}`);
-      continue;
-    }
-
+  for (const { github, prNumber } of linkedPRs) {
     try {
-      const status = await githubClient.getPRStatus(def.repo.githubRepo, prNumber);
-      results.push({
-        repoKey,
-        githubRepo: def.repo.githubRepo,
-        prNumber,
-        status,
-      });
+      const status = await githubClient.getPRStatus(github, prNumber);
+      results.push({ github, prNumber, status });
     } catch (error) {
       logger.error(
         'merge-orchestrator',
-        `Failed to get status for ${def.repo!.githubRepo}#${prNumber}`,
+        `Failed to get status for ${github}#${prNumber}`,
         error
       );
     }

--- a/src/connectors/github/repo-clone.ts
+++ b/src/connectors/github/repo-clone.ts
@@ -15,7 +15,6 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 import { logger } from '../../system/logger.js';
 import { fetchOrigin } from './client.js';
-import type { RepositoryInfo } from '../../types/task.js';
 
 const execAsync = promisify(exec);
 
@@ -77,43 +76,87 @@ async function getDefaultBranch(repoPath: string): Promise<string> {
 // ---- Shared clone setup ----
 
 /**
- * Create a shared clone for a repo agent.
+ * Ensure the base cache exists at `baseRepoPath` by cloning from GitHub on
+ * first use. The startup `cloneRepos()` pre-warms every plugin-declared repo,
+ * but PM-spawned dynamic agents and runtime plugin refreshes can reference
+ * repos whose base cache was never created — this is the lazy fallback.
+ *
+ * No-op when the cache already exists. Requires `githubRepo` to be set,
+ * since that's the only way we know what to clone from.
+ */
+async function ensureBaseCache(
+  baseRepoPath: string,
+  githubRepo: string | undefined,
+  baseBranch: string | undefined,
+): Promise<void> {
+  const gitDir = path.join(baseRepoPath, '.git');
+  try {
+    const stat = await fs.stat(gitDir);
+    if (stat.isDirectory()) return; // already present
+  } catch {
+    // Falls through to clone
+  }
+
+  if (!githubRepo) {
+    throw new Error(
+      `Base cache missing at ${baseRepoPath} and no githubRepo provided — cannot lazy-clone.`,
+    );
+  }
+
+  const url = githubRepoToUrl(githubRepo);
+  await fs.mkdir(path.dirname(baseRepoPath), { recursive: true });
+  const branchFlag = baseBranch ? ` -b "${baseBranch}"` : '';
+  logger.system(`Base cache missing for ${githubRepo} — cloning from ${url}`);
+  await execAsync(`git clone${branchFlag} "${url}" "${baseRepoPath}"`);
+  logger.system(`Created base cache at ${baseRepoPath}`);
+}
+
+/**
+ * Create a shared clone for a repo agent at the given path.
  *
  * Uses `git clone --shared` which creates an independent repository that
  * borrows the base repo's object store via an alternates file (read-only).
  * The clone gets its own .git/ directory, refs, index, and remote pointing
- * to GitHub.
+ * to GitHub. The caller is responsible for choosing where the clone lives —
+ * `setupSharedClone` mkdir-p's the parent and clones into `clonePath`.
+ *
+ * If the base cache at `baseRepoPath` doesn't exist yet (PM-spawned dynamic
+ * agent, plugin added at runtime), it's lazily cloned from `githubRepo` first.
  */
 export async function setupSharedClone(
-  repoKey: string,
-  reposPath: string,
+  clonePath: string,
   baseRepoPath: string,
   checkout: CloneCheckout,
   baseBranch?: string,
   githubRepo?: string,
 ): Promise<CloneResult> {
+  // Lazy-clone the base cache if missing. Must happen before any operation
+  // that reads from `baseRepoPath` (fetchOrigin, getDefaultBranch, git clone
+  // --shared) — all of those require an existing git repo.
+  await ensureBaseCache(baseRepoPath, githubRepo, baseBranch);
+
   const defaultBranch = baseBranch || await getDefaultBranch(baseRepoPath);
   const githubUrl = githubRepo ? githubRepoToUrl(githubRepo) : undefined;
+  const label = githubRepo || clonePath;
 
   await fetchOrigin(baseRepoPath);
-  await fs.mkdir(reposPath, { recursive: true });
-  const clonePath = path.join(reposPath, repoKey);
+  await fs.mkdir(path.dirname(clonePath), { recursive: true });
 
   // Determine which branch to clone and what to do after
   let cloneBranch: string;
   let resultBranch: string;
 
   if (checkout.type === 'new_branch') {
-    logger.system(`Creating shared clone for ${repoKey} (new branch: ${checkout.name})`);
+    logger.system(`Creating shared clone for ${label} (new branch: ${checkout.name})`);
     cloneBranch = defaultBranch;
     resultBranch = checkout.name;
   } else if (checkout.type === 'branch') {
-    logger.system(`Creating shared clone for ${repoKey} (branch: ${checkout.name})`);
+    logger.system(`Creating shared clone for ${label} (branch: ${checkout.name})`);
     await fetchOrigin(baseRepoPath, checkout.name);
     cloneBranch = checkout.name;
     resultBranch = checkout.name;
   } else {
-    logger.system(`Creating shared clone for ${repoKey} (base: ${defaultBranch})`);
+    logger.system(`Creating shared clone for ${label} (base: ${defaultBranch})`);
     cloneBranch = defaultBranch;
     resultBranch = defaultBranch;
   }
@@ -159,20 +202,6 @@ export async function cloneExists(clonePath: string): Promise<boolean> {
   }
 }
 
-/**
- * Check if a path is a git worktree (legacy, for migration).
- * Worktrees have a .git file containing "gitdir: ..." pointer.
- */
-export async function isWorktree(repoPath: string): Promise<boolean> {
-  try {
-    const gitPath = path.join(repoPath, '.git');
-    const stat = await fs.stat(gitPath);
-    return stat.isFile();
-  } catch {
-    return false;
-  }
-}
-
 // ---- Cleanup ----
 
 /**
@@ -181,112 +210,4 @@ export async function isWorktree(repoPath: string): Promise<boolean> {
 export async function removeClone(clonePath: string): Promise<void> {
   await fs.rm(clonePath, { recursive: true, force: true });
   logger.system(`Removed clone at ${clonePath}`);
-}
-
-// ---- Migration (worktree → shared clone) ----
-
-/**
- * Migrate an existing worktree to a shared clone.
- *
- * For RO tasks: just delete and re-clone on base branch.
- * For RW tasks: capture uncommitted work, push branch if needed,
- * delete worktree, create shared clone, re-apply patch.
- *
- * Runs in spawn code (not sandboxed), has full git access via GIT_ASKPASS.
- */
-export async function migrateWorktreeToClone(
-  repoKey: string,
-  reposPath: string,
-  baseRepoPath: string,
-  baseBranch: string,
-  githubRepo: string,
-  repoInfo: RepositoryInfo,
-  editAllowed: boolean,
-): Promise<CloneResult> {
-  const clonePath = path.join(reposPath, repoKey);
-  const branch = repoInfo.current_branch || repoInfo.feature_branch || baseBranch;
-  const isRW = editAllowed && branch !== baseBranch;
-
-  logger.system(`Migrating worktree to shared clone for ${repoKey} (${isRW ? 'RW' : 'RO'}, branch: ${branch})`);
-
-  try {
-    if (!isRW) {
-      // On base branch or RO — delete worktree and create fresh clone on base
-      logger.system(`[migrate] Deleting worktree and creating fresh clone on ${baseBranch}`);
-      await removeWorktreeSafely(baseRepoPath, clonePath);
-      logger.system(`[migrate] Worktree removed, creating shared clone`);
-      const result = await setupSharedClone(repoKey, reposPath, baseRepoPath, { type: 'base' }, baseBranch, githubRepo);
-      logger.system(`[migrate] Migration complete → ${result.clone_path} (${result.branch})`);
-      return result;
-    }
-
-    // RW path — preserve branch and uncommitted work
-    logger.system(`[migrate] RW mode — preserving branch ${branch} and uncommitted work`);
-
-    let patch = '';
-    try {
-      // Stage everything (including untracked files) so diff captures all work
-      await gitExec(clonePath, 'add -A');
-      // Use execAsync directly — gitExec trims stdout, which corrupts the patch
-      const { stdout } = await execAsync('git diff --cached HEAD', { cwd: clonePath });
-      patch = stdout;
-      logger.system(`[migrate] Captured patch: ${patch.trim() ? `${patch.split('\n').length} lines` : 'empty (no uncommitted changes)'}`);
-    } catch (error) {
-      logger.warn('repo-clone', `[migrate] Failed to capture diff: ${error}`);
-    }
-
-    // Remove worktree (branch refs are in the base repo, shared clone will find them locally)
-    logger.system(`[migrate] Removing worktree at ${clonePath}`);
-    await removeWorktreeSafely(baseRepoPath, clonePath);
-    logger.system(`[migrate] Worktree removed`);
-
-    // Create shared clone on the branch
-    logger.system(`[migrate] Creating shared clone on branch ${branch}`);
-    const result = await setupSharedClone(repoKey, reposPath, baseRepoPath, { type: 'branch', name: branch }, baseBranch, githubRepo);
-    logger.system(`[migrate] Shared clone created at ${result.clone_path}`);
-
-    // Apply patch if non-empty
-    if (patch.trim()) {
-      const patchFile = path.join(reposPath, `${repoKey}-migration.patch`);
-      logger.system(`[migrate] Applying ${patch.split('\n').length}-line patch to preserve uncommitted work`);
-      try {
-        await fs.writeFile(patchFile, patch);
-        await gitExec(clonePath, `apply "${patchFile}"`);
-        logger.system(`[migrate] Patch applied successfully`);
-      } catch (error) {
-        logger.warn('repo-clone', `[migrate] Failed to apply patch: ${error}`);
-      } finally {
-        await fs.rm(patchFile, { force: true });
-      }
-    } else {
-      logger.system(`[migrate] No uncommitted changes to restore`);
-    }
-
-    logger.system(`[migrate] RW migration complete → ${result.clone_path} (${result.branch})`);
-    return result;
-  } catch (error) {
-    logger.error('repo-clone', `[migrate] Migration failed for ${repoKey}: ${error}`);
-    logger.system(`[migrate] Falling back to fresh clone on ${baseBranch}`);
-
-    // Ensure the path is clean
-    await fs.rm(clonePath, { recursive: true, force: true }).catch(() => {});
-    return await setupSharedClone(repoKey, reposPath, baseRepoPath, { type: 'base' }, baseBranch, githubRepo);
-  }
-}
-
-/**
- * Remove a worktree via git, then prune stale entries.
- */
-async function removeWorktreeSafely(baseRepoPath: string, worktreePath: string): Promise<void> {
-  try {
-    await gitExec(baseRepoPath, `worktree remove --force "${worktreePath}"`);
-  } catch {
-    // If worktree remove fails, force-delete and prune
-    await fs.rm(worktreePath, { recursive: true, force: true });
-  }
-  try {
-    await gitExec(baseRepoPath, 'worktree prune');
-  } catch {
-    // Best effort
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ import { mountOAuthRoutes } from './connectors/oauth/routes.js';
 import { getIsShuttingDown, setShuttingDown } from './system/shutdown.js';
 import { getActiveTaskIds } from './tasks/task.js';
 import { logger } from './system/logger.js';
-import { bootstrapWorkdir, cloneRepos, OAUTH_DIR } from './system/workdir.js';
+import { bootstrapWorkdir, cloneRepos, OAUTH_DIR, REPOS_DIR } from './system/workdir.js';
+import { join } from 'path';
 import { validateMasterKey } from './system/secrets-vault.js';
 import { initPlugins, getPlugins } from './system/plugin-loader.js';
 import { initRegistry, getAllAgentDefs } from './agents/registry.js';
@@ -98,14 +99,19 @@ async function main(): Promise<void> {
     initEventPersistence();
     await initMemory();
 
-    // Clone repos declared by plugins
+    // Clone repos declared by plugins (every entry across every repo agent,
+    // deduplicated by github identifier).
     const agentDefs = getAllAgentDefs();
     const repoDefs = agentDefs.filter(isRepoAgent);
-    await cloneRepos(repoDefs.map((d) => ({
-      key: d.repo!.repoKey,
-      githubRepo: d.repo!.githubRepo,
-      baseBranch: d.repo!.baseBranch,
-    })));
+    const byGithub = new Map<string, { github: string; baseBranch: string }>();
+    for (const def of repoDefs) {
+      for (const entry of def.repo!.repos) {
+        if (!byGithub.has(entry.github)) {
+          byGithub.set(entry.github, { github: entry.github, baseBranch: entry.baseBranch });
+        }
+      }
+    }
+    await cloneRepos([...byGithub.values()]);
 
     // Log loaded plugins and agents
     const plugins = getPlugins();
@@ -140,10 +146,16 @@ async function main(): Promise<void> {
     }
     for (const def of repoDefs) {
       logger.plain(`  [${def.pluginName}] ${def.id} (${def.visibility}) — ${def.role}`);
-      const gitName = await configureGitIdentity(def.repo!.defaultPath);
-      logger.plain(`    repo: ${def.repo!.defaultPath} (${def.repo!.githubRepo})`);
+      const primary = def.repo!.primary;
+      const primaryPath = join(REPOS_DIR, primary);
+      const gitName = await configureGitIdentity(primaryPath);
+      logger.plain(`    primary: ${primary} (${primaryPath})`);
       if (gitName) {
         logger.plain(`    git: ${gitName}`);
+      }
+      const otherRepos = def.repo!.repos.filter((r) => r.github !== primary);
+      if (otherRepos.length > 0) {
+        logger.plain(`    also mounts: ${otherRepos.map((r) => r.github).join(', ')}`);
       }
       if (def.mcpServers) {
         logger.plain(`    mcp: ${Object.keys(def.mcpServers).join(', ')}`);

--- a/src/system/plugin-loader.ts
+++ b/src/system/plugin-loader.ts
@@ -89,6 +89,12 @@ export interface PluginRepoConfig {
   prompt: string;
 }
 
+/** A single repo entry parsed from agent frontmatter `metadata.archie.repos[]`. */
+export interface PluginRepoEntry {
+  github: string;
+  baseBranch?: string;
+}
+
 export interface PluginAgentDef {
   /** Filename without .md, e.g., 'copywriter' */
   key: string;
@@ -112,10 +118,22 @@ export interface PluginAgentDef {
   visibility?: 'global' | 'local';
   /** Markdown body (domain-specific instructions) */
   prompt: string;
-  /** Repo metadata from frontmatter (if present, agent is a repo agent) */
+  /**
+   * Repo metadata from frontmatter (if present, agent is a repo agent).
+   *
+   * Accepted frontmatter shapes:
+   *  - New (preferred):
+   *      metadata.archie.repos: [{ github, baseBranch }, ...]
+   *      metadata.archie.primary: <github>   # optional, defaults to repos[0].github
+   *  - Legacy (auto-migrated):
+   *      metadata.archie.repo: { github, baseBranch }
+   *
+   * Both shapes in the same file → fail at load. The loader normalises to the
+   * plural shape so downstream consumers only ever see this.
+   */
   repo?: {
-    github: string;
-    baseBranch?: string;
+    repos: PluginRepoEntry[];
+    primary: string;
   };
   /** MCP server names this agent should have access to (from plugin's .mcp.json) */
   mcpServers?: string[];
@@ -237,12 +255,56 @@ function scanPlugins(): LoadedPlugin[] {
           prompt: substitutePluginVars(content.trim()),
         };
 
-        // If frontmatter has repo metadata, this is a repo agent
-        const repoMeta = data.metadata?.archie?.repo;
-        if (repoMeta && typeof repoMeta === 'object' && repoMeta.github) {
+        // If frontmatter has repo metadata, this is a repo agent. Accept both
+        // the new plural shape (`metadata.archie.repos: [...]` + optional
+        // `primary`) and the legacy singular shape (`metadata.archie.repo`).
+        // Reject if both appear in the same file.
+        const archie = data.metadata?.archie;
+        const repoMeta = archie?.repo;
+        const reposMeta = archie?.repos;
+        const primaryMeta = archie?.primary;
+
+        if (repoMeta && reposMeta) {
+          throw new Error(
+            `Plugin ${pluginName}, agent ${key}: frontmatter declares both ` +
+            `metadata.archie.repo and metadata.archie.repos — use one.`
+          );
+        }
+
+        if (Array.isArray(reposMeta) && reposMeta.length > 0) {
+          const repos: PluginRepoEntry[] = reposMeta.map((entry: any, idx: number) => {
+            if (!entry || typeof entry !== 'object' || typeof entry.github !== 'string') {
+              throw new Error(
+                `Plugin ${pluginName}, agent ${key}: metadata.archie.repos[${idx}] ` +
+                `must be an object with a string \`github\` field.`
+              );
+            }
+            return {
+              github: entry.github,
+              baseBranch: typeof entry.baseBranch === 'string' ? entry.baseBranch : undefined,
+            };
+          });
+          let primary: string;
+          if (typeof primaryMeta === 'string') {
+            if (!repos.some((r) => r.github === primaryMeta)) {
+              throw new Error(
+                `Plugin ${pluginName}, agent ${key}: metadata.archie.primary ` +
+                `"${primaryMeta}" does not match any entry in metadata.archie.repos.`
+              );
+            }
+            primary = primaryMeta;
+          } else {
+            primary = repos[0].github;
+          }
+          agentDef.repo = { repos, primary };
+        } else if (repoMeta && typeof repoMeta === 'object' && typeof repoMeta.github === 'string') {
+          // Legacy singular shape — synthesise the new plural form.
           agentDef.repo = {
-            github: repoMeta.github,
-            baseBranch: repoMeta.baseBranch || undefined,
+            repos: [{
+              github: repoMeta.github,
+              baseBranch: typeof repoMeta.baseBranch === 'string' ? repoMeta.baseBranch : undefined,
+            }],
+            primary: repoMeta.github,
           };
         }
 

--- a/src/system/workdir.ts
+++ b/src/system/workdir.ts
@@ -8,7 +8,7 @@
  * Bootstrap functions are async and must be called from main() at startup.
  */
 
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { existsSync, lstatSync } from 'fs';
 import { mkdir } from 'fs/promises';
 import { exec } from 'child_process';
@@ -107,16 +107,27 @@ export async function bootstrapWorkdir(): Promise<void> {
 /**
  * Clone repos declared by plugins. Called after plugins are loaded.
  *
- * @param repos - Array of { key, githubRepo } from loaded plugin configs
+ * Each base clone lives at `$ARCHIE_WORKDIR/repos/<org>/<repo>` (the github
+ * identifier becomes a nested directory). Task-local agent clones use this as
+ * their alternates source via `git clone --shared`.
+ *
+ * @param repos - Array of { github, baseBranch } — deduplicated by caller
  */
 export async function cloneRepos(
-  repos: Array<{ key: string; githubRepo: string; baseBranch?: string }>
+  repos: Array<{ github: string; baseBranch?: string }>
 ): Promise<void> {
-  for (const { key, githubRepo, baseBranch } of repos) {
-    const repoPath = join(REPOS_DIR, key);
-    const repoUrl = githubRepoToUrl(githubRepo);
-    await cloneOrFetch(repoUrl, repoPath, key, baseBranch);
+  for (const { github, baseBranch } of repos) {
+    const repoPath = getBaseCachePath(github);
+    const repoUrl = githubRepoToUrl(github);
+    await cloneOrFetch(repoUrl, repoPath, github, baseBranch);
   }
+}
+
+/**
+ * Base-cache path for a github repo on disk. Computed, not stored.
+ */
+export function getBaseCachePath(github: string): string {
+  return join(REPOS_DIR, github);
 }
 
 // =============================================================================
@@ -284,6 +295,8 @@ async function cloneOrFetch(url: string, targetDir: string, label: string, baseB
       logger.warn('workdir', `Failed to pull ${label}, using existing state: ${error}`);
     }
   } else {
+    // Nested `org/repo` target dirs require the parent to exist before clone.
+    await mkdir(dirname(targetDir), { recursive: true });
     const branchFlag = baseBranch ? ` -b "${baseBranch}"` : '';
     logger.system(`Cloning ${label} from ${url}...`);
     await execAsync(`git clone${branchFlag} "${url}" "${targetDir}"`);

--- a/src/tasks/__tests__/repositories-migration.test.ts
+++ b/src/tasks/__tests__/repositories-migration.test.ts
@@ -1,0 +1,268 @@
+/**
+ * v30 migration: legacy `metadata.repositories` (Record<repoKey, RepositoryInfo>)
+ * → new shape (Record<agentId, AttachedRepo[]>).
+ *
+ * This runs against real production task metadata on Task.get, so the round-trip
+ * must preserve everything that drives in-flight work: clone paths (so RW tasks
+ * reuse their existing working tree), branch state, PR numbers, and the
+ * comment-dedup cursor. These tests feed representative legacy shapes through
+ * the migration and assert nothing is lost.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { AgentDef } from '../../types/agent.js';
+import type { TaskMetadata } from '../../types/task.js';
+import { __setRegistryForTesting } from '../../agents/registry.js';
+import { migrateRepositoriesShape } from '../task.js';
+
+function repoDef(key: string, github: string): AgentDef {
+  return {
+    id: `${key}-agent`,
+    key,
+    role: `${key} role`,
+    expertise: `${key} expertise`,
+    pluginName: 'engineering',
+    visibility: 'global',
+    repo: { repos: [{ github, baseBranch: 'main' }], primary: github },
+  } as AgentDef;
+}
+
+/** Minimal metadata wrapper — only `repositories` matters for these tests. */
+function meta(repositories: any): TaskMetadata {
+  return {
+    task_id: 'task-test',
+    task_owner: null,
+    participants: [],
+    channels: {},
+    default_channel: null,
+    agent_sessions: {},
+    repositories,
+    status: 'in_progress',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  } as TaskMetadata;
+}
+
+beforeEach(() => {
+  __setRegistryForTesting([
+    repoDef('backend', 'sweatco/backend'),
+    repoDef('mobile', 'sweatco/mobile'),
+  ]);
+});
+
+describe('migrateRepositoriesShape', () => {
+  it('migrates a legacy entry with branch_states, preserving clone path + PR state', () => {
+    // Shape a real in-flight RW task would have on disk pre-v30.
+    const m = meta({
+      backend: {
+        path: '/workdir/repos/backend',
+        clone_path: '/sessions/task-test/repos/backend',
+        current_branch: 'feature/task-test',
+        branch_states: {
+          'feature/task-test': {
+            base_branch: 'main',
+            pr_number: 42,
+            last_processed_comment_id: 1001,
+          },
+        },
+      },
+    });
+
+    migrateRepositoriesShape(m);
+
+    // Re-keyed by agentId, value is an array.
+    expect(Object.keys(m.repositories)).toEqual(['backend-agent']);
+    const entries = m.repositories['backend-agent'];
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries).toHaveLength(1);
+
+    const att = entries[0];
+    expect(att.github).toBe('sweatco/backend');
+    // clone_path preserved → RW task reuses its existing working tree, no re-clone.
+    expect(att.clone_path).toBe('/sessions/task-test/repos/backend');
+    // base_path preserved → sandbox grants read access to the OLD base cache
+    // (pre-v30 short-key layout), which is what this clone's alternates points
+    // at. Without this, every git read through alternates would hit EACCES.
+    expect(att.base_path).toBe('/workdir/repos/backend');
+    expect(att.current_branch).toBe('feature/task-test');
+    // Branch/PR/comment-dedup state survives intact.
+    expect(att.branch_states!['feature/task-test']).toEqual({
+      base_branch: 'main',
+      pr_number: 42,
+      last_processed_comment_id: 1001,
+    });
+  });
+
+  it('lifts legacy top-level fields (feature_branch/pr_number) into branch_states', () => {
+    // Older shape: no branch_states map, just the flat legacy fields.
+    const m = meta({
+      backend: {
+        path: '/workdir/repos/backend',
+        clone_path: '/sessions/task-test/repos/backend',
+        feature_branch: 'feature/old',
+        base_branch: 'develop',
+        pr_number: 7,
+        last_processed_comment_id: 500,
+      },
+    });
+
+    migrateRepositoriesShape(m);
+
+    const att = m.repositories['backend-agent'][0];
+    expect(att.github).toBe('sweatco/backend');
+    expect(att.current_branch).toBe('feature/old');
+    expect(att.branch_states!['feature/old']).toEqual({
+      base_branch: 'develop',
+      pr_number: 7,
+      last_processed_comment_id: 500,
+    });
+  });
+
+  it('lifts top-level PR state when a legacy task sits on current_branch with no feature_branch', () => {
+    // Post-v17 shape: the task tracks current_branch (not feature_branch) and
+    // carries top-level pr_number/last_processed_comment_id but has no
+    // branch_states map yet. The lift must key off current_branch or the PR
+    // linkage is lost on migration.
+    const m = meta({
+      backend: {
+        path: '/workdir/repos/backend',
+        clone_path: '/sessions/task-test/repos/backend',
+        current_branch: 'feature/task-test',
+        base_branch: 'main',
+        pr_number: 314,
+        last_processed_comment_id: 900,
+      },
+    });
+
+    migrateRepositoriesShape(m);
+
+    const att = m.repositories['backend-agent'][0];
+    expect(att.current_branch).toBe('feature/task-test');
+    expect(att.branch_states!['feature/task-test']).toEqual({
+      base_branch: 'main',
+      pr_number: 314,
+      last_processed_comment_id: 900,
+    });
+  });
+
+  it('does not duplicate a repo when a legacy key and its v30 agentId key coexist', () => {
+    // Mid-rollout: a v30 spawn already wrote the new agentId-keyed array entry,
+    // but the legacy repoKey entry is still on disk. The migration must not
+    // append a second AttachedRepo for the same github.
+    const m = meta({
+      'backend-agent': [
+        {
+          github: 'sweatco/backend',
+          clone_path: '/sessions/task-test/repos/backend-agent/sweatco/backend',
+          current_branch: 'feature/new',
+          branch_states: { 'feature/new': { base_branch: 'main', pr_number: 42 } },
+        },
+      ],
+      backend: {
+        clone_path: '/sessions/task-test/repos/backend',
+        current_branch: 'feature/old',
+        branch_states: { 'feature/old': { base_branch: 'main', pr_number: 41 } },
+      },
+    });
+
+    migrateRepositoriesShape(m);
+
+    const entries = m.repositories['backend-agent'];
+    expect(entries).toHaveLength(1);
+    // The already-migrated array entry wins; the stale legacy duplicate is dropped.
+    expect(entries[0].current_branch).toBe('feature/new');
+    expect(entries[0].branch_states!['feature/new'].pr_number).toBe(42);
+  });
+
+  it('leaves clone_path undefined (not "") when a legacy entry had no clone', () => {
+    const m = meta({
+      backend: { current_branch: 'main', branch_states: {} },
+    });
+
+    migrateRepositoriesShape(m);
+
+    expect(m.repositories['backend-agent'][0].clone_path).toBeUndefined();
+  });
+
+  it('migrates multiple repos and keys each by its own agent', () => {
+    const m = meta({
+      backend: { clone_path: '/c/backend', current_branch: 'main', branch_states: {} },
+      mobile: { clone_path: '/c/mobile', current_branch: 'main', branch_states: {} },
+    });
+
+    migrateRepositoriesShape(m);
+
+    expect(Object.keys(m.repositories).sort()).toEqual(['backend-agent', 'mobile-agent']);
+    expect(m.repositories['backend-agent'][0].github).toBe('sweatco/backend');
+    expect(m.repositories['mobile-agent'][0].github).toBe('sweatco/mobile');
+  });
+
+  it('drops entries whose agent is no longer registered (plugin removed)', () => {
+    const m = meta({
+      backend: { clone_path: '/c/backend', current_branch: 'main', branch_states: {} },
+      legacyghost: { clone_path: '/c/ghost', current_branch: 'main', branch_states: {} },
+    });
+
+    migrateRepositoriesShape(m);
+
+    // backend survives; the orphan is dropped rather than crashing the load.
+    expect(Object.keys(m.repositories)).toEqual(['backend-agent']);
+  });
+
+  it('is a no-op on already-migrated (array) shape — idempotent', () => {
+    const alreadyNew = {
+      'backend-agent': [
+        {
+          github: 'sweatco/backend',
+          clone_path: '/sessions/task-test/repos/backend-agent/sweatco/backend',
+          current_branch: 'feature/task-test',
+          branch_states: { 'feature/task-test': { base_branch: 'main', pr_number: 42 } },
+        },
+      ],
+    };
+    const m = meta(alreadyNew);
+
+    migrateRepositoriesShape(m);
+
+    // Untouched — same reference contents, no double-migration.
+    expect(m.repositories).toEqual(alreadyNew);
+  });
+
+  it('running twice produces the same result (migration then no-op)', () => {
+    const m = meta({
+      backend: {
+        clone_path: '/c/backend',
+        current_branch: 'feature/x',
+        branch_states: { 'feature/x': { base_branch: 'main', pr_number: 9 } },
+      },
+    });
+
+    migrateRepositoriesShape(m);
+    const afterFirst = JSON.parse(JSON.stringify(m.repositories));
+    migrateRepositoriesShape(m);
+    expect(m.repositories).toEqual(afterFirst);
+  });
+
+  it('handles a mixed map (one already-migrated, one legacy)', () => {
+    const m = meta({
+      // already new
+      'mobile-agent': [
+        { github: 'sweatco/mobile', clone_path: '/c/mobile', current_branch: 'main', branch_states: {} },
+      ],
+      // still legacy
+      backend: { clone_path: '/c/backend', current_branch: 'main', branch_states: {} },
+    });
+
+    migrateRepositoriesShape(m);
+
+    expect(Object.keys(m.repositories).sort()).toEqual(['backend-agent', 'mobile-agent']);
+    expect(m.repositories['mobile-agent'][0].github).toBe('sweatco/mobile');
+    expect(m.repositories['backend-agent'][0].github).toBe('sweatco/backend');
+  });
+
+  it('no-ops on an empty repositories map', () => {
+    const m = meta({});
+    migrateRepositoriesShape(m);
+    expect(m.repositories).toEqual({});
+  });
+});

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -58,7 +58,39 @@ export function getSharedPath(taskId: string): string {
 }
 
 /**
- * Get the path to a task's repos directory (for worktrees in MVP-v2)
+ * Get the path to a task's agents directory.
+ * Each agent's per-task workspace (cwd, RW scratch space) lives under
+ * `agents/<agentId>/`. Agent workspaces never contain repo clones — clones
+ * live under the task's `repos/` tree (see `getAgentClonesDir`).
+ */
+export function getAgentsPath(taskId: string): string {
+  return join(getTaskPath(taskId), 'agents');
+}
+
+/**
+ * Get the directory where a given agent's repo clones live for this task.
+ *
+ * Layout: `sessions/<taskId>/repos/<agentId>/`. Each clone is then nested at
+ * `<github>` (e.g., `org/repo/`). This is a sibling of `agents/<agentId>/`
+ * (the agent's cwd) — clones are deliberately kept out of the workspace tree
+ * so the workspace stays a clean RW scratch space and clone permissions are
+ * controlled solely via the sandbox's allow/deny mounts.
+ */
+export function getAgentClonesDir(taskId: string, agentId: string): string {
+  return join(getTaskPath(taskId), 'repos', agentId);
+}
+
+/**
+ * Get the clone path for a specific repo attached to a specific agent.
+ * Returns `sessions/<taskId>/repos/<agentId>/<github>/`.
+ */
+export function getAgentClonePath(taskId: string, agentId: string, github: string): string {
+  return join(getAgentClonesDir(taskId, agentId), github);
+}
+
+/**
+ * Get the legacy per-task repos directory (pre-v30).
+ * Used only by the migration path; new code should use `getAgentClonesDir`.
  */
 export function getReposPath(taskId: string): string {
   return join(getTaskPath(taskId), 'repos');
@@ -554,24 +586,17 @@ export async function findTaskByThread(threadId: string): Promise<string | null>
 }
 
 /**
- * Find a task by PR number and repo
- * Uses grep to find candidates, then verifies repo matches
+ * Find a task by PR number and repo.
+ *
+ * Uses grep to find candidates, then verifies that some agent on the task has
+ * an AttachedRepo for the matching github with a branch state pointing at the
+ * given PR number.
  */
 export async function findTaskByPRNumber(
   githubRepo: string,
   prNumber: number
 ): Promise<string | null> {
   await ensureSessionsDir();
-
-  // Import registry to map githubRepo -> repoKey
-  const { getAgentDefByGithubRepo } = await import('../agents/registry.js');
-  const repoDef = getAgentDefByGithubRepo(githubRepo);
-  const repoKey = repoDef?.repo?.repoKey;
-
-  if (!repoKey) {
-    // Unknown repo - can't match
-    return null;
-  }
 
   try {
     // Use grep to find metadata files containing the PR number
@@ -592,16 +617,25 @@ export async function findTaskByPRNumber(
       const metadata = await loadMetadata(taskId);
       if (!metadata) continue;
 
-      // Verify this task has the PR in the correct repo
-      const repoInfo = metadata.repositories[repoKey];
-      // Check branch_states first, then legacy top-level field
-      if (repoInfo?.branch_states) {
-        for (const state of Object.values(repoInfo.branch_states)) {
-          if (state.pr_number === prNumber) return taskId;
+      // Normalize legacy (pre-v30) `repositories` shape in memory before
+      // walking. This routes webhook events for in-flight PRs on tasks that
+      // haven't been re-saved since deploy (their on-disk metadata is still the
+      // old Record<repoKey, RepositoryInfo>). Mutates the loaded copy only — we
+      // never persist from here. Dynamic import avoids a static persistence↔task
+      // cycle; the call is runtime-only so the cycle is harmless either way.
+      const { migrateRepositoriesShape } = await import('./task.js');
+      migrateRepositoriesShape(metadata);
+
+      // Walk every agent's attached repos and look for the github + pr_number.
+      for (const attachments of Object.values(metadata.repositories || {})) {
+        if (!Array.isArray(attachments)) continue;
+        for (const attached of attachments) {
+          if (attached.github !== githubRepo) continue;
+          if (!attached.branch_states) continue;
+          for (const state of Object.values(attached.branch_states)) {
+            if (state.pr_number === prNumber) return taskId;
+          }
         }
-      }
-      if (repoInfo?.pr_number === prNumber) {
-        return taskId;
       }
     }
   } catch {

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -53,7 +53,8 @@ import {
 } from './persistence.js';
 import { getIsShuttingDown } from '../system/shutdown.js';
 import { scheduleIdleCheck } from './recovery.js';
-import { scanAgentDefs, getVisiblePeerIdsForSender } from '../agents/registry.js';
+import { scanAgentDefs, getAgentDef, getVisiblePeerIdsForSender } from '../agents/registry.js';
+import type { AttachedRepo } from '../types/task.js';
 import { syncPlugins } from '../system/plugin-sync.js';
 import { postSlackMessage, postSlackFiles, postInteractiveToThreads, addReaction, removeReaction, getMessageReactions, buildThreadUrl, openDMChannel, getChannelInfo, getUserInfo, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
 import { basename } from 'path';
@@ -134,15 +135,8 @@ export class Task {
     // Scan fresh agent defs for this task
     const team = scanAgentDefs();
 
-    // Build repositories map from repo agent defs
-    const repositories: Record<string, { path: string }> = {};
-    for (const def of team) {
-      if (def.repo) {
-        repositories[def.repo.repoKey] = { path: def.repo.defaultPath };
-      }
-    }
-
-    // Create initial metadata
+    // metadata.repositories is populated lazily per-agent during spawn.
+    // It maps agentId → list of currently-attached repos.
     const metadata: TaskMetadata = {
       task_id: taskId,
       task_owner: null,
@@ -150,7 +144,7 @@ export class Task {
       channels: {},
       default_channel: null,
       agent_sessions: {},
-      repositories,
+      repositories: {},
       status: 'in_progress',
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
@@ -186,6 +180,12 @@ export class Task {
     if (!metadata) {
       throw new Error(`Task ${taskId} not found`);
     }
+
+    // v30 migration: `metadata.repositories` used to be Record<repoKey, RepositoryInfo>
+    // (one object per repo agent, keyed by short name). Now it's
+    // Record<agentId, AttachedRepo[]> (per-agent list of attached repos).
+    // Detect by structural check: any value that's NOT an array is old shape.
+    migrateRepositoriesShape(metadata);
 
     const team = scanAgentDefs();
     return new Task(taskId, metadata, team);
@@ -679,17 +679,20 @@ export class Task {
 
   /**
    * Remove shared clones and clear clone_path so next spawn creates a fresh one.
+   * Iterates every attached repo across every agent in the task.
    */
   private async cleanupClones(): Promise<void> {
     const { removeClone } = await import('../connectors/github/repo-clone.js');
-    for (const [repoKey, repoInfo] of Object.entries(this.metadata.repositories)) {
-      if (repoInfo.clone_path) {
+    for (const [agentId, attachments] of Object.entries(this.metadata.repositories)) {
+      if (!Array.isArray(attachments)) continue;
+      for (const attached of attachments) {
+        if (!attached.clone_path) continue;
         try {
-          await removeClone(repoInfo.clone_path);
-          repoInfo.clone_path = undefined;
-          logger.system(`Task ${this.taskId}: cleaned up clone for ${repoKey}`);
+          await removeClone(attached.clone_path);
+          attached.clone_path = undefined as unknown as string;
+          logger.system(`Task ${this.taskId}: cleaned up clone for ${agentId}/${attached.github}`);
         } catch (error) {
-          logger.warn('task', `Failed to cleanup clone for ${repoKey}: ${error}`);
+          logger.warn('task', `Failed to cleanup clone for ${agentId}/${attached.github}: ${error}`);
         }
       }
     }
@@ -1039,4 +1042,105 @@ export function getActiveTaskIds(): string[] {
 
 export function getTask(taskId: string): Task | undefined {
   return activeTasks.get(taskId);
+}
+
+// ---- v30 migration ----
+
+/**
+ * Migrate `metadata.repositories` from the legacy `Record<repoKey, RepositoryInfo>`
+ * shape to the new `Record<agentId, AttachedRepo[]>` shape.
+ *
+ * Detection: legacy values are objects with a `clone_path` / `current_branch`
+ * field; the new shape is always an array. We discriminate per-value and rewrite
+ * in-place. Persistence happens on the next `debouncedSave()`.
+ *
+ * For each legacy entry, we map `repoKey -> agentId` as `${repoKey}-agent` and
+ * use the registered agent's primary github to construct the new `AttachedRepo`.
+ * If the agent is no longer registered (plugin removed), the entry is dropped
+ * with a warning.
+ *
+ * Exported for testing — exercised in the normal flow only via `Task.get`.
+ */
+export function migrateRepositoriesShape(metadata: TaskMetadata): void {
+  const repos = metadata.repositories;
+  if (!repos || typeof repos !== 'object') return;
+
+  // Fast path: nothing to migrate if every entry is already an array.
+  let needsMigration = false;
+  for (const value of Object.values(repos)) {
+    if (!Array.isArray(value)) {
+      needsMigration = true;
+      break;
+    }
+  }
+  if (!needsMigration) return;
+
+  const migrated: Record<string, AttachedRepo[]> = {};
+  for (const [key, value] of Object.entries(repos)) {
+    if (Array.isArray(value)) {
+      migrated[key] = value;
+      continue;
+    }
+    // Legacy entry: object keyed by short repoKey (e.g. 'backend')
+    const agentId = `${key}-agent`;
+    const def = getAgentDef(agentId);
+    const primary = def?.repo?.primary;
+    if (!primary) {
+      logger.warn('task', `[migrate] Dropping legacy metadata.repositories[${key}] — no agent ${agentId} found in registry`);
+      continue;
+    }
+    const legacy = value as {
+      path?: string;
+      clone_path?: string;
+      current_branch?: string;
+      branch_states?: Record<string, any>;
+      feature_branch?: string;
+      base_branch?: string;
+      pr_number?: number;
+      last_processed_comment_id?: number;
+    };
+    const currentBranch = legacy.current_branch ?? legacy.feature_branch;
+    const attached: AttachedRepo = {
+      github: primary,
+      // Absent clone_path means "no clone yet" — keep it undefined (uniform with
+      // the live shape) rather than an empty-string sentinel. Spawn re-clones.
+      clone_path: legacy.clone_path || undefined,
+      // Preserve the legacy base-cache path the clone borrows from. The pre-v30
+      // base cache lived at $ARCHIE_WORKDIR/repos/<short-key>/, which differs
+      // from the new github-nested layout — without this, an in-flight clone
+      // whose alternates point at the old base path would lose read access
+      // through the sandbox when the spawner re-derives baseObjectsPath from
+      // the new layout convention. Spawn falls back to getBaseCachePath(github)
+      // only when base_path is absent (e.g. a fresh clone or a legacy entry
+      // with no `path` field).
+      base_path: legacy.path || undefined,
+      current_branch: currentBranch,
+      branch_states: legacy.branch_states,
+    };
+    // Lift legacy top-level PR/branch state into the branch_states map when the
+    // branch the task is on has no entry yet. Key off current_branch (the
+    // post-v17 norm) and fall back to feature_branch (older shape) — earlier
+    // code only handled feature_branch, losing PR state for tasks sitting on
+    // current_branch with no branch_states map.
+    if (currentBranch && !attached.branch_states?.[currentBranch]) {
+      attached.branch_states ??= {};
+      attached.branch_states[currentBranch] = {
+        base_branch: legacy.base_branch,
+        pr_number: legacy.pr_number,
+        last_processed_comment_id: legacy.last_processed_comment_id,
+      };
+    }
+    // Guard against a legacy repoKey and its v30 agentId key coexisting
+    // mid-rollout: don't append a second AttachedRepo for a github the
+    // already-migrated array entry covers.
+    const list = (migrated[agentId] ??= []);
+    if (!list.some((a) => a.github === attached.github)) {
+      list.push(attached);
+      logger.system(`[migrate] task ${metadata.task_id}: ${key} -> ${agentId}/${primary}`);
+    } else {
+      logger.warn('task', `[migrate] task ${metadata.task_id}: skipping legacy ${key} — ${agentId} already has ${attached.github}`);
+    }
+  }
+
+  metadata.repositories = migrated;
 }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -57,17 +57,29 @@ export interface AgentHandle {
 }
 
 /**
- * Repo-specific fields (present only when the agent has repo access attached)
+ * A single repo entry declared by a repo agent in its frontmatter.
+ * The `github` identifier (e.g. 'sweatco/backend') doubles as the entry's key —
+ * no separate repoKey field, no short-name derivation.
+ */
+export interface RepoEntry {
+  /** GitHub repository identifier, e.g., 'sweatco/backend'. Also the key. */
+  github: string;
+  /** Base branch for PRs and merges. Defaults applied at consume sites. */
+  baseBranch: string;
+}
+
+/**
+ * Repo-specific fields (present only when the agent has repo access attached).
+ *
+ * Multi-repo: each repo agent declares one or more repos in its frontmatter.
+ * ALL of them are mounted at spawn; `primary` is the default target for
+ * repo-tools when the `github` arg is omitted.
  */
 export interface AgentRepoDef {
-  /** GitHub repository identifier, e.g., 'sweatco/backend' */
-  githubRepo: string;
-  /** Base branch for PRs and merges. Defaults to 'main' if not specified. */
-  baseBranch?: string;
-  /** Default repository path on disk */
-  defaultPath: string;
-  /** Key in TaskMetadata.repositories, e.g., 'backend', 'mobile' */
-  repoKey: string;
+  /** All repos this agent works with — every entry is mounted at spawn. At least one. */
+  repos: RepoEntry[];
+  /** Github identifier of the primary repo. Must match one entry's `github`. */
+  primary: string;
 }
 
 /**

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -136,18 +136,59 @@ export interface BranchState {
   stash_name?: string;                 // set if dirty work was auto-stashed when leaving
 }
 
+/**
+ * One repo attached to a specific agent in a specific task.
+ *
+ * Each agent has its own clone — two agents attaching the same `github` get two
+ * independent `AttachedRepo` records under different agent IDs in
+ * `TaskMetadata.repositories`. The base-cache path is derivable as
+ * `join(REPOS_DIR, github)` and is not stored here.
+ */
+export interface AttachedRepo {
+  /** Github identifier, e.g. 'sweatco/backend'. */
+  github: string;
+  /**
+   * Task-local shared clone path, e.g.
+   * `sessions/<id>/repos/<agentId>/sweatco/backend`. Set when the clone is
+   * created during agent spawn; undefined briefly between attachment record
+   * creation and clone setup. Lives outside the agent's cwd
+   * (`sessions/<id>/agents/<agentId>/`) so workspace and repo state are
+   * cleanly separated.
+   */
+  clone_path?: string;
+  /**
+   * Absolute path to the base cache this clone borrows from — i.e. the
+   * directory the clone's `.git/objects/info/alternates` file points at the
+   * parent of. Pinned at clone time and used by the sandbox to grant read
+   * access to the borrowed object store, so the clone keeps working even if
+   * the layout convention changes underneath it (pre-v30 caches lived at
+   * `$ARCHIE_WORKDIR/repos/<short-key>/`; new caches at
+   * `$ARCHIE_WORKDIR/repos/<org>/<repo>/`). Migration preserves the legacy
+   * `path` here; fresh clones populate it from `getBaseCachePath(github)`.
+   */
+  base_path?: string;
+  /** Branch the agent is on right now (key into `branch_states`). */
+  current_branch?: string;
+  /** Per-branch state — PR number, base branch, stash, last-processed-comment id. */
+  branch_states?: Record<string, BranchState>;
+}
+
+/**
+ * Legacy per-repo state shape (pre-v30).
+ * Retained only to type the lazy migration path in Task.get; new code uses
+ * `AttachedRepo` and `metadata.repositories: Record<agentId, AttachedRepo[]>`.
+ */
 export interface RepositoryInfo {
   path: string;
-  branch?: string;                     // legacy, unused
-  base_branch?: string;                // legacy — now per-branch in BranchState
-  base_sha?: string;                   // legacy, unused
-  clone_path?: string;                 // Path to shared clone (task-local independent repo)
-  feature_branch?: string;             // legacy — now current_branch
-  pr_number?: number;                  // legacy — now per-branch in BranchState
-  last_processed_comment_id?: number;  // legacy — now per-branch in BranchState
-
-  current_branch?: string;                          // branch agent is on right now (key into branch_states)
-  branch_states?: Record<string, BranchState>;      // keyed by branch name
+  branch?: string;
+  base_branch?: string;
+  base_sha?: string;
+  clone_path?: string;
+  feature_branch?: string;
+  pr_number?: number;
+  last_processed_comment_id?: number;
+  current_branch?: string;
+  branch_states?: Record<string, BranchState>;
 }
 
 /**
@@ -169,7 +210,15 @@ export interface TaskMetadata {
   title?: string;                      // AI-generated one-line summary; absent on pre-feature tasks
   slack_threads?: SlackThreadRef[];    // Legacy — only present on old tasks loaded from disk, removed after migration
   agent_sessions: Record<string, AgentSessionState | string>; // union handles legacy string values on disk
-  repositories: Record<string, RepositoryInfo>;
+  /**
+   * Per-agent attached repos. Keyed by agent ID. Each value is the list of
+   * repos that agent currently has mounted (always includes the agent's
+   * primary at minimum, once it has spawned).
+   *
+   * Legacy on-disk shape (pre-v30): `Record<repoKey, RepositoryInfo>` keyed by
+   * short repo name. Migrated lazily in `Task.get`.
+   */
+  repositories: Record<string, AttachedRepo[]>;
   status: TaskStatus;
   edit_allowed?: boolean;     // Has user approved edit mode for this task?
   research_budget_extra?: number;    // Additional research budget granted via Slack approval (+5 per approval)


### PR DESCRIPTION
## Summary

Lets a repo agent **declare one or more repositories** in its plugin frontmatter; **all of them are mounted at spawn**. This replaces the 1:1 agent↔repo binding so a single agent can investigate/modify across related repos (e.g. `backend` + `shared-libs`) without inter-agent coordination overhead.

Deliberately **eager-only**: no on-demand attach, no respawn machinery — the dumb-simple model that delivers the capability with the least moving parts. On-demand attach and PM dynamic spawning were prototyped and then cut from this PR; see *Deferred* below.

## Frontmatter (plugins repo)

```yaml
metadata:
  archie:
    repos:
      - github: org/backend
        baseBranch: main
      - github: org/shared-libs
        baseBranch: main
    primary: org/backend   # optional; defaults to repos[0].github
```

The legacy singular `metadata.archie.repo: { github, baseBranch }` is auto-migrated by the plugin loader. Both shapes in one file → load error.

## Key changes

**Types & metadata**
- `AgentDef.repo` → `{ repos: RepoEntry[], primary }` (was `{ githubRepo, repoKey, defaultPath, baseBranch }`).
- `TaskMetadata.repositories` → `Record<agentId, AttachedRepo[]>` (was `Record<repoKey, RepositoryInfo>`). Each `AttachedRepo` owns its `clone_path` / `current_branch` / `branch_states`, so two agents declaring the same github get independent clones + PR/branch state.

**Migration (production-critical — live tasks on disk)**
- `migrateRepositoriesShape` normalizes the legacy shape in memory on `Task.get`: preserves `clone_path`, `current_branch`, `branch_states`, `pr_number`, `last_processed_comment_id`; lifts top-level PR state into `branch_states` keyed off `current_branch`; idempotent; drops orphan entries for removed agents without throwing.
- `findTaskByPRNumber` runs the same migration before walking, so an in-flight PR's webhook (comment / CI check) still routes on the deploy *before* the task re-saves.
- 11-case round-trip test suite (`repositories-migration.test.ts`).

**Eager mount at spawn**
- The repo-agent spawn branch iterates the **declared** `repos` list, ensures an `AttachedRepo` per repo (preserving existing clone/branch state), and clones each. Adding a repo to frontmatter → it mounts on the next spawn (old tasks pick it up on recovery); removing one → simply stops mounting (stale metadata is harmless).
- Sandbox allow/deny paths aggregate over every clone; RO keeps clones out of `allowWritePaths`; each clone's `.git/HEAD` is denied in RW.
- Clones live at `sessions/<task>/repos/<agentId>/<org>/<repo>/` — siblings of the agent cwd, never nested inside it.
- Base cache at `$ARCHIE_WORKDIR/repos/<org>/<repo>/`, pre-warmed at startup and lazy-cloned on first spawn if missing (`ensureBaseCache`) — covers a repo added to frontmatter after startup.

**repo-tools**
- Every PR/git tool takes an optional `github` arg, defaulting to the agent's primary. `resolveGithub` validates against the declared list; clone-touching tools also require a local clone (`requireAttached`).

`merge.ts` / `events.ts` walk the per-agent shape to find a PR by `(github, prNumber)`. Architecture docs + repo-agent prompt updated.

## Deferred to a follow-up

Cut from this PR to keep it simple and certain; full implementation preserved on branch `claude/multi-repo-full-backup`:
- **On-demand `attach_repo`** (mount a declared repo mid-conversation via a turn-ending tool + sessionId-resume respawn). The respawn state machine was the most intricate, race-prone part of the original PR; eager mounting removes the need for it.
- **PM dynamic spawning** (`spawn_repo_agent` / `list_available_repos`). Will be rebuilt on the eager-mount foundation — a PM-spawned agent just eager-mounts its repos at spawn, no respawn needed.

## Review trail

Built, reviewed by subagent (one blocker found + fixed: legacy-task PR routing in `findTaskByPRNumber`), then reduced from the larger original scope in three verified stages. The recovery-of-an-old-task-after-gaining-a-repo path was specifically verified end-to-end. Rebased onto current `main`; squashed to one commit.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 411/411 pass (incl. the migration suite)
- [ ] Manual: declare a 2nd repo on an existing repo agent, ping an old in-flight task, confirm it recovers and mounts both repos (existing one reused, new one cloned)
- [ ] Manual: edit-mode PR flow on a non-primary repo via the `github` arg

https://claude.ai/code/session_013CNvEhfGpWLGr3HswTfyqr