### PR TITLE
Unify agent spawning: replace track-based model with capability-based

### DIFF
--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -89,7 +89,6 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
       key: 'backend',
       role: 'Backend engineer',
       expertise: 'Node.js',
-      track: 'repo',
       pluginName: 'engineering',
       visibility: 'global',
       repo: {
@@ -369,7 +368,7 @@ describe('get_check_run', () => {
 
 describe('PM agent tools', () => {
   it('does not include any PR tools', () => {
-    const agent = makeAgent({ track: 'pm', repo: undefined, id: 'pm-agent' });
+    const agent = makeAgent({ isPm: true, repo: undefined, id: 'pm-agent' });
     const task = makeTask();
     const server = createPMAgentMcpServer(agent, task);
 

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -8,9 +8,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   createRepoToolsMcpServer,
-  createPmCommsMcpServer,
-  createPmOrchestrationMcpServer,
-  createPmSchedulingMcpServer,
+  createCommsMcpServer,
+  createOrchestrationMcpServer,
+  createSchedulingMcpServer,
   mirrorLegacyFields,
   hydrateBranchState,
   findBranchStateByPR,
@@ -373,9 +373,9 @@ describe('PM agent tools', () => {
     const agent = makeAgent({ isPm: true, repo: undefined, id: 'pm-agent' });
     const task = makeTask();
     const servers = [
-      createPmCommsMcpServer(agent, task),
-      createPmOrchestrationMcpServer(agent, task),
-      createPmSchedulingMcpServer(agent, task),
+      createCommsMcpServer(agent, task),
+      createOrchestrationMcpServer(agent, task),
+      createSchedulingMcpServer(agent, task),
     ];
 
     const registeredTools = servers.flatMap((server) =>

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -8,7 +8,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   createRepoToolsMcpServer,
-  createPMAgentMcpServer,
+  createPmCommsMcpServer,
+  createPmOrchestrationMcpServer,
+  createPmSchedulingMcpServer,
   mirrorLegacyFields,
   hydrateBranchState,
   findBranchStateByPR,
@@ -370,10 +372,16 @@ describe('PM agent tools', () => {
   it('does not include any PR tools', () => {
     const agent = makeAgent({ isPm: true, repo: undefined, id: 'pm-agent' });
     const task = makeTask();
-    const server = createPMAgentMcpServer(agent, task);
+    const servers = [
+      createPmCommsMcpServer(agent, task),
+      createPmOrchestrationMcpServer(agent, task),
+      createPmSchedulingMcpServer(agent, task),
+    ];
 
-    const registeredTools = Object.keys(
-      (server.instance as any)._registeredTools ?? Object.fromEntries((server.instance as any)._tools ?? []),
+    const registeredTools = servers.flatMap((server) =>
+      Object.keys(
+        (server.instance as any)._registeredTools ?? Object.fromEntries((server.instance as any)._tools ?? []),
+      ),
     );
 
     const prToolNames = [
@@ -384,7 +392,7 @@ describe('PM agent tools', () => {
     ];
 
     for (const prTool of prToolNames) {
-      expect(registeredTools, `PM server should not have tool: ${prTool}`).not.toContain(prTool);
+      expect(registeredTools, `PM servers should not have tool: ${prTool}`).not.toContain(prTool);
     }
   });
 });

--- a/src/agents/__tests__/registry-visibility.test.ts
+++ b/src/agents/__tests__/registry-visibility.test.ts
@@ -21,7 +21,6 @@ function mkPlugin(pluginName: string, key: string, visibility: 'global' | 'local
     key,
     role: `${key} role`,
     expertise: `${key} expertise`,
-    track: 'plugin',
     pluginName,
     visibility,
     ...extras,
@@ -34,7 +33,6 @@ function mkRepo(pluginName: string, key: string, visibility: 'global' | 'local')
     key,
     role: `${key} role`,
     expertise: `${key} expertise`,
-    track: 'repo',
     pluginName,
     visibility,
     repo: {
@@ -51,7 +49,7 @@ function mkPm(): AgentDef {
     key: 'pm',
     role: 'PM',
     expertise: 'Coordination',
-    track: 'pm',
+    isPm: true,
     pluginName: 'pm',
     visibility: 'global',
   } as AgentDef;

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -10,9 +10,9 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   createRepoToolsMcpServer,
   createBaseAgentMcpServer,
-  createPmCommsMcpServer,
-  createPmOrchestrationMcpServer,
-  createPmSchedulingMcpServer,
+  createCommsMcpServer,
+  createOrchestrationMcpServer,
+  createSchedulingMcpServer,
 } from '../tools.js';
 import type { Agent } from '../agent.js';
 import type { Task } from '../../tasks/task.js';
@@ -111,28 +111,28 @@ const AGENT_TOOLS = [
 ];
 
 const PM_COMMS_TOOLS = [
-  'mcp__pm-comms__post_to_user',
-  'mcp__pm-comms__post_files_to_user',
-  'mcp__pm-comms__find_slack_user',
-  'mcp__pm-comms__find_slack_channel',
-  'mcp__pm-comms__mute_channel',
-  'mcp__pm-comms__react_to_message',
-  'mcp__pm-comms__unreact_from_message',
-  'mcp__pm-comms__get_message_reactions',
+  'mcp__comms-tools__post_to_user',
+  'mcp__comms-tools__post_files_to_user',
+  'mcp__comms-tools__find_slack_user',
+  'mcp__comms-tools__find_slack_channel',
+  'mcp__comms-tools__mute_channel',
+  'mcp__comms-tools__react_to_message',
+  'mcp__comms-tools__unreact_from_message',
+  'mcp__comms-tools__get_message_reactions',
 ];
 
 const PM_ORCHESTRATION_TOOLS = [
-  'mcp__pm-orchestration__assign_task_owner',
-  'mcp__pm-orchestration__report_completion',
-  'mcp__pm-orchestration__request_edit_mode',
-  'mcp__pm-orchestration__get_agents_status',
-  'mcp__pm-orchestration__launch_task',
+  'mcp__orchestration-tools__assign_task_owner',
+  'mcp__orchestration-tools__report_completion',
+  'mcp__orchestration-tools__request_edit_mode',
+  'mcp__orchestration-tools__get_agents_status',
+  'mcp__orchestration-tools__launch_task',
 ];
 
 const PM_SCHEDULING_TOOLS = [
-  'mcp__pm-scheduling__parse_datetime',
-  'mcp__pm-scheduling__set_reminder',
-  'mcp__pm-scheduling__cancel_reminder',
+  'mcp__scheduling-tools__parse_datetime',
+  'mcp__scheduling-tools__set_reminder',
+  'mcp__scheduling-tools__cancel_reminder',
 ];
 
 const SPAWN_REPO_TOOLS = [
@@ -183,21 +183,21 @@ describe('PM MCP server contracts', () => {
     expect(registered.sort()).toEqual(AGENT_TOOLS.sort());
   });
 
-  it('pm-comms registers exactly its tools', () => {
-    const server = createPmCommsMcpServer(pmAgent(), makeTask());
-    const registered = getRegisteredToolNames(server).map((n) => `mcp__pm-comms__${n}`);
+  it('comms-tools registers exactly its tools', () => {
+    const server = createCommsMcpServer(pmAgent(), makeTask());
+    const registered = getRegisteredToolNames(server).map((n) => `mcp__comms-tools__${n}`);
     expect(registered.sort()).toEqual(PM_COMMS_TOOLS.sort());
   });
 
-  it('pm-orchestration registers exactly its tools', () => {
-    const server = createPmOrchestrationMcpServer(pmAgent(), makeTask());
-    const registered = getRegisteredToolNames(server).map((n) => `mcp__pm-orchestration__${n}`);
+  it('orchestration-tools registers exactly its tools', () => {
+    const server = createOrchestrationMcpServer(pmAgent(), makeTask());
+    const registered = getRegisteredToolNames(server).map((n) => `mcp__orchestration-tools__${n}`);
     expect(registered.sort()).toEqual(PM_ORCHESTRATION_TOOLS.sort());
   });
 
-  it('pm-scheduling registers exactly its tools', () => {
-    const server = createPmSchedulingMcpServer(pmAgent(), makeTask());
-    const registered = getRegisteredToolNames(server).map((n) => `mcp__pm-scheduling__${n}`);
+  it('scheduling-tools registers exactly its tools', () => {
+    const server = createSchedulingMcpServer(pmAgent(), makeTask());
+    const registered = getRegisteredToolNames(server).map((n) => `mcp__scheduling-tools__${n}`);
     expect(registered.sort()).toEqual(PM_SCHEDULING_TOOLS.sort());
   });
 });

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -9,7 +9,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   createRepoToolsMcpServer,
-  createPMAgentMcpServer,
+  createBaseAgentMcpServer,
+  createPmCommsMcpServer,
+  createPmOrchestrationMcpServer,
+  createPmSchedulingMcpServer,
 } from '../tools.js';
 import type { Agent } from '../agent.js';
 import type { Task } from '../../tasks/task.js';
@@ -101,25 +104,35 @@ function getRegisteredToolNames(server: ReturnType<typeof createRepoToolsMcpServ
 
 // ---- Expected tool lists (must stay in sync with spawn.ts) ----
 
-const SPAWN_PM_TOOLS = [
-  'mcp__pm-agent-tools__send_message_to_agent',
-  'mcp__pm-agent-tools__post_to_user',
-  'mcp__pm-agent-tools__post_files_to_user',
-  'mcp__pm-agent-tools__share_artifact',
-  'mcp__pm-agent-tools__find_slack_user',
-  'mcp__pm-agent-tools__find_slack_channel',
-  'mcp__pm-agent-tools__assign_task_owner',
-  'mcp__pm-agent-tools__report_completion',
-  'mcp__pm-agent-tools__request_edit_mode',
-  'mcp__pm-agent-tools__get_agents_status',
-  'mcp__pm-agent-tools__mute_channel',
-  'mcp__pm-agent-tools__react_to_message',
-  'mcp__pm-agent-tools__unreact_from_message',
-  'mcp__pm-agent-tools__get_message_reactions',
-  'mcp__pm-agent-tools__launch_task',
-  'mcp__pm-agent-tools__parse_datetime',
-  'mcp__pm-agent-tools__set_reminder',
-  'mcp__pm-agent-tools__cancel_reminder',
+const AGENT_TOOLS = [
+  'mcp__agent-tools__send_message_to_agent',
+  'mcp__agent-tools__log_finding',
+  'mcp__agent-tools__share_artifact',
+];
+
+const PM_COMMS_TOOLS = [
+  'mcp__pm-comms__post_to_user',
+  'mcp__pm-comms__post_files_to_user',
+  'mcp__pm-comms__find_slack_user',
+  'mcp__pm-comms__find_slack_channel',
+  'mcp__pm-comms__mute_channel',
+  'mcp__pm-comms__react_to_message',
+  'mcp__pm-comms__unreact_from_message',
+  'mcp__pm-comms__get_message_reactions',
+];
+
+const PM_ORCHESTRATION_TOOLS = [
+  'mcp__pm-orchestration__assign_task_owner',
+  'mcp__pm-orchestration__report_completion',
+  'mcp__pm-orchestration__request_edit_mode',
+  'mcp__pm-orchestration__get_agents_status',
+  'mcp__pm-orchestration__launch_task',
+];
+
+const PM_SCHEDULING_TOOLS = [
+  'mcp__pm-scheduling__parse_datetime',
+  'mcp__pm-scheduling__set_reminder',
+  'mcp__pm-scheduling__cancel_reminder',
 ];
 
 const SPAWN_REPO_TOOLS = [
@@ -161,12 +174,30 @@ describe('repo-tools MCP server contract', () => {
   });
 });
 
-describe('pm-agent-tools MCP server contract', () => {
-  it('registers exactly the tools listed in spawn.ts allowedTools', () => {
-    const agent = makeAgent({ isPm: true, repo: undefined, id: 'pm-agent' });
-    const server = createPMAgentMcpServer(agent, makeTask());
-    const registered = getRegisteredToolNames(server).map((n) => `mcp__pm-agent-tools__${n}`);
+describe('PM MCP server contracts', () => {
+  const pmAgent = () => makeAgent({ isPm: true, repo: undefined, id: 'pm-agent' });
 
-    expect(registered.sort()).toEqual(SPAWN_PM_TOOLS.sort());
+  it('agent-tools registers the shared base tools', () => {
+    const server = createBaseAgentMcpServer(pmAgent(), makeTask());
+    const registered = getRegisteredToolNames(server).map((n) => `mcp__agent-tools__${n}`);
+    expect(registered.sort()).toEqual(AGENT_TOOLS.sort());
+  });
+
+  it('pm-comms registers exactly its tools', () => {
+    const server = createPmCommsMcpServer(pmAgent(), makeTask());
+    const registered = getRegisteredToolNames(server).map((n) => `mcp__pm-comms__${n}`);
+    expect(registered.sort()).toEqual(PM_COMMS_TOOLS.sort());
+  });
+
+  it('pm-orchestration registers exactly its tools', () => {
+    const server = createPmOrchestrationMcpServer(pmAgent(), makeTask());
+    const registered = getRegisteredToolNames(server).map((n) => `mcp__pm-orchestration__${n}`);
+    expect(registered.sort()).toEqual(PM_ORCHESTRATION_TOOLS.sort());
+  });
+
+  it('pm-scheduling registers exactly its tools', () => {
+    const server = createPmSchedulingMcpServer(pmAgent(), makeTask());
+    const registered = getRegisteredToolNames(server).map((n) => `mcp__pm-scheduling__${n}`);
+    expect(registered.sort()).toEqual(PM_SCHEDULING_TOOLS.sort());
   });
 });

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -59,7 +59,7 @@ function makeAgent(overrides: Partial<AgentDef> = {}): Agent {
   return {
     def: {
       id: 'backend-agent', key: 'backend', role: 'Backend', expertise: 'Node',
-      track: 'repo', pluginName: 'engineering', visibility: 'global',
+      pluginName: 'engineering', visibility: 'global',
       repo: { githubRepo: 'org/backend', repoKey: 'backend', defaultPath: '/repos/backend' },
       ...overrides,
     },
@@ -163,7 +163,7 @@ describe('repo-tools MCP server contract', () => {
 
 describe('pm-agent-tools MCP server contract', () => {
   it('registers exactly the tools listed in spawn.ts allowedTools', () => {
-    const agent = makeAgent({ track: 'pm', repo: undefined, id: 'pm-agent' });
+    const agent = makeAgent({ isPm: true, repo: undefined, id: 'pm-agent' });
     const server = createPMAgentMcpServer(agent, makeTask());
     const registered = getRegisteredToolNames(server).map((n) => `mcp__pm-agent-tools__${n}`);
 

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -8,7 +8,7 @@
  * Scanned fresh at startup (validate + fail-fast) and on every task start/restart.
  */
 
-import { type AgentDef, isRepoAgent, isPmAgent, isPluginAgent } from '../types/agent.js';
+import { type AgentDef, isRepoAgent, isPmAgent } from '../types/agent.js';
 import { getPlugins, getRootMcpConfig, getPmOverlay, type LoadedMcpConfig, type PluginAgentDef } from '../system/plugin-loader.js';
 import { REPOS_DIR, PLUGINS_DATA_DIR } from '../system/workdir.js';
 import { existsSync } from 'fs';
@@ -194,8 +194,9 @@ export function buildPeerListForSender(senderDef: AgentDef): string {
     .filter((d) => isRepoAgent(d) && visibleIds.has(d.id))
     .map((d) => `- ${d.id}: ${d.role} (${d.repo!.repoKey} repository)`);
 
+  // Non-repo peers (visibleIds already excludes the PM).
   const pluginPeers = registry
-    .filter((d) => isPluginAgent(d) && visibleIds.has(d.id))
+    .filter((d) => !isRepoAgent(d) && visibleIds.has(d.id))
     .map((d) => `- ${d.id}: ${d.role} [${d.pluginName}]`);
 
   return [...repoPeers, ...pluginPeers].join('\n');

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -8,7 +8,7 @@
  * Scanned fresh at startup (validate + fail-fast) and on every task start/restart.
  */
 
-import type { AgentDef } from '../types/agent.js';
+import { type AgentDef, isRepoAgent, isPmAgent, isPluginAgent } from '../types/agent.js';
 import { getPlugins, getRootMcpConfig, getPmOverlay, type LoadedMcpConfig, type PluginAgentDef } from '../system/plugin-loader.js';
 import { REPOS_DIR, PLUGINS_DATA_DIR } from '../system/workdir.js';
 import { existsSync } from 'fs';
@@ -72,7 +72,6 @@ export function scanAgentDefs(): AgentDef[] {
           model: agent.model,
           effort: agent.effort,
           maxTurns: agent.maxTurns,
-          track: 'repo',
           pluginName: plugin.name,
           visibility,
           agentPrompt: agent.prompt || undefined,
@@ -97,7 +96,6 @@ export function scanAgentDefs(): AgentDef[] {
           model: agent.model,
           effort: agent.effort,
           maxTurns: agent.maxTurns,
-          track: 'plugin',
           pluginName: plugin.name,
           visibility,
           agentPrompt: agent.prompt,
@@ -139,14 +137,14 @@ export function __setRegistryForTesting(defs: AgentDef[]): void {
  * Get all agent IDs (repo + plugin, excludes PM)
  */
 export function getAgentIds(): string[] {
-  return registry.filter((d) => d.track !== 'pm').map((d) => d.id);
+  return registry.filter((d) => !isPmAgent(d)).map((d) => d.id);
 }
 
 /**
  * Get all repo agent IDs
  */
 export function getRepoAgentIds(): string[] {
-  return registry.filter((d) => d.track === 'repo').map((d) => d.id);
+  return registry.filter(isRepoAgent).map((d) => d.id);
 }
 
 /**
@@ -160,14 +158,14 @@ export function getAgentDef(id: string): AgentDef | undefined {
  * Get repo AgentDef by GitHub repository identifier (e.g., 'sweatco/backend')
  */
 export function getAgentDefByGithubRepo(githubRepo: string): AgentDef | undefined {
-  return registry.find((d) => d.track === 'repo' && d.repo?.githubRepo === githubRepo);
+  return registry.find((d) => d.repo?.githubRepo === githubRepo);
 }
 
 /**
  * Get the PM AgentDef
  */
 export function getPmDef(): AgentDef | undefined {
-  return registry.find((d) => d.track === 'pm');
+  return registry.find(isPmAgent);
 }
 
 /**
@@ -180,7 +178,7 @@ export function getPmDef(): AgentDef | undefined {
  */
 export function getVisiblePeerIdsForSender(senderDef: AgentDef): string[] {
   return registry
-    .filter((d) => d.track !== 'pm')
+    .filter((d) => !isPmAgent(d))
     .filter((d) => d.id !== senderDef.id)
     .filter((d) => d.pluginName === senderDef.pluginName || d.visibility === 'global')
     .map((d) => d.id);
@@ -193,11 +191,11 @@ export function buildPeerListForSender(senderDef: AgentDef): string {
   const visibleIds = new Set(getVisiblePeerIdsForSender(senderDef));
 
   const repoPeers = registry
-    .filter((d) => d.track === 'repo' && visibleIds.has(d.id))
+    .filter((d) => isRepoAgent(d) && visibleIds.has(d.id))
     .map((d) => `- ${d.id}: ${d.role} (${d.repo!.repoKey} repository)`);
 
   const pluginPeers = registry
-    .filter((d) => d.track === 'plugin' && visibleIds.has(d.id))
+    .filter((d) => isPluginAgent(d) && visibleIds.has(d.id))
     .map((d) => `- ${d.id}: ${d.role} [${d.pluginName}]`);
 
   return [...repoPeers, ...pluginPeers].join('\n');
@@ -288,7 +286,7 @@ function buildPmDef(teamDefs: AgentDef[], rootMcp: LoadedMcpConfig): AgentDef {
     model: overlay?.model,
     effort: overlay?.effort,
     maxTurns: overlay?.maxTurns,
-    track: 'pm',
+    isPm: true,
     pluginName: 'pm',
     visibility: 'global',
     pluginDataPath: join(PLUGINS_DATA_DIR, 'pm'),

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -2,8 +2,10 @@
  * Unified Agent Spawner
  *
  * Single spawnAgent(agent, task) function replaces three separate spawners
- * (pm.ts, repo-agent.ts, plugin-agent.ts). Branches on agent.def.track for
- * model, CWD, prompt, tools, edit mode, and skills.
+ * (pm.ts, repo-agent.ts, plugin-agent.ts). One agent model: a plain plugin
+ * agent gains repo access when it has `repo` attached, and the PM coordinator
+ * is the one agent with `isPm`. Branches on those capabilities for model, CWD,
+ * prompt, tools, edit mode, and skills.
  *
  * Session recovery pattern (try with session → reset → retry → give up) written once.
  */
@@ -14,6 +16,7 @@ import { existsSync } from 'fs';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { Agent } from './agent.js';
 import type { Task } from '../tasks/task.js';
+import { isRepoAgent, isPmAgent } from '../types/agent.js';
 import {
   createPMAgentMcpServer,
   createBaseAgentMcpServer,
@@ -38,10 +41,10 @@ import { processAgentEventForLogging, logger } from '../system/logger.js';
 import { buildSandboxConfig, createFilesystemGuardHooks, type SandboxOptions } from './sandbox.js';
 import { applyOAuthBindings } from '../system/oauth/inject.js';
 
-// ---- Prompt generation (per track) ----
+// ---- Prompt generation (per agent kind) ----
 
 async function generatePMPrompt(task: Task): Promise<string> {
-  const pmDef = task.team.find((d) => d.track === 'pm');
+  const pmDef = task.team.find(isPmAgent);
   return loadPrompt('pm-agent', {
     TEAM_LIST: pmDef?.pmConfig?.teamList ?? '',
     TEAM_EXPERTISE: pmDef?.pmConfig?.teamExpertise ?? '',
@@ -130,8 +133,8 @@ async function setupAgentWorkspace(taskId: string, agent: Agent): Promise<string
 // ---- Main spawner ----
 
 /**
- * Spawn an agent. Branches on agent.def.track for all track-specific behavior.
- * Sets agent.handle on success.
+ * Spawn an agent. Branches on the agent's capabilities (PM coordinator vs. repo
+ * access vs. plain plugin) for all behavior. Sets agent.handle on success.
  */
 export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   const { def } = agent;
@@ -169,8 +172,8 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   let sandboxOpts: SandboxOptions;
   let model: string;
 
-  if (def.track === 'pm') {
-    // ---- PM track ----
+  if (isPmAgent(def)) {
+    // ---- PM coordinator ----
     const pmWorkspace = await setupAgentWorkspace(taskId, agent);
     systemPrompt = await generatePMPrompt(task);
     model = (def.model || 'opus') as string;
@@ -280,8 +283,8 @@ Shared folder: ${sharedPath} [READ-ONLY]
       ],
       allowedNetworkDomains: def.allowedNetworkDomains,
     };
-  } else if (def.track === 'repo') {
-    // ---- Repo track ----
+  } else if (isRepoAgent(def)) {
+    // ---- Repo access attached ----
     const repoWorkspace = await setupAgentWorkspace(taskId, agent);
     const repoInfo = metadata.repositories[def.repo!.repoKey];
     const baseRepoPath = repoInfo?.path || def.repo!.defaultPath;
@@ -446,7 +449,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       };
     }
   } else {
-    // ---- Plugin track ----
+    // ---- Plain plugin agent ----
     const agentWorkspace = await setupAgentWorkspace(taskId, agent);
 
     systemPrompt = await generatePluginAgentPrompt(agent);
@@ -608,7 +611,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
               event,
               def.id,
               additionalDirectories || [cwd],
-              def.track === 'repo' && metadata.edit_allowed === true,
+              isRepoAgent(def) && metadata.edit_allowed === true,
             );
           }
 

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -272,7 +272,6 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   const cwd = workspace;
   const model = def.model || (isPmAgent(def) ? 'opus' : 'sonnet');
   const tools = def.tools;
-  const baseDisallowedTools = ['WebSearch', 'WebFetch', ...(def.disallowedTools || [])];
 
   const pluginPaths = def.pluginPath ? [def.pluginPath] : [];
   const pluginReadPaths = [...pluginPaths, ...(def.pluginDataPath ? [def.pluginDataPath] : [])];
@@ -302,7 +301,7 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
 
   let systemPrompt: string;
   let additionalDirectories: string[] = [sharedPath, ...pluginPaths];
-  let disallowedTools: string[] = baseDisallowedTools;
+  let disallowedTools: string[] = ['WebSearch', 'WebFetch', ...(def.disallowedTools || [])];
   let sandboxOpts: SandboxOptions = {
     cwd,
     denyReadPaths: [WORKDIR],
@@ -414,7 +413,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
     mcpServers['repo-tools'] = createRepoToolsMcpServer(agent, task);
 
     disallowedTools = [
-      ...baseDisallowedTools,
+      ...disallowedTools,
       ...(editAllowed
         ? []
         : [

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -20,9 +20,9 @@ import { isRepoAgent, isPmAgent } from '../types/agent.js';
 import {
   createBaseAgentMcpServer,
   createRepoToolsMcpServer,
-  createPmCommsMcpServer,
-  createPmOrchestrationMcpServer,
-  createPmSchedulingMcpServer,
+  createCommsMcpServer,
+  createOrchestrationMcpServer,
+  createSchedulingMcpServer,
 } from './tools.js';
 import { hydrateBranchState } from '../connectors/github/branch-state.js';
 import { createResearchMcpServer, createResearchPostToolHook, createResearchDefenseTagHook } from '../mcp/research-tools.js';
@@ -385,9 +385,9 @@ Shared folder: ${sharedPath} [READ-ONLY]
     }
 
     mcpServers['agent-tools'] = createBaseAgentMcpServer(agent, task);
-    mcpServers['pm-comms'] = createPmCommsMcpServer(agent, task);
-    mcpServers['pm-orchestration'] = createPmOrchestrationMcpServer(agent, task);
-    mcpServers['pm-scheduling'] = createPmSchedulingMcpServer(agent, task);
+    mcpServers['comms-tools'] = createCommsMcpServer(agent, task);
+    mcpServers['orchestration-tools'] = createOrchestrationMcpServer(agent, task);
+    mcpServers['scheduling-tools'] = createSchedulingMcpServer(agent, task);
   } else if (isRepoAgent(def)) {
     // ---- Repo access attached ----
     const { repoPath, editAllowed, baseObjectsPath, currentBranch } = await prepareRepoClone(agent, task);

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -311,9 +311,11 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     denyWritePaths: [sharedPath, ...pluginPaths, ...protectedWorkspaceFiles],
     allowedNetworkDomains: def.allowedNetworkDomains,
   };
-  // Common to all agents; each branch adds its own agent-tools server.
+  // Base servers every agent gets; branches add their own (repo-tools, the PM
+  // coordinator servers, etc.) on top.
   const mcpServers: Record<string, any> = {
     ...(def.mcpServers || {}),
+    'agent-tools': createBaseAgentMcpServer(agent, task),
     'research-tools': researchServer,
   };
 
@@ -384,7 +386,6 @@ Shared folder: ${sharedPath} [READ-ONLY]
       systemPrompt = `${systemPrompt}\n\n${def.pmOverlayPrompt}`;
     }
 
-    mcpServers['agent-tools'] = createBaseAgentMcpServer(agent, task);
     mcpServers['comms-tools'] = createCommsMcpServer(agent, task);
     mcpServers['orchestration-tools'] = createOrchestrationMcpServer(agent, task);
     mcpServers['scheduling-tools'] = createSchedulingMcpServer(agent, task);
@@ -410,7 +411,6 @@ Shared folder: ${sharedPath} [READ-ONLY]
 
     additionalDirectories = [repoPath, ...additionalDirectories];
 
-    mcpServers['agent-tools'] = createBaseAgentMcpServer(agent, task);
     mcpServers['repo-tools'] = createRepoToolsMcpServer(agent, task);
 
     disallowedTools = [
@@ -463,7 +463,6 @@ Shared folder: ${sharedPath} [READ-ONLY]
 `;
     systemPrompt = `${systemPrompt}\n\nCurrent Context:\n${context}`;
 
-    mcpServers['agent-tools'] = createBaseAgentMcpServer(agent, task);
   }
 
   // Expose the sandbox config on the agent so in-process tools (e.g.

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -18,9 +18,11 @@ import type { Agent } from './agent.js';
 import type { Task } from '../tasks/task.js';
 import { isRepoAgent, isPmAgent } from '../types/agent.js';
 import {
-  createPMAgentMcpServer,
   createBaseAgentMcpServer,
   createRepoToolsMcpServer,
+  createPmCommsMcpServer,
+  createPmOrchestrationMcpServer,
+  createPmSchedulingMcpServer,
 } from './tools.js';
 import { hydrateBranchState } from '../connectors/github/branch-state.js';
 import { createResearchMcpServer, createResearchPostToolHook, createResearchDefenseTagHook } from '../mcp/research-tools.js';
@@ -382,7 +384,10 @@ Shared folder: ${sharedPath} [READ-ONLY]
       systemPrompt = `${systemPrompt}\n\n${def.pmOverlayPrompt}`;
     }
 
-    mcpServers['pm-agent-tools'] = createPMAgentMcpServer(agent, task);
+    mcpServers['agent-tools'] = createBaseAgentMcpServer(agent, task);
+    mcpServers['pm-comms'] = createPmCommsMcpServer(agent, task);
+    mcpServers['pm-orchestration'] = createPmOrchestrationMcpServer(agent, task);
+    mcpServers['pm-scheduling'] = createPmSchedulingMcpServer(agent, task);
   } else if (isRepoAgent(def)) {
     // ---- Repo access attached ----
     const { repoPath, editAllowed, baseObjectsPath, currentBranch } = await prepareRepoClone(agent, task);

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -405,7 +405,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
 
     additionalDirectories = [repoPath, ...additionalDirectories];
 
-    mcpServers['repo-agent-tools'] = createBaseAgentMcpServer(agent, task);
+    mcpServers['agent-tools'] = createBaseAgentMcpServer(agent, task);
     mcpServers['repo-tools'] = createRepoToolsMcpServer(agent, task);
 
     disallowedTools = [
@@ -458,7 +458,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
 `;
     systemPrompt = `${systemPrompt}\n\nCurrent Context:\n${context}`;
 
-    mcpServers['repo-agent-tools'] = createBaseAgentMcpServer(agent, task);
+    mcpServers['agent-tools'] = createBaseAgentMcpServer(agent, task);
   }
 
   // Expose the sandbox config on the agent so in-process tools (e.g.

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -161,27 +161,60 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   }
   const useClaudeDirs = hasClaudeDirs || !agent.session.session_id;
 
-  // ---- Build track-specific config ----
+  // ---- Shared scaffolding (all agents) ----
+  //
+  // Every agent gets a workspace, the same research-tools server, the same base
+  // tool set, and the same base filesystem boundaries. Repo access and the PM
+  // coordinator role are layered on top of this.
+
+  const workspace = await setupAgentWorkspace(taskId, agent);
+  const cwd = workspace;
+  const model = def.model || (isPmAgent(def) ? 'opus' : 'sonnet');
+  const tools = def.tools;
+  const baseDisallowedTools = ['WebSearch', 'WebFetch', ...(def.disallowedTools || [])];
+
+  const pluginPaths = def.pluginPath ? [def.pluginPath] : [];
+  const pluginReadPaths = [...pluginPaths, ...(def.pluginDataPath ? [def.pluginDataPath] : [])];
+  const claudeReadDirs = useClaudeDirs ? [claudeConfigDir, claudeTmpDir] : [];
+  const claudeWriteDirs = useClaudeDirs ? [claudeTmpDir] : [];
+  const protectedWorkspaceFiles = [
+    join(workspace, '.claude', 'settings.json'),
+    join(workspace, '.claude', 'skills'),
+    join(workspace, '.claude', 'hooks'),
+    join(workspace, 'CLAUDE.md'),
+  ];
+
+  const researchServer = createResearchMcpServer({
+    getTaskId: () => taskId,
+    getResearchesDir: () => join(getTaskPath(taskId), 'researches'),
+    getCallerAgentId: () => def.id,
+    checkResearchBudget: () => task.checkResearchBudget(),
+    incrementResearchCount: () => task.incrementResearchCount(),
+    onResearchBudgetExceeded: () => task.onResearchBudgetExceeded(),
+  });
+
+  // Standard (non-repo) filesystem sandbox — shared by the PM and plugin agents.
+  const standardSandbox: SandboxOptions = {
+    cwd,
+    denyReadPaths: [WORKDIR],
+    allowReadPaths: [workspace, sharedPath, ...claudeReadDirs, ...pluginReadPaths],
+    allowWritePaths: [workspace, ...claudeWriteDirs],
+    denyWritePaths: [sharedPath, ...pluginPaths, ...protectedWorkspaceFiles],
+    allowedNetworkDomains: def.allowedNetworkDomains,
+  };
+
+  // ---- Per-agent layers ----
 
   let systemPrompt: string;
-  let cwd: string;
-  let additionalDirectories: string[] | undefined;
+  let additionalDirectories: string[];
   let mcpServers: Record<string, any>;
-  let disallowedTools: string[] | undefined;
-  let tools: string[] | undefined;
+  let disallowedTools: string[];
   let sandboxOpts: SandboxOptions;
-  let model: string;
 
   if (isPmAgent(def)) {
     // ---- PM coordinator ----
-    const pmWorkspace = await setupAgentWorkspace(taskId, agent);
     systemPrompt = await generatePMPrompt(task);
-    model = (def.model || 'opus') as string;
-    cwd = pmWorkspace;
-    additionalDirectories = [sharedPath];
-    if (def.pluginPath) {
-      additionalDirectories.push(def.pluginPath);
-    }
+    additionalDirectories = [sharedPath, ...pluginPaths];
 
     const channelEntries = Object.entries(metadata.channels);
     const renderChannel = (id: string, ch: typeof metadata.channels[string]): string => {
@@ -230,7 +263,7 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     const context = `
 ${contextLines.join('\n')}
 
-Working directory (cwd): ${pmWorkspace} [READ-WRITE]
+Working directory (cwd): ${workspace} [READ-WRITE]
 
 Shared folder: ${sharedPath} [READ-ONLY]
   - knowledge.log — conversation history and agent findings
@@ -249,43 +282,12 @@ Shared folder: ${sharedPath} [READ-ONLY]
     mcpServers = {
       ...(def.mcpServers || {}),
       'pm-agent-tools': createPMAgentMcpServer(agent, task),
-      'research-tools': createResearchMcpServer({
-        getTaskId: () => taskId,
-        getResearchesDir: () => join(getTaskPath(taskId), 'researches'),
-        getCallerAgentId: () => 'pm-agent',
-        checkResearchBudget: () => task.checkResearchBudget(),
-        incrementResearchCount: () => task.incrementResearchCount(),
-        onResearchBudgetExceeded: () => task.onResearchBudgetExceeded(),
-      }),
+      'research-tools': researchServer,
     };
-
-    tools = def.tools;
-    disallowedTools = [
-      'WebSearch', 'WebFetch',
-      ...(def.disallowedTools || []),
-    ];
-    sandboxOpts = {
-      cwd: pmWorkspace,
-      denyReadPaths: [WORKDIR],
-      allowReadPaths: [
-        pmWorkspace, sharedPath, ...(useClaudeDirs ? [claudeConfigDir, claudeTmpDir] : []),
-        ...(def.pluginPath ? [def.pluginPath] : []),
-        ...(def.pluginDataPath ? [def.pluginDataPath] : []),
-      ],
-      allowWritePaths: [pmWorkspace, ...(useClaudeDirs ? [claudeTmpDir] : [])],
-      denyWritePaths: [
-        sharedPath,
-        ...(def.pluginPath ? [def.pluginPath] : []),
-        join(pmWorkspace, '.claude', 'settings.json'),
-        join(pmWorkspace, '.claude', 'skills'),
-        join(pmWorkspace, '.claude', 'hooks'),
-        join(pmWorkspace, 'CLAUDE.md'),
-      ],
-      allowedNetworkDomains: def.allowedNetworkDomains,
-    };
+    disallowedTools = baseDisallowedTools;
+    sandboxOpts = standardSandbox;
   } else if (isRepoAgent(def)) {
     // ---- Repo access attached ----
-    const repoWorkspace = await setupAgentWorkspace(taskId, agent);
     const repoInfo = metadata.repositories[def.repo!.repoKey];
     const baseRepoPath = repoInfo?.path || def.repo!.defaultPath;
     const editAllowed = metadata.edit_allowed === true;
@@ -360,7 +362,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
     const context = `
 Task: ${taskId}
 
-Working directory (cwd): ${repoWorkspace} [READ-WRITE]
+Working directory (cwd): ${workspace} [READ-WRITE]
 
 Repository: ${repoPath} [${repoMode}]
   - Current branch: ${currentBranch}
@@ -371,40 +373,17 @@ Shared folder: ${sharedPath} [READ-ONLY]
 `;
     systemPrompt = `${systemPrompt}\n\nCurrent Context:\n${context}`;
 
-    cwd = repoWorkspace;
-    model = (def.model || 'sonnet') as string;
-    additionalDirectories = [repoPath, sharedPath];
-    if (def.pluginPath) {
-      additionalDirectories.push(def.pluginPath);
-    }
+    additionalDirectories = [repoPath, sharedPath, ...pluginPaths];
 
     mcpServers = {
       ...(def.mcpServers || {}),
       'repo-agent-tools': createBaseAgentMcpServer(agent, task),
       'repo-tools': createRepoToolsMcpServer(agent, task),
-      'research-tools': createResearchMcpServer({
-        getTaskId: () => taskId,
-        getResearchesDir: () => join(getTaskPath(taskId), 'researches'),
-        getCallerAgentId: () => def.id,
-        checkResearchBudget: () => task.checkResearchBudget(),
-        incrementResearchCount: () => task.incrementResearchCount(),
-        onResearchBudgetExceeded: () => task.onResearchBudgetExceeded(),
-      }),
+      'research-tools': researchServer,
     };
 
-    const denyWriteProtected = [
-      // Protect SDK config in cwd (agent workspace)
-      join(repoWorkspace, '.claude', 'settings.json'),
-      join(repoWorkspace, '.claude', 'skills'),
-      join(repoWorkspace, '.claude', 'hooks'),
-      join(repoWorkspace, 'CLAUDE.md'),
-      // Prevent agent from switching branches (git checkout/switch writes .git/HEAD)
-      join(repoPath, '.git', 'HEAD'),
-    ];
-
-    tools = def.tools;
     disallowedTools = [
-      'WebSearch', 'WebFetch',
+      ...baseDisallowedTools,
       ...(editAllowed
         ? []
         : [
@@ -421,43 +400,32 @@ Shared folder: ${sharedPath} [READ-ONLY]
             'mcp__repo-tools__close_pull_request',
             'mcp__repo-tools__create_branch',
           ]),
-      ...(def.disallowedTools || []),
-    ];
-    const readOnlyPaths = [
-      sharedPath, baseObjectsPath,
-      ...(def.pluginPath ? [def.pluginPath] : []),
-      ...(def.pluginDataPath ? [def.pluginDataPath] : []),
     ];
 
-    if (editAllowed) {
-      sandboxOpts = {
-        cwd,
-        denyReadPaths: [WORKDIR],
-        allowReadPaths: [repoWorkspace, repoPath, ...(useClaudeDirs ? [claudeConfigDir, claudeTmpDir] : []), ...readOnlyPaths],
-        allowWritePaths: [repoWorkspace, repoPath, ...(useClaudeDirs ? [claudeTmpDir] : [])],
-        denyWritePaths: [...readOnlyPaths, ...denyWriteProtected],
-        allowedNetworkDomains: def.allowedNetworkDomains,
-      };
-    } else {
-      sandboxOpts = {
-        cwd,
-        denyReadPaths: [WORKDIR],
-        allowReadPaths: [repoWorkspace, repoPath, ...(useClaudeDirs ? [claudeConfigDir, claudeTmpDir] : []), ...readOnlyPaths],
-        allowWritePaths: [repoWorkspace, ...(useClaudeDirs ? [claudeTmpDir] : [])],
-        denyWritePaths: [repoPath, ...readOnlyPaths],
-        allowedNetworkDomains: def.allowedNetworkDomains,
-      };
-    }
+    // Repo agents extend the base sandbox with the clone (RW in edit mode) and
+    // a few repo-specific read-only/protected paths.
+    const readOnlyPaths = [sharedPath, baseObjectsPath, ...pluginReadPaths];
+    sandboxOpts = {
+      cwd,
+      denyReadPaths: [WORKDIR],
+      allowReadPaths: [workspace, repoPath, ...claudeReadDirs, ...readOnlyPaths],
+      allowWritePaths: editAllowed
+        ? [workspace, repoPath, ...claudeWriteDirs]
+        : [workspace, ...claudeWriteDirs],
+      denyWritePaths: editAllowed
+        ? [...readOnlyPaths, ...protectedWorkspaceFiles, join(repoPath, '.git', 'HEAD')]
+        : [repoPath, ...readOnlyPaths],
+      allowedNetworkDomains: def.allowedNetworkDomains,
+    };
   } else {
     // ---- Plain plugin agent ----
-    const agentWorkspace = await setupAgentWorkspace(taskId, agent);
-
     systemPrompt = await generatePluginAgentPrompt(agent);
+    additionalDirectories = [sharedPath, ...pluginPaths];
     const context = `
 Task: ${taskId}
 Plugin: ${def.pluginName}
 
-Working directory (cwd): ${agentWorkspace} [READ-WRITE]
+Working directory (cwd): ${workspace} [READ-WRITE]
 
 Shared folder: ${sharedPath} [READ-ONLY]
   - knowledge.log — conversation history and agent findings (read ONCE per message, don't poll)
@@ -465,50 +433,13 @@ Shared folder: ${sharedPath} [READ-ONLY]
 `;
     systemPrompt = `${systemPrompt}\n\nCurrent Context:\n${context}`;
 
-    cwd = agentWorkspace;
-    additionalDirectories = [sharedPath];
-    if (def.pluginPath) {
-      additionalDirectories.push(def.pluginPath);
-    }
-    model = (def.model || 'sonnet') as string;
-
     mcpServers = {
       ...(def.mcpServers || {}),
       'repo-agent-tools': createBaseAgentMcpServer(agent, task),
-      'research-tools': createResearchMcpServer({
-        getTaskId: () => taskId,
-        getResearchesDir: () => join(getTaskPath(taskId), 'researches'),
-        getCallerAgentId: () => def.id,
-        checkResearchBudget: () => task.checkResearchBudget(),
-        incrementResearchCount: () => task.incrementResearchCount(),
-        onResearchBudgetExceeded: () => task.onResearchBudgetExceeded(),
-      }),
+      'research-tools': researchServer,
     };
-
-    tools = def.tools;
-    disallowedTools = [
-      'WebSearch', 'WebFetch',
-      ...(def.disallowedTools || []),
-    ];
-    sandboxOpts = {
-      cwd: agentWorkspace,
-      denyReadPaths: [WORKDIR],
-      allowReadPaths: [
-        agentWorkspace, sharedPath, ...(useClaudeDirs ? [claudeConfigDir, claudeTmpDir] : []),
-        ...(def.pluginPath ? [def.pluginPath] : []),
-        ...(def.pluginDataPath ? [def.pluginDataPath] : []),
-      ],
-      allowWritePaths: [agentWorkspace, ...(useClaudeDirs ? [claudeTmpDir] : [])],
-      denyWritePaths: [
-        sharedPath,
-        ...(def.pluginPath ? [def.pluginPath] : []),
-        join(agentWorkspace, '.claude', 'settings.json'),
-        join(agentWorkspace, '.claude', 'skills'),
-        join(agentWorkspace, '.claude', 'hooks'),
-        join(agentWorkspace, 'CLAUDE.md'),
-      ],
-      allowedNetworkDomains: def.allowedNetworkDomains,
-    };
+    disallowedTools = baseDisallowedTools;
+    sandboxOpts = standardSandbox;
   }
 
   // Expose the sandbox config on the agent so in-process tools (e.g.

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -292,8 +292,16 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     onResearchBudgetExceeded: () => task.onResearchBudgetExceeded(),
   });
 
-  // Standard (non-repo) filesystem sandbox — shared by the PM and plugin agents.
-  const standardSandbox: SandboxOptions = {
+  // ---- Per-agent config ----
+  //
+  // Defaults describe the plain plugin agent. The PM coordinator and repo
+  // agents deviate from these in their branches below; anything they don't
+  // touch keeps the default.
+
+  let systemPrompt: string;
+  let additionalDirectories: string[] = [sharedPath, ...pluginPaths];
+  let disallowedTools: string[] = baseDisallowedTools;
+  let sandboxOpts: SandboxOptions = {
     cwd,
     denyReadPaths: [WORKDIR],
     allowReadPaths: [workspace, sharedPath, ...claudeReadDirs, ...pluginReadPaths],
@@ -301,15 +309,11 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     denyWritePaths: [sharedPath, ...pluginPaths, ...protectedWorkspaceFiles],
     allowedNetworkDomains: def.allowedNetworkDomains,
   };
-
-  // ---- Per-agent layers ----
-
-  let systemPrompt: string;
-  // Base shared by every agent; the repo branch prepends its clone path.
-  let additionalDirectories: string[] = [sharedPath, ...pluginPaths];
-  let mcpServers: Record<string, any>;
-  let disallowedTools: string[];
-  let sandboxOpts: SandboxOptions;
+  // Common to all agents; each branch adds its own agent-tools server.
+  const mcpServers: Record<string, any> = {
+    ...(def.mcpServers || {}),
+    'research-tools': researchServer,
+  };
 
   if (isPmAgent(def)) {
     // ---- PM coordinator ----
@@ -378,13 +382,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       systemPrompt = `${systemPrompt}\n\n${def.pmOverlayPrompt}`;
     }
 
-    mcpServers = {
-      ...(def.mcpServers || {}),
-      'pm-agent-tools': createPMAgentMcpServer(agent, task),
-      'research-tools': researchServer,
-    };
-    disallowedTools = baseDisallowedTools;
-    sandboxOpts = standardSandbox;
+    mcpServers['pm-agent-tools'] = createPMAgentMcpServer(agent, task);
   } else if (isRepoAgent(def)) {
     // ---- Repo access attached ----
     const { repoPath, editAllowed, baseObjectsPath, currentBranch } = await prepareRepoClone(agent, task);
@@ -407,12 +405,8 @@ Shared folder: ${sharedPath} [READ-ONLY]
 
     additionalDirectories = [repoPath, ...additionalDirectories];
 
-    mcpServers = {
-      ...(def.mcpServers || {}),
-      'repo-agent-tools': createBaseAgentMcpServer(agent, task),
-      'repo-tools': createRepoToolsMcpServer(agent, task),
-      'research-tools': researchServer,
-    };
+    mcpServers['repo-agent-tools'] = createBaseAgentMcpServer(agent, task);
+    mcpServers['repo-tools'] = createRepoToolsMcpServer(agent, task);
 
     disallowedTools = [
       ...baseDisallowedTools,
@@ -464,13 +458,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
 `;
     systemPrompt = `${systemPrompt}\n\nCurrent Context:\n${context}`;
 
-    mcpServers = {
-      ...(def.mcpServers || {}),
-      'repo-agent-tools': createBaseAgentMcpServer(agent, task),
-      'research-tools': researchServer,
-    };
-    disallowedTools = baseDisallowedTools;
-    sandboxOpts = standardSandbox;
+    mcpServers['repo-agent-tools'] = createBaseAgentMcpServer(agent, task);
   }
 
   // Expose the sandbox config on the agent so in-process tools (e.g.

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -130,6 +130,105 @@ async function setupAgentWorkspace(taskId: string, agent: Agent): Promise<string
   return agentWorkspace;
 }
 
+// ---- Repo clone setup ----
+
+interface RepoCloneSetup {
+  /** Path to the task-local shared clone the agent works in */
+  repoPath: string;
+  /** Whether the agent may write/push (edit mode) */
+  editAllowed: boolean;
+  /** Path to the base repo's .git/objects (shared, read-only) */
+  baseObjectsPath: string;
+  /** Branch the clone is currently checked out on */
+  currentBranch: string;
+}
+
+/**
+ * Ensure a task-local shared clone exists for the agent's repo, migrating any
+ * legacy worktree and hydrating branch state. Mutates the task's repo metadata
+ * by reference. Returns the paths/flags the spawner needs to build its config.
+ */
+async function prepareRepoClone(agent: Agent, task: Task): Promise<RepoCloneSetup> {
+  const { def } = agent;
+  const taskId = task.taskId;
+  const metadata = task.metadata;
+
+  const repoInfo = metadata.repositories[def.repo!.repoKey];
+  const baseRepoPath = repoInfo?.path || def.repo!.defaultPath;
+  const editAllowed = metadata.edit_allowed === true;
+  const baseBranch = repoInfo?.base_branch || def.repo!.baseBranch || 'main';
+  const baseObjectsPath = join(baseRepoPath, '.git', 'objects');
+
+  // CWD: always a shared clone at task-local path
+  const taskRepoPath = join(getReposPath(taskId), def.repo!.repoKey);
+  let repoPath: string;
+
+  // Step A: Migrate legacy worktree → shared clone if needed
+  if (await isWorktree(taskRepoPath)) {
+    logger.agent(def.id, `Migrating worktree to shared clone`);
+    await migrateWorktreeToClone(
+      def.repo!.repoKey, getReposPath(taskId), baseRepoPath,
+      baseBranch, def.repo!.githubRepo, repoInfo, editAllowed,
+    );
+  }
+
+  // Step B: Reuse existing clone or create new one
+  if (await cloneExists(taskRepoPath)) {
+    repoPath = taskRepoPath;
+    logger.agent(def.id, `Reusing existing clone at ${repoPath}`, { editMode: editAllowed });
+  } else {
+    const previousBranch = repoInfo?.current_branch;
+    const wasOnBaseBranch = !previousBranch || previousBranch === baseBranch;
+
+    let checkout: CloneCheckout;
+    if (editAllowed && wasOnBaseBranch) {
+      // RW mode, was on base branch (or no branch) — create feature branch for new work
+      checkout = { type: 'new_branch', name: `feature/${taskId}` };
+    } else if (editAllowed && !wasOnBaseBranch) {
+      // RW but was on a specific branch — restore it
+      checkout = { type: 'branch', name: previousBranch! };
+    } else {
+      // RO default: clone on base branch
+      checkout = { type: 'base' };
+    }
+
+    const result = await setupSharedClone(
+      def.repo!.repoKey, getReposPath(taskId), baseRepoPath,
+      checkout, baseBranch, def.repo!.githubRepo,
+    );
+    repoPath = result.clone_path;
+
+    if (result.branch !== result.base_branch) {
+      hydrateBranchState(repoInfo, result.branch, result.base_branch);
+    } else {
+      repoInfo.current_branch = result.branch;
+    }
+    logger.agent(def.id, `Created shared clone at ${repoPath} (${result.branch})`, { editMode: editAllowed });
+  }
+
+  // Configure git identity for the clone
+  await configureGitIdentity(repoPath);
+
+  // Update metadata
+  repoInfo.clone_path = repoPath;
+  metadata.repositories[def.repo!.repoKey] = { ...repoInfo, path: baseRepoPath };
+
+  // Legacy hydration: old tasks with feature_branch but no branch_states
+  if (repoInfo.feature_branch && !repoInfo.branch_states) {
+    hydrateBranchState(repoInfo, repoInfo.feature_branch, repoInfo.base_branch);
+    const state = repoInfo.branch_states![repoInfo.feature_branch];
+    state.pr_number = repoInfo.pr_number;
+    state.last_processed_comment_id = repoInfo.last_processed_comment_id;
+  }
+
+  return {
+    repoPath,
+    editAllowed,
+    baseObjectsPath,
+    currentBranch: repoInfo.current_branch || baseBranch,
+  };
+}
+
 // ---- Main spawner ----
 
 /**
@@ -206,7 +305,8 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   // ---- Per-agent layers ----
 
   let systemPrompt: string;
-  let additionalDirectories: string[];
+  // Base shared by every agent; the repo branch prepends its clone path.
+  let additionalDirectories: string[] = [sharedPath, ...pluginPaths];
   let mcpServers: Record<string, any>;
   let disallowedTools: string[];
   let sandboxOpts: SandboxOptions;
@@ -214,7 +314,6 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   if (isPmAgent(def)) {
     // ---- PM coordinator ----
     systemPrompt = await generatePMPrompt(task);
-    additionalDirectories = [sharedPath, ...pluginPaths];
 
     const channelEntries = Object.entries(metadata.channels);
     const renderChannel = (id: string, ch: typeof metadata.channels[string]): string => {
@@ -288,76 +387,9 @@ Shared folder: ${sharedPath} [READ-ONLY]
     sandboxOpts = standardSandbox;
   } else if (isRepoAgent(def)) {
     // ---- Repo access attached ----
-    const repoInfo = metadata.repositories[def.repo!.repoKey];
-    const baseRepoPath = repoInfo?.path || def.repo!.defaultPath;
-    const editAllowed = metadata.edit_allowed === true;
-    const baseBranch = repoInfo?.base_branch || def.repo!.baseBranch || 'main';
-    const baseObjectsPath = join(baseRepoPath, '.git', 'objects');
-
-    // CWD: always a shared clone at task-local path
-    const taskRepoPath = join(getReposPath(taskId), def.repo!.repoKey);
-    let repoPath: string;
-
-    // Step A: Migrate legacy worktree → shared clone if needed
-    if (await isWorktree(taskRepoPath)) {
-      logger.agent(def.id, `Migrating worktree to shared clone`);
-      await migrateWorktreeToClone(
-        def.repo!.repoKey, getReposPath(taskId), baseRepoPath,
-        baseBranch, def.repo!.githubRepo, repoInfo, editAllowed,
-      );
-    }
-
-    // Step B: Reuse existing clone or create new one
-    if (await cloneExists(taskRepoPath)) {
-      repoPath = taskRepoPath;
-      logger.agent(def.id, `Reusing existing clone at ${repoPath}`, { editMode: editAllowed });
-    } else {
-      const previousBranch = repoInfo?.current_branch;
-      const wasOnBaseBranch = !previousBranch || previousBranch === baseBranch;
-
-      let checkout: CloneCheckout;
-      if (editAllowed && wasOnBaseBranch) {
-        // RW mode, was on base branch (or no branch) — create feature branch for new work
-        checkout = { type: 'new_branch', name: `feature/${taskId}` };
-      } else if (editAllowed && !wasOnBaseBranch) {
-        // RW but was on a specific branch — restore it
-        checkout = { type: 'branch', name: previousBranch! };
-      } else {
-        // RO default: clone on base branch
-        checkout = { type: 'base' };
-      }
-
-      const result = await setupSharedClone(
-        def.repo!.repoKey, getReposPath(taskId), baseRepoPath,
-        checkout, baseBranch, def.repo!.githubRepo,
-      );
-      repoPath = result.clone_path;
-
-      if (result.branch !== result.base_branch) {
-        hydrateBranchState(repoInfo, result.branch, result.base_branch);
-      } else {
-        repoInfo.current_branch = result.branch;
-      }
-      logger.agent(def.id, `Created shared clone at ${repoPath} (${result.branch})`, { editMode: editAllowed });
-    }
-
-    // Configure git identity for the clone
-    await configureGitIdentity(repoPath);
-
-    // Update metadata
-    repoInfo.clone_path = repoPath;
-    metadata.repositories[def.repo!.repoKey] = { ...repoInfo, path: baseRepoPath };
-
-    // Legacy hydration: old tasks with feature_branch but no branch_states
-    if (repoInfo.feature_branch && !repoInfo.branch_states) {
-      hydrateBranchState(repoInfo, repoInfo.feature_branch, repoInfo.base_branch);
-      const state = repoInfo.branch_states![repoInfo.feature_branch];
-      state.pr_number = repoInfo.pr_number;
-      state.last_processed_comment_id = repoInfo.last_processed_comment_id;
-    }
+    const { repoPath, editAllowed, baseObjectsPath, currentBranch } = await prepareRepoClone(agent, task);
 
     systemPrompt = await generateRepoAgentPrompt(agent);
-    const currentBranch = repoInfo.current_branch || baseBranch;
     const repoMode = editAllowed ? 'READ-WRITE' : 'READ-ONLY';
     const context = `
 Task: ${taskId}
@@ -373,7 +405,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
 `;
     systemPrompt = `${systemPrompt}\n\nCurrent Context:\n${context}`;
 
-    additionalDirectories = [repoPath, sharedPath, ...pluginPaths];
+    additionalDirectories = [repoPath, ...additionalDirectories];
 
     mcpServers = {
       ...(def.mcpServers || {}),
@@ -420,7 +452,6 @@ Shared folder: ${sharedPath} [READ-ONLY]
   } else {
     // ---- Plain plugin agent ----
     systemPrompt = await generatePluginAgentPrompt(agent);
-    additionalDirectories = [sharedPath, ...pluginPaths];
     const context = `
 Task: ${taskId}
 Plugin: ${def.pluginName}
@@ -457,9 +488,8 @@ Shared folder: ${sharedPath} [READ-ONLY]
     model: model as any,
     systemPrompt,
     cwd,
-    ...(additionalDirectories ? { additionalDirectories: additionalDirectories as any } : {}),
+    additionalDirectories: additionalDirectories as any,
     executable: 'node' as const,
-    // pathToClaudeCodeExecutable: process.env.CLAUDE_PATH || 'claude',
     settingSources: ['project'] as any,
     env: {
       NODE_ENV: process.env.NODE_ENV || 'development',
@@ -475,7 +505,6 @@ Shared folder: ${sharedPath} [READ-ONLY]
     },
     resume: sessionId,
     maxTurns: def.maxTurns ?? 100,
-    // thinking: { type: 'adaptive' } as const,
     ...(def.effort ? { effort: def.effort } : {}),
     permissionMode: 'bypassPermissions' as const,
     allowDangerouslySkipPermissions: true,
@@ -541,7 +570,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
             processAgentEventForLogging(
               event,
               def.id,
-              additionalDirectories || [cwd],
+              additionalDirectories,
               isRepoAgent(def) && metadata.edit_allowed === true,
             );
           }

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -1394,28 +1394,50 @@ function createCancelReminderTool(agent: Agent, task: Task) {
 // ---- MCP Server creation ----
 
 /**
- * Create the MCP server with PM agent tools.
+ * PM coordinator tools, split by concern. The PM also gets the shared
+ * `agent-tools` server (send_message_to_agent, log_finding, share_artifact),
+ * so those are not repeated here.
  */
-export function createPMAgentMcpServer(agent: Agent, task: Task) {
+
+/** User-facing communication (Slack messaging, lookups, channel control, reactions). */
+export function createPmCommsMcpServer(agent: Agent, task: Task) {
   return createSdkMcpServer({
-    name: 'pm-agent-tools',
+    name: 'pm-comms',
     version: '1.0.0',
     tools: [
-      createSendMessageTool(agent, task),
       createPostToUserTool(agent, task),
       createPostFilesToUserTool(agent, task),
-      createShareArtifactTool(agent, task),
       createFindSlackUserTool(agent, task),
       createFindSlackChannelTool(agent, task),
-      createAssignTaskOwnerTool(agent, task),
-      createReportCompletionTool(agent, task),
-      createRequestEditModeTool(agent, task),
-      createGetAgentsStatusTool(agent, task),
       createMuteChannelTool(agent, task),
       createReactToMessageTool(agent, task),
       createUnreactFromMessageTool(agent, task),
       createGetMessageReactionsTool(agent, task),
+    ],
+  });
+}
+
+/** Task orchestration (ownership, completion, edit mode, team status, spawning). */
+export function createPmOrchestrationMcpServer(agent: Agent, task: Task) {
+  return createSdkMcpServer({
+    name: 'pm-orchestration',
+    version: '1.0.0',
+    tools: [
+      createAssignTaskOwnerTool(agent, task),
+      createReportCompletionTool(agent, task),
+      createRequestEditModeTool(agent, task),
+      createGetAgentsStatusTool(agent, task),
       createLaunchTaskTool(agent, task),
+    ],
+  });
+}
+
+/** Scheduling (datetime parsing and reminders). */
+export function createPmSchedulingMcpServer(agent: Agent, task: Task) {
+  return createSdkMcpServer({
+    name: 'pm-scheduling',
+    version: '1.0.0',
+    tools: [
       createParseDatetimeTool(agent, task),
       createSetReminderTool(agent, task),
       createCancelReminderTool(agent, task),
@@ -1462,7 +1484,8 @@ export function createRepoToolsMcpServer(agent: Agent, task: Task) {
 }
 
 /**
- * Create the MCP server with base agent tools (repo + plugin agents).
+ * Create the MCP server with base agent tools shared by every agent
+ * (PM, repo, and plugin): inter-agent messaging, findings, and artifacts.
  */
 export function createBaseAgentMcpServer(agent: Agent, task: Task) {
   return createSdkMcpServer({

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -1466,7 +1466,7 @@ export function createRepoToolsMcpServer(agent: Agent, task: Task) {
  */
 export function createBaseAgentMcpServer(agent: Agent, task: Task) {
   return createSdkMcpServer({
-    name: 'repo-agent-tools',
+    name: 'agent-tools',
     version: '1.0.0',
     tools: [
       createSendMessageTool(agent, task),

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -1400,9 +1400,9 @@ function createCancelReminderTool(agent: Agent, task: Task) {
  */
 
 /** User-facing communication (Slack messaging, lookups, channel control, reactions). */
-export function createPmCommsMcpServer(agent: Agent, task: Task) {
+export function createCommsMcpServer(agent: Agent, task: Task) {
   return createSdkMcpServer({
-    name: 'pm-comms',
+    name: 'comms-tools',
     version: '1.0.0',
     tools: [
       createPostToUserTool(agent, task),
@@ -1418,9 +1418,9 @@ export function createPmCommsMcpServer(agent: Agent, task: Task) {
 }
 
 /** Task orchestration (ownership, completion, edit mode, team status, spawning). */
-export function createPmOrchestrationMcpServer(agent: Agent, task: Task) {
+export function createOrchestrationMcpServer(agent: Agent, task: Task) {
   return createSdkMcpServer({
-    name: 'pm-orchestration',
+    name: 'orchestration-tools',
     version: '1.0.0',
     tools: [
       createAssignTaskOwnerTool(agent, task),
@@ -1433,9 +1433,9 @@ export function createPmOrchestrationMcpServer(agent: Agent, task: Task) {
 }
 
 /** Scheduling (datetime parsing and reminders). */
-export function createPmSchedulingMcpServer(agent: Agent, task: Task) {
+export function createSchedulingMcpServer(agent: Agent, task: Task) {
   return createSdkMcpServer({
-    name: 'pm-scheduling',
+    name: 'scheduling-tools',
     version: '1.0.0',
     tools: [
       createParseDatetimeTool(agent, task),

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { bootstrapWorkdir, cloneRepos, OAUTH_DIR } from './system/workdir.js';
 import { validateMasterKey } from './system/secrets-vault.js';
 import { initPlugins, getPlugins } from './system/plugin-loader.js';
 import { initRegistry, getAllAgentDefs } from './agents/registry.js';
-import { isRepoAgent, isPmAgent, isPluginAgent } from './types/agent.js';
+import { isRepoAgent, isPmAgent } from './types/agent.js';
 import { configureGitIdentity } from './connectors/github/client.js';
 import { recoverActiveTasks } from './tasks/recovery.js';
 import { initEventPersistence } from './tasks/persistence.js';
@@ -147,7 +147,7 @@ async function main(): Promise<void> {
         logger.plain(`    mcp: ${Object.keys(def.mcpServers).join(', ')}`);
       }
     }
-    for (const def of agentDefs.filter(isPluginAgent)) {
+    for (const def of agentDefs.filter((d) => !isPmAgent(d) && !isRepoAgent(d))) {
       logger.plain(`  [${def.pluginName}] ${def.id} (${def.visibility}) — ${def.role}`);
       if (def.mcpServers) {
         logger.plain(`    mcp: ${Object.keys(def.mcpServers).join(', ')}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { bootstrapWorkdir, cloneRepos, OAUTH_DIR } from './system/workdir.js';
 import { validateMasterKey } from './system/secrets-vault.js';
 import { initPlugins, getPlugins } from './system/plugin-loader.js';
 import { initRegistry, getAllAgentDefs } from './agents/registry.js';
+import { isRepoAgent, isPmAgent, isPluginAgent } from './types/agent.js';
 import { configureGitIdentity } from './connectors/github/client.js';
 import { recoverActiveTasks } from './tasks/recovery.js';
 import { initEventPersistence } from './tasks/persistence.js';
@@ -97,7 +98,7 @@ async function main(): Promise<void> {
 
     // Clone repos declared by plugins
     const agentDefs = getAllAgentDefs();
-    const repoDefs = agentDefs.filter((d) => d.track === 'repo');
+    const repoDefs = agentDefs.filter(isRepoAgent);
     await cloneRepos(repoDefs.map((d) => ({
       key: d.repo!.repoKey,
       githubRepo: d.repo!.githubRepo,
@@ -110,7 +111,7 @@ async function main(): Promise<void> {
     logger.plain(`Plugins loaded: ${plugins.map((p) => p.name).join(', ') || 'none'}`);
     logger.plain('');
 
-    const pmDef = agentDefs.find((d) => d.track === 'pm');
+    const pmDef = agentDefs.find(isPmAgent);
 
     logger.plain('Team:');
     logger.plain('  pm-agent (orchestrator)');
@@ -146,7 +147,7 @@ async function main(): Promise<void> {
         logger.plain(`    mcp: ${Object.keys(def.mcpServers).join(', ')}`);
       }
     }
-    for (const def of agentDefs.filter((d) => d.track === 'plugin')) {
+    for (const def of agentDefs.filter(isPluginAgent)) {
       logger.plain(`  [${def.pluginName}] ${def.id} (${def.visibility}) — ${def.role}`);
       if (def.mcpServers) {
         logger.plain(`    mcp: ${Object.keys(def.mcpServers).join(', ')}`);
@@ -161,10 +162,10 @@ async function main(): Promise<void> {
     const pluginNames = new Set(plugins.map((p) => p.name));
     pluginNames.delete('pm');
     for (const pluginName of pluginNames) {
-      const pluginAgents = agentDefs.filter((d) => d.pluginName === pluginName && d.track !== 'pm');
+      const pluginAgents = agentDefs.filter((d) => d.pluginName === pluginName && !isPmAgent(d));
       if (pluginAgents.length === 0) continue;
       const hasEntryPoint = pluginAgents.some(
-        (d) => d.visibility === 'global' || d.track === 'repo',
+        (d) => d.visibility === 'global' || isRepoAgent(d),
       );
       if (!hasEntryPoint) {
         logger.warn(

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -137,7 +137,7 @@ export class Task {
     // Build repositories map from repo agent defs
     const repositories: Record<string, { path: string }> = {};
     for (const def of team) {
-      if (def.track === 'repo' && def.repo) {
+      if (def.repo) {
         repositories[def.repo.repoKey] = { path: def.repo.defaultPath };
       }
     }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -57,12 +57,7 @@ export interface AgentHandle {
 }
 
 /**
- * Agent track — determines spawning behavior, tools, and CWD
- */
-export type AgentTrack = 'pm' | 'repo' | 'plugin';
-
-/**
- * Repo-specific fields (only for track='repo')
+ * Repo-specific fields (present only when the agent has repo access attached)
  */
 export interface AgentRepoDef {
   /** GitHub repository identifier, e.g., 'sweatco/backend' */
@@ -76,7 +71,7 @@ export interface AgentRepoDef {
 }
 
 /**
- * PM-specific fields (only for track='pm')
+ * PM-specific fields (present only on the PM coordinator agent)
  */
 export interface AgentPmDef {
   /** Formatted team list for prompt template */
@@ -89,7 +84,9 @@ export interface AgentPmDef {
  * Unified agent definition — replaces RepoAgentConfig + PluginAgentConfig
  *
  * Scanned fresh from plugins at startup and on every task start/restart.
- * One type for all three tracks: PM, repo, plugin.
+ * There is a single kind of agent; capabilities are additive:
+ *   - repo access is attached when `repo` is set
+ *   - the PM coordinator is the one agent with `isPm` set (overlaid by the pm plugin)
  */
 export interface AgentDef {
   /** Unique agent identifier, e.g., 'backend-agent', 'pm-agent' */
@@ -104,7 +101,7 @@ export interface AgentDef {
   /** Detailed expertise */
   expertise: string;
 
-  /** Model override (default per track: opus for PM, sonnet for repo/plugin) */
+  /** Model override (default: opus for PM, sonnet otherwise) */
   model?: string;
 
   /** Reasoning effort level (default: 'high') */
@@ -113,8 +110,8 @@ export interface AgentDef {
   /** Maximum agentic turns before stopping (default: 100) */
   maxTurns?: number;
 
-  /** Which track: pm, repo, or plugin */
-  track: AgentTrack;
+  /** True only for the PM coordinator agent (the core agent overlaid by the pm plugin) */
+  isPm?: boolean;
 
   /** Plugin name this agent belongs to */
   pluginName: string;
@@ -130,25 +127,25 @@ export interface AgentDef {
   /** Domain-specific prompt body (Layer 3) from agents/<key>.md */
   agentPrompt?: string;
 
-  /** Repo-specific fields (track='repo' only) */
+  /** Repo-specific fields — set only when the agent has repo access */
   repo?: AgentRepoDef;
 
-  /** Absolute path to plugin directory (track='plugin' only) */
+  /** Absolute path to plugin directory (not set on the PM coordinator) */
   pluginPath?: string;
 
   /** Absolute path to plugin's persistent data directory (workdir/plugins-data/<name>/) */
   pluginDataPath?: string;
 
-  /** Absolute path to plugin's skills/ directory (track='plugin' only) */
+  /** Absolute path to plugin's skills/ directory */
   skillsPath?: string;
 
-  /** Absolute path to archie-hq's built-in skills/ directory (track='pm' only). Symlinked alongside plugin skills. */
+  /** Absolute path to archie-hq's built-in skills/ directory (PM only). Symlinked alongside plugin skills. */
   coreSkillsPath?: string;
 
-  /** PM-specific fields (track='pm' only) — built dynamically from team */
+  /** PM-specific fields (PM only) — built dynamically from team */
   pmConfig?: AgentPmDef;
 
-  /** Extra prompt from pm plugin overlay (track='pm' only) */
+  /** Extra prompt from pm plugin overlay (PM only) */
   pmOverlayPrompt?: string;
 
   /** MCP server configs resolved from plugin's .mcp.json (server name → config) */
@@ -165,4 +162,26 @@ export interface AgentDef {
 
   /** Plugin hooks config (from plugin's hooks/hooks.json), written to .claude/settings.json */
   pluginHooks?: Record<string, any>;
+}
+
+// ---- Capability predicates ----
+//
+// There is one kind of agent. What it can do is derived from its def:
+//   - a repo agent is any agent with repo access attached
+//   - the PM coordinator is the single agent with `isPm`
+//   - everything else is a plain plugin agent
+
+/** True when the agent has repository access attached. */
+export function isRepoAgent(def: AgentDef): boolean {
+  return def.repo != null;
+}
+
+/** True for the PM coordinator (the core agent overlaid by the pm plugin). */
+export function isPmAgent(def: AgentDef): boolean {
+  return def.isPm === true;
+}
+
+/** True for a plain plugin agent — no repo access and not the PM. */
+export function isPluginAgent(def: AgentDef): boolean {
+  return !isRepoAgent(def) && !isPmAgent(def);
 }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -166,10 +166,10 @@ export interface AgentDef {
 
 // ---- Capability predicates ----
 //
-// There is one kind of agent. What it can do is derived from its def:
+// There is one kind of agent: a plain agent is the default. What it can do on
+// top of that is derived from its def:
 //   - a repo agent is any agent with repo access attached
 //   - the PM coordinator is the single agent with `isPm`
-//   - everything else is a plain plugin agent
 
 /** True when the agent has repository access attached. */
 export function isRepoAgent(def: AgentDef): boolean {
@@ -179,9 +179,4 @@ export function isRepoAgent(def: AgentDef): boolean {
 /** True for the PM coordinator (the core agent overlaid by the pm plugin). */
 export function isPmAgent(def: AgentDef): boolean {
   return def.isPm === true;
-}
-
-/** True for a plain plugin agent — no repo access and not the PM. */
-export function isPluginAgent(def: AgentDef): boolean {
-  return !isRepoAgent(def) && !isPmAgent(def);
 }


### PR DESCRIPTION
## Summary

Refactor the agent spawning system to use a single unified agent model based on capabilities rather than discrete tracks. Agents now gain repo access when `repo` is attached and the PM coordinator is identified by `isPm` flag, eliminating the three-track system (pm/repo/plugin).

## Key Changes

- **Unified agent model**: Removed `AgentTrack` enum and `track` field from `AgentDef`. Replaced with:
  - `isPm?: boolean` — identifies the PM coordinator agent
  - `repo?: AgentRepoDef` — attached when agent has repo access
  - Plain plugin agents are the default (no special fields needed)

- **Capability-based spawning**: `spawnAgent()` now branches on `isPmAgent(def)` and `isRepoAgent(def)` instead of `def.track`

- **Extracted repo clone setup**: Moved all repo preparation logic into dedicated `prepareRepoClone()` function for clarity and reusability

- **Refactored PM tools**: Split monolithic `createPMAgentMcpServer()` into three focused servers:
  - `createCommsMcpServer()` — Slack messaging, user lookups, thread control
  - `createOrchestrationMcpServer()` — task ownership, completion, edit mode, team status, spawning
  - `createSchedulingMcpServer()` — datetime parsing and reminders

- **Shared base tools**: All agents (PM, repo, plugin) now get `createBaseAgentMcpServer()` with common tools (inter-agent messaging, findings, artifacts)

- **Simplified defaults**: Established clear defaults for all agents, with PM and repo agents deviating only where needed

- **Updated tests**: Adjusted tool contract tests and registry tests to use new capability-based checks

## Implementation Details

- Added helper functions `isPmAgent()` and `isRepoAgent()` to `src/types/agent.ts` for clean capability checks
- Consolidated workspace setup and sandbox configuration into reusable patterns
- Maintained backward compatibility with legacy branch state hydration
- All agent-specific behavior (model selection, prompt generation, tool availability, sandbox rules) now flows from capabilities rather than track membership

https://claude.ai/code/session_01WW8t3dS3B8GhNkdeQBn9Yd