### PR TITLE
Add private channel and group DM support to Slack manifest

### DIFF
--- a/docs/architecture/slack-integration.md
+++ b/docs/architecture/slack-integration.md
@@ -19,7 +19,9 @@ settings:
       - app_mention
       - assistant_thread_started
       - message.channels
+      - message.groups
       - message.im
+      - message.mpim
   interactivity:
     is_enabled: true
     request_url: https://<host>/webhooks/slack
@@ -40,7 +42,7 @@ To enable Socket Mode end-to-end, also flip `socket_mode_enabled: true` in `slac
 
 ### Bot Scopes
 
-The manifest declares these bot scopes: `app_mentions:read`, `chat:write`, `channels:history`, `channels:read`, `groups:read`, `im:history`, `im:read`, `im:write`, `users:read`, `usergroups:read`, `files:read`, `files:write`, `reactions:read`, `reactions:write`, `assistant:write`. The `im:*` scopes enable DM-originated tasks; `reactions:write` powers the eyes-emoji acknowledgment pattern and the PM's `react_to_message` tool; `reactions:read` backs `get_message_reactions`; `assistant:write` is required to push generated titles to DM-rooted assistant threads via `assistant.threads.setTitle`.
+The manifest declares these bot scopes: `app_mentions:read`, `chat:write`, `channels:history`, `channels:read`, `groups:history`, `groups:read`, `im:history`, `im:read`, `im:write`, `users:read`, `usergroups:read`, `files:read`, `files:write`, `reactions:read`, `reactions:write`, `assistant:write`. The `channels:*` and `groups:*` scopes cover public and private channels respectively (`groups:history` is required to read messages and thread context in private channels); the `im:*` scopes enable DM-originated tasks; `reactions:write` powers the eyes-emoji acknowledgment pattern and the PM's `react_to_message` tool; `reactions:read` backs `get_message_reactions`; `assistant:write` is required to push generated titles to DM-rooted assistant threads via `assistant.threads.setTitle`.
 
 ## Bot Identity Detection
 
@@ -53,9 +55,9 @@ On startup, `initSlackClient()` in `src/connectors/slack/client.ts` calls `auth.
 
 The server registers two Bolt event handlers:
 
-1. **`app_mention`** -- Fires when a user mentions `@Archie` in any channel. This is the primary way users start new tasks in channels.
+1. **`app_mention`** -- Fires when a user mentions `@Archie` in any channel Archie is a member of (public or private). This is the primary way users start new tasks in channels.
 
-2. **`message`** -- Fires for thread replies and DM messages. The handler accepts an event when it is either a thread reply (`event.thread_ts && event.thread_ts !== event.ts`) or a DM (channel ID starting with `D`), and the subtype is empty / `file_share` / `thread_broadcast`. In channels, messages containing a bot mention are skipped here because `app_mention` already handles them; in DMs, mention-containing messages are processed here because `app_mention` does not fire for DMs.
+2. **`message`** -- Fires for thread replies and DM messages. Slack delivers these via four subscribed event types — `message.channels` (public channels), `message.groups` (private channels), `message.im` (DMs), and `message.mpim` (group DMs) — all of which Bolt surfaces as a single `message` event. The handler accepts an event when it is either a thread reply (`event.thread_ts && event.thread_ts !== event.ts`) or a DM (channel ID starting with `D`), and the subtype is empty / `file_share` / `thread_broadcast`. In channels, messages containing a bot mention are skipped here because `app_mention` already handles them; in DMs, mention-containing messages are processed here because `app_mention` does not fire for DMs. Note that Archie only receives private-channel events for channels it has been invited to.
 
 Both handlers run the same pipeline:
 

--- a/slack-manifest.yaml
+++ b/slack-manifest.yaml
@@ -28,6 +28,7 @@ oauth_config:
       - chat:write
       - channels:history
       - channels:read
+      - groups:history
       - groups:read
       - im:history
       - im:read
@@ -49,7 +50,9 @@ settings:
       - app_mention
       - assistant_thread_started
       - message.channels
+      - message.groups
       - message.im
+      - message.mpim
   org_deploy_enabled: false
   socket_mode_enabled: false
   token_rotation_enabled: false


### PR DESCRIPTION
## Problem

Archie was not picking up messages in **private channels**. The Slack app manifest only subscribed to public-channel and DM events, and was missing the scope needed to read private-channel history.

## Root cause

In `slack-manifest.yaml`:

- **Missing `message.groups` event subscription** — Slack delivers private-channel messages under a separate event type (`message.groups`); only `message.channels` (public) and `message.im` (DMs) were subscribed, so private-channel messages were never delivered to the webhook.
- **Missing `groups:history` scope** — the manifest had `groups:read` (can see the channel) but not `groups:history` (can read its messages / thread context).

`app_mention` could still fire on an explicit `@Archie` in a private channel, but plain messages and thread replies there were silently dropped.

## Changes

- Add `groups:history` bot scope
- Add `message.groups` (private channels) and `message.mpim` (group DMs) event subscriptions
- Update `docs/architecture/slack-integration.md` to match

## Deployment notes

After merge, this requires manual Slack-side steps:

1. Re-import `slack-manifest.yaml` in the Slack app config
2. **Reinstall the app** — the new `groups:history` scope requires re-authorization
3. Restart Archie so it picks up the re-scoped token
4. **Invite Archie into the private channel** (`/invite @Archie`) — bots only receive private-channel events for channels they're a member of

## Testing

No code changes — the existing `message` handler in `src/connectors/slack/events.ts` already keys on thread-reply / DM logic and will process the newly-arriving events. Validation is manual: post a message / thread reply in a private channel after the deployment steps above.

https://claude.ai/code/session_01G4gANWEdxPXJHdaofYaCwj

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4gANWEdxPXJHdaofYaCwj)_