### PR TITLE
docker: drop broken ~/.claude bind mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,10 +66,6 @@ services:
       # can persist refreshed tokens.
       - ./secrets:/app/secrets
 
-      # Claude Code config - stores API keys, sessions, settings
-      - ./claude-data:/home/archie/.claude
-      - ./claude-data/.claude.json:/home/archie/.claude.json
-
       # Exclude node_modules (use container's version)
       - /app/node_modules
 


### PR DESCRIPTION
## Summary
- `docker-compose.yml` was bind-mounting `./claude-data` and `./claude-data/.claude.json` from the host. On first `docker compose up`, neither path existed, so Docker auto-created both as **directories** owned by the host user — leaving the container's `archie` user (UID 1001) unable to write to `~/.claude` and with `~/.claude.json` existing as a directory instead of a file.
- That trips the SDK CLI's "refuse to write to avoid wiping `~/.claude.json`" guard (GH #3117), and side-agents burn their turn budget on the auth-state retry loop. Symptoms: `[memory] Extraction agent ... returned no text` (extractor, `maxTurns: 1`) and `[title-generator] haiku call failed: error_max_turns` (title generator, `maxTurns: 2`). Local `npm run dev` was fine because it runs as the host user against the real `~/.claude`.
- Nothing in this repo actually needs `~/.claude` to persist: side-agents are one-shot `query()` calls, parent agents in `src/agents/spawn.ts` redirect `CLAUDE_CONFIG_DIR` to per-task dirs under `/workdir/sessions/`, and auth comes from `ANTHROPIC_API_KEY`. So the fix is to just drop the mounts. The SDK CLI creates `~/.claude` on demand as archie in the container's writable layer; it goes away on `docker compose down`.

## Test plan
- [x] `docker compose config` validates.
- [x] `docker compose down -v && npm run docker:dev`, post a message in Slack, then `docker compose exec archie ls -lad /home/archie/.claude` → directory exists, owned by `archie:archie` (created on demand by the SDK CLI inside the container's writable layer).
- [x] Confirm `[title-generator] ... error_max_turns` no longer fires when a new task starts.

## Notes for reviewers
- The existing `./claude-data/` directory on host (with the bogus empty `.claude.json/` subdir) is orphaned by this change and can be `rm -rf`'d locally. `.gitignore` already excludes it.
- `docs/guides/deployment.md:89-90` still shows the same risky `-v /data/claude/.claude.json:...` pattern for prod. Not changing it in this PR (separate scope / runbook), but worth dropping in a follow-up — same Docker-auto-creates-as-directory trap if the operator hasn't pre-created the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)