### PR TITLE
Add get_check_run tool to fetch CI checks and workflow runs

### DIFF
--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -120,6 +120,8 @@ Read:
 - `list_prs(state?, base?, sort?, limit?)` — list PRs with filters
 - `get_pr(pr_number)` — full PR details: title, description, diff, branches
 - `get_pr_status(pr_number)` — mergeability state + approval state
+- `get_pr_checks(pr_number)` — CI checks on a PR's HEAD commit, with failure output
+- `get_check_run(ref)` — fetch a single check/run by id or github.com URL (no PR needed). Use when someone shares a raw CI link like `.../runs/123`, `.../actions/runs/123`, or `.../actions/runs/123/job/456`; returns conclusion, output, annotations, and (for Actions) the failing slice of the job log
 - `get_pr_reviews(pr_number)` — review-level summary (approvals, change requests, review bodies)
 - `get_pr_comments(pr_number)` — top-level PR conversation comments with `comment_id`
 - `get_review_threads(pr_number)` — every review thread with its `thread_id` (GraphQL node id) plus each comment's `comment_id`, resolved/outdated flags, file, line

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -20,10 +20,15 @@ import type { RepositoryInfo } from '../../types/task.js';
 
 // ---- Module mocks ----
 
-vi.mock('../../connectors/github/client.js', () => ({
-  getGitHubClient: vi.fn(),
-  fetchOrigin: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock('../../connectors/github/client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../connectors/github/client.js')>();
+  return {
+    // Keep the real parseCheckRef (pure helper) so get_check_run parses for real.
+    parseCheckRef: actual.parseCheckRef,
+    getGitHubClient: vi.fn(),
+    fetchOrigin: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock('../../connectors/github/repo-clone.js', () => ({
   gitExec: vi.fn().mockResolvedValue(''),
@@ -73,6 +78,8 @@ const mockGitHubClient = {
   replyToReviewComment: vi.fn(),
   resolveReviewThread: vi.fn(),
   requestReReview: vi.fn(),
+  getCheckRunById: vi.fn(),
+  getWorkflowRunById: vi.fn(),
 };
 
 function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
@@ -270,6 +277,93 @@ describe('get_pr_status (read-only server)', () => {
     expect(result.content[0].text).toContain('State: open');
     expect(result.content[0].text).toContain('Mergeable: true');
     expect(result.content[0].text).toContain('Approved: true');
+  });
+});
+
+describe('get_check_run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getGitHubClient).mockReturnValue(mockGitHubClient as any);
+  });
+
+  it('resolves a legacy /runs/<id> check-run permalink and shows output + log', async () => {
+    mockGitHubClient.getCheckRunById.mockResolvedValue({
+      id: 78033491451, name: 'rspec', app: 'github-actions', status: 'completed',
+      conclusion: 'failure', url: 'https://github.com/org/backend/runs/78033491451',
+      headSha: 'abc1234def', startedAt: null, completedAt: null,
+      output: { title: 'RSpec', summary: '3 failures' },
+      logTail: 'Failures:\n  1) Widget flakes\n  rspec ./spec/widget_spec.rb:12',
+    });
+
+    const tool = getRepoTool(makeAgent(), makeTask(), 'get_check_run');
+    const result = await tool({ ref: 'https://github.com/org/backend/runs/78033491451' }, {});
+
+    expect(mockGitHubClient.getCheckRunById).toHaveBeenCalledWith('org/backend', 78033491451);
+    const text = result.content[0].text;
+    expect(text).toContain('rspec');
+    expect(text).toContain('failure');
+    expect(text).toContain('Failures:');
+    expect(text).toContain('rspec ./spec/widget_spec.rb:12');
+  });
+
+  it('accepts a bare numeric id', async () => {
+    mockGitHubClient.getCheckRunById.mockResolvedValue({
+      id: 999, name: 'lint', app: 'ci', status: 'completed', conclusion: 'success',
+      url: null, headSha: null, startedAt: null, completedAt: null,
+    });
+
+    const tool = getRepoTool(makeAgent(), makeTask(), 'get_check_run');
+    await tool({ ref: '999' }, {});
+
+    expect(mockGitHubClient.getCheckRunById).toHaveBeenCalledWith('org/backend', 999);
+  });
+
+  it('routes an /actions/runs/<id> URL to the workflow-run path', async () => {
+    mockGitHubClient.getWorkflowRunById.mockResolvedValue({
+      id: 555, name: 'CI', status: 'completed', conclusion: 'failure',
+      headSha: 'deadbeef', headBranch: 'main', url: 'https://github.com/org/backend/actions/runs/555',
+      jobs: [
+        { id: 1, name: 'build', status: 'completed', conclusion: 'success', url: null },
+        { id: 2, name: 'test', status: 'completed', conclusion: 'failure', url: null, logTail: 'Failures:\n  boom' },
+      ],
+    });
+
+    const tool = getRepoTool(makeAgent(), makeTask(), 'get_check_run');
+    const result = await tool({ ref: 'https://github.com/org/backend/actions/runs/555' }, {});
+
+    expect(mockGitHubClient.getWorkflowRunById).toHaveBeenCalledWith('org/backend', 555);
+    expect(mockGitHubClient.getCheckRunById).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('test (job 2)');
+    expect(result.content[0].text).toContain('boom');
+  });
+
+  it('treats /actions/runs/<run>/job/<job> as a check-run (job id)', async () => {
+    mockGitHubClient.getCheckRunById.mockResolvedValue({
+      id: 42, name: 'rspec', app: 'github-actions', status: 'completed',
+      conclusion: 'failure', url: null, headSha: null, startedAt: null, completedAt: null,
+    });
+
+    const tool = getRepoTool(makeAgent(), makeTask(), 'get_check_run');
+    await tool({ ref: 'https://github.com/org/backend/actions/runs/555/job/42' }, {});
+
+    expect(mockGitHubClient.getCheckRunById).toHaveBeenCalledWith('org/backend', 42);
+  });
+
+  it('refuses a URL pointing at a different repo', async () => {
+    const tool = getRepoTool(makeAgent(), makeTask(), 'get_check_run');
+    const result = await tool({ ref: 'https://github.com/other/repo/runs/1' }, {});
+
+    expect(result.content[0].text).toContain('Error');
+    expect(result.content[0].text).toContain('other/repo');
+    expect(mockGitHubClient.getCheckRunById).not.toHaveBeenCalled();
+  });
+
+  it('errors on an unparseable ref', async () => {
+    const tool = getRepoTool(makeAgent(), makeTask(), 'get_check_run');
+    const result = await tool({ ref: 'not-a-run' }, {});
+
+    expect(result.content[0].text).toContain('Error');
+    expect(mockGitHubClient.getCheckRunById).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -130,6 +130,7 @@ const SPAWN_REPO_TOOLS = [
   'mcp__repo-tools__get_pr',
   'mcp__repo-tools__get_pr_status',
   'mcp__repo-tools__get_pr_checks',
+  'mcp__repo-tools__get_check_run',
   'mcp__repo-tools__get_pr_reviews',
   'mcp__repo-tools__get_pr_comments',
   'mcp__repo-tools__get_review_threads',

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -17,7 +17,7 @@ import type { AgentName, FindingType } from '../types/task.js';
 import type { Task } from '../tasks/task.js';
 import type { Agent } from './agent.js';
 import { getAgentIds, getVisiblePeerIdsForSender, getAgentDef } from './registry.js';
-import { getGitHubClient } from '../connectors/github/client.js';
+import { getGitHubClient, parseCheckRef } from '../connectors/github/client.js';
 import { gitExec } from '../connectors/github/repo-clone.js';
 import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
 import { appendAgentFinding, appendArtifactShared } from '../tasks/persistence.js';
@@ -724,6 +724,86 @@ function createGetPRChecksTool(agent: Agent, task: Task) {
   );
 }
 
+function createGetCheckRunTool(agent: Agent, task: Task) {
+  const githubRepo = agent.def.repo!.githubRepo;
+  return tool(
+    'get_check_run',
+    'Fetch a single CI check/run by its id or a github.com URL — no PR needed. ' +
+    'Use this when someone shares a raw check-run, Actions job, or workflow-run link (e.g. ".../runs/123", ".../actions/runs/123", or ".../actions/runs/123/job/456") or just a run id, and you need the failure details. ' +
+    'Returns the conclusion, check output, annotations, and — for GitHub Actions — the failing slice of the job log (the rspec "Failures:" / "Failed examples:" block). ' +
+    'For checks on a PR you already know, prefer get_pr_checks.',
+    {
+      ref: z.string().describe('A numeric check-run/job/workflow-run id, or a full github.com URL pointing at one.'),
+    },
+    async (args) => {
+      const client = getGitHubClient();
+      if (!client) throw new Error('GitHub client not configured');
+
+      let parsed;
+      try {
+        parsed = parseCheckRef(args.ref);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+
+      // Stay within this agent's repo: a URL pointing elsewhere is out of scope.
+      if (parsed.owner && parsed.repo) {
+        const refRepo = `${parsed.owner}/${parsed.repo}`;
+        if (refRepo.toLowerCase() !== githubRepo.toLowerCase()) {
+          return err(
+            `That link points at ${refRepo}, but you are scoped to ${githubRepo}. ` +
+            `I can only fetch checks for ${githubRepo}.`
+          );
+        }
+      }
+
+      if (parsed.kind === 'workflow_run') {
+        const report = await client.getWorkflowRunById(githubRepo, parsed.id);
+        const lines: string[] = [
+          `Workflow run ${report.id} — ${report.name} [${report.conclusion ?? report.status}]`,
+          `Branch: ${report.headBranch ?? 'unknown'} (head ${report.headSha ? report.headSha.slice(0, 7) : 'unknown'})`,
+        ];
+        if (report.url) lines.push(`URL: ${report.url}`);
+        lines.push('', `Jobs (${report.jobs.length}):`);
+        for (const job of report.jobs) {
+          lines.push(`- [${job.conclusion ?? job.status}] ${job.name} (job ${job.id})${job.url ? ` — ${job.url}` : ''}`);
+        }
+        for (const job of report.jobs) {
+          if (job.logTail) {
+            lines.push('', `${job.name} log:`, job.logTail);
+          }
+        }
+        return ok(lines.join('\n'));
+      }
+
+      const report = await client.getCheckRunById(githubRepo, parsed.id);
+      const lines: string[] = [
+        `Check run ${report.id} — ${report.name} (${report.app}) [${report.conclusion ?? report.status}]`,
+        `Head: ${report.headSha ? report.headSha.slice(0, 7) : 'unknown'}`,
+      ];
+      if (report.url) lines.push(`URL: ${report.url}`);
+      if (report.output?.title) lines.push(`title: ${report.output.title}`);
+      if (report.output?.summary) {
+        lines.push('summary:', report.output.summary);
+      }
+      if (report.output?.text) {
+        lines.push('text:', report.output.text);
+      }
+      if (report.annotations?.length) {
+        lines.push('', `Annotations (${report.annotations.length}):`);
+        for (const a of report.annotations) {
+          const loc = a.startLine !== null ? `${a.path}:${a.startLine}` : a.path;
+          lines.push(`- [${a.level}] ${loc}${a.title ? ` ${a.title}` : ''}: ${a.message}`);
+        }
+      }
+      if (report.logTail) {
+        lines.push('', 'log:', report.logTail);
+      }
+      return ok(lines.join('\n'));
+    },
+  );
+}
+
 function createGetPRReviewsTool(agent: Agent, task: Task) {
   const githubRepo = agent.def.repo!.githubRepo;
   return tool(
@@ -1263,6 +1343,7 @@ export function createRepoToolsMcpServer(agent: Agent, task: Task) {
       createGetPRTool(agent, task),
       createGetPRStatusTool(agent, task),
       createGetPRChecksTool(agent, task),
+      createGetCheckRunTool(agent, task),
       createGetPRReviewsTool(agent, task),
       createGetPRCommentsTool(agent, task),
       createGetReviewThreadsTool(agent, task),

--- a/src/connectors/github/client.ts
+++ b/src/connectors/github/client.ts
@@ -78,6 +78,125 @@ export interface PRDetails {
   url: string;
 }
 
+export interface CheckRunAnnotation {
+  path: string;
+  startLine: number | null;
+  level: string;
+  message: string;
+  title?: string;
+}
+
+export interface CheckRunReport {
+  id: number;
+  name: string;
+  app: string;
+  status: string;
+  conclusion: PRCheckEntry['conclusion'];
+  url: string | null;
+  headSha: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  output?: { title?: string; summary?: string; text?: string };
+  annotations?: CheckRunAnnotation[];
+  logTail?: string;
+}
+
+export interface WorkflowJobEntry {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: PRCheckEntry['conclusion'];
+  url: string | null;
+  logTail?: string;
+}
+
+export interface WorkflowRunReport {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: PRCheckEntry['conclusion'];
+  headSha: string | null;
+  headBranch: string | null;
+  url: string | null;
+  jobs: WorkflowJobEntry[];
+}
+
+export interface ParsedCheckRef {
+  /** `check_run` covers check-run permalinks and Actions job links (job id == check-run id). */
+  kind: 'check_run' | 'workflow_run';
+  id: number;
+  owner?: string;
+  repo?: string;
+}
+
+/**
+ * Classify a GitHub CI reference — a bare numeric id or a github.com URL — into
+ * the id + kind needed to hit the right API.
+ *
+ * Recognized URL shapes (owner/repo extracted when present):
+ * - `.../pull/N/checks?check_run_id=ID`        → check_run
+ * - `.../actions/runs/R/job/J` (or `/jobs/J`)  → check_run (J is the job id)
+ * - `.../actions/runs/R`                       → workflow_run
+ * - `.../runs/ID` (legacy check-run permalink) → check_run
+ * - bare `ID`                                  → check_run
+ */
+export function parseCheckRef(input: string): ParsedCheckRef {
+  const trimmed = input.trim();
+
+  let owner: string | undefined;
+  let repo: string | undefined;
+  const repoMatch = trimmed.match(/github\.com\/([^/\s]+)\/([^/\s?#]+)/i);
+  if (repoMatch) {
+    owner = repoMatch[1];
+    repo = repoMatch[2];
+  }
+
+  const checkRunQuery = trimmed.match(/[?&]check_run_id=(\d+)/);
+  if (checkRunQuery) {
+    return { kind: 'check_run', id: Number(checkRunQuery[1]), owner, repo };
+  }
+
+  const jobMatch = trimmed.match(/\/actions\/runs\/\d+\/jobs?\/(\d+)/);
+  if (jobMatch) {
+    return { kind: 'check_run', id: Number(jobMatch[1]), owner, repo };
+  }
+
+  const workflowMatch = trimmed.match(/\/actions\/runs\/(\d+)/);
+  if (workflowMatch) {
+    return { kind: 'workflow_run', id: Number(workflowMatch[1]), owner, repo };
+  }
+
+  const legacyMatch = trimmed.match(/\/runs\/(\d+)/);
+  if (legacyMatch) {
+    return { kind: 'check_run', id: Number(legacyMatch[1]), owner, repo };
+  }
+
+  const bare = trimmed.match(/^(\d+)$/);
+  if (bare) {
+    return { kind: 'check_run', id: Number(bare[1]) };
+  }
+
+  throw new Error(
+    `Could not extract a check-run, job, or workflow-run id from: "${input}". ` +
+    `Pass a numeric id or a github.com run/check/job URL.`
+  );
+}
+
+/**
+ * Pull the most useful slice out of a raw CI log: the rspec-style "Failures:"
+ * block when present, otherwise the tail. Actions logs can be megabytes, so
+ * the result is capped.
+ */
+function extractFailureTail(text: string, maxChars = 15000): string {
+  if (!text) return '';
+  const marker = text.indexOf('Failures:');
+  const slice = marker >= 0 ? text.slice(marker) : text;
+  if (slice.length <= maxChars) return slice;
+  return marker >= 0
+    ? slice.slice(0, maxChars) + '\n…(truncated)'
+    : '…(truncated)\n' + slice.slice(slice.length - maxChars);
+}
+
 export class GitHubClient {
   private app: App;
   private installationId: number;
@@ -647,6 +766,145 @@ export class GitHubClient {
     logger.system(`GitHub: PR #${prNumber} checks (head ${headSha.slice(0, 7)}): ${entries.length} total (${summary})`);
 
     return { headSha, entries };
+  }
+
+  /**
+   * Best-effort fetch of an Actions job log tail. For GitHub Actions, a job's
+   * id equals its check-run id, so a check-run permalink id works here too.
+   * Returns undefined for non-Actions checks (the endpoint 404s) or any error.
+   */
+  private async tryFetchJobLogTail(owner: string, repo: string, jobId: number): Promise<string | undefined> {
+    try {
+      const octokit = await this.getOctokit();
+      const res = await octokit.request(
+        'GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs',
+        { owner, repo, job_id: jobId }
+      );
+      const text = typeof res.data === 'string' ? res.data : '';
+      const tail = extractFailureTail(text);
+      return tail || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Fetch a single check run by id, resolving the failure detail an agent
+   * actually needs: the check output, any annotations, and — for Actions jobs
+   * (where job id == check-run id) — the failing slice of the job log.
+   */
+  async getCheckRunById(githubRepo: string, checkRunId: number): Promise<CheckRunReport> {
+    const octokit = await this.getOctokit();
+    const { owner, repo } = this.parseRepo(githubRepo);
+
+    const res = await octokit.request(
+      'GET /repos/{owner}/{repo}/check-runs/{check_run_id}',
+      { owner, repo, check_run_id: checkRunId }
+    );
+    const run = res.data;
+
+    const report: CheckRunReport = {
+      id: run.id,
+      name: run.name,
+      app: run.app?.slug || 'unknown',
+      status: run.status,
+      conclusion: run.conclusion as PRCheckEntry['conclusion'],
+      url: run.html_url ?? null,
+      headSha: run.head_sha ?? null,
+      startedAt: run.started_at ?? null,
+      completedAt: run.completed_at ?? null,
+    };
+
+    const output = run.output;
+    if (output && (output.title || output.summary || output.text)) {
+      report.output = {
+        title: output.title ?? undefined,
+        summary: output.summary ?? undefined,
+        text: output.text ?? undefined,
+      };
+    }
+
+    if (output?.annotations_count && output.annotations_count > 0) {
+      try {
+        const ann = await octokit.request(
+          'GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations',
+          { owner, repo, check_run_id: checkRunId, per_page: 50 }
+        );
+        report.annotations = ann.data.map((a) => ({
+          path: a.path,
+          startLine: a.start_line ?? null,
+          level: a.annotation_level ?? 'notice',
+          message: a.message ?? '',
+          title: a.title ?? undefined,
+        }));
+      } catch {
+        // annotations are best-effort
+      }
+    }
+
+    const logTail = await this.tryFetchJobLogTail(owner, repo, checkRunId);
+    if (logTail) report.logTail = logTail;
+
+    logger.system(
+      `GitHub: check run ${checkRunId} (${report.name}): ${report.conclusion ?? report.status}` +
+      `${report.annotations ? `, ${report.annotations.length} annotations` : ''}` +
+      `${report.logTail ? ', log captured' : ''}`
+    );
+
+    return report;
+  }
+
+  /**
+   * Fetch a workflow run by id plus its jobs. Failed jobs include a tail of
+   * their log so an agent can see what broke without a PR in hand.
+   */
+  async getWorkflowRunById(githubRepo: string, runId: number): Promise<WorkflowRunReport> {
+    const octokit = await this.getOctokit();
+    const { owner, repo } = this.parseRepo(githubRepo);
+
+    const runRes = await octokit.request(
+      'GET /repos/{owner}/{repo}/actions/runs/{run_id}',
+      { owner, repo, run_id: runId }
+    );
+    const run = runRes.data;
+
+    const jobsRes = await octokit.request(
+      'GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs',
+      { owner, repo, run_id: runId, per_page: 100 }
+    );
+
+    const FAILED = new Set(['failure', 'cancelled', 'timed_out', 'action_required']);
+    const jobs: WorkflowJobEntry[] = [];
+    for (const job of jobsRes.data.jobs) {
+      const entry: WorkflowJobEntry = {
+        id: job.id,
+        name: job.name,
+        status: job.status,
+        conclusion: job.conclusion as PRCheckEntry['conclusion'],
+        url: job.html_url ?? null,
+      };
+      if (job.conclusion && FAILED.has(job.conclusion)) {
+        const logTail = await this.tryFetchJobLogTail(owner, repo, job.id);
+        if (logTail) entry.logTail = logTail;
+      }
+      jobs.push(entry);
+    }
+
+    logger.system(
+      `GitHub: workflow run ${runId} (${run.name ?? 'unknown'}): ` +
+      `${run.conclusion ?? run.status}, ${jobs.length} jobs`
+    );
+
+    return {
+      id: run.id,
+      name: run.name ?? 'unknown',
+      status: run.status ?? 'unknown',
+      conclusion: run.conclusion as PRCheckEntry['conclusion'],
+      headSha: run.head_sha ?? null,
+      headBranch: run.head_branch ?? null,
+      url: run.html_url ?? null,
+      jobs,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a new `get_check_run` tool that allows agents to fetch detailed information about GitHub CI checks, Actions jobs, and workflow runs by their ID or URL — without needing a PR context. This enables agents to investigate CI failures when users share raw check/run links.

## Key Changes

- **New interfaces and types** (`CheckRunReport`, `WorkflowRunReport`, `CheckRunAnnotation`, `WorkflowJobEntry`, `ParsedCheckRef`) to represent CI check and workflow data structures
- **`parseCheckRef()` function** to parse various GitHub CI URL formats and bare numeric IDs:
  - Check-run permalinks (`.../runs/<id>`)
  - Actions job links (`.../actions/runs/<run>/job/<job>`)
  - Workflow run URLs (`.../actions/runs/<run>`)
  - Query parameters (`?check_run_id=<id>`)
  - Bare numeric IDs
- **`extractFailureTail()` helper** to extract the most useful slice from CI logs (rspec "Failures:" block when present, otherwise tail, capped at 15KB)
- **`getCheckRunById()` method** to fetch a single check run with output, annotations, and job log tail
- **`getWorkflowRunById()` method** to fetch a workflow run with all its jobs and log tails for failed jobs
- **`tryFetchJobLogTail()` private method** for best-effort Actions job log retrieval
- **`createGetCheckRunTool()` function** in `tools.ts` that exposes the new capability as an MCP tool with:
  - URL/ID parsing and validation
  - Repo scope enforcement (rejects URLs pointing to different repos)
  - Formatted output for both check runs and workflow runs
- **Test coverage** in `pr-tools.test.ts` covering URL parsing, bare IDs, workflow vs. check-run routing, and error cases
- **Updated tool registry** to include the new tool in the MCP server and contract tests
- **Documentation** in `repo-agent.md` describing the new tool's purpose and usage

## Implementation Details

- The tool uses `parseCheckRef()` to classify inputs and route to the appropriate API endpoint
- Repo scope is enforced by comparing parsed owner/repo against the agent's configured repo
- For workflow runs, all jobs are fetched and failed jobs include log tails for debugging
- For check runs, annotations are fetched separately (best-effort) and output/summary/text are included
- Log extraction intelligently finds rspec-style failure blocks to avoid megabyte-sized raw logs
- All GitHub API calls are wrapped with proper error handling and logging

https://claude.ai/code/session_01LPhazvtaiXyP3NE2Dh2zfW