### PR TITLE
Drop message.mpim event subscription from Slack manifest

### DIFF
--- a/docs/architecture/slack-integration.md
+++ b/docs/architecture/slack-integration.md
@@ -21,7 +21,6 @@ settings:
       - message.channels
       - message.groups
       - message.im
-      - message.mpim
   interactivity:
     is_enabled: true
     request_url: https://<host>/webhooks/slack
@@ -57,7 +56,7 @@ The server registers two Bolt event handlers:
 
 1. **`app_mention`** -- Fires when a user mentions `@Archie` in any channel Archie is a member of (public or private). This is the primary way users start new tasks in channels.
 
-2. **`message`** -- Fires for thread replies and DM messages. Slack delivers these via four subscribed event types — `message.channels` (public channels), `message.groups` (private channels), `message.im` (DMs), and `message.mpim` (group DMs) — all of which Bolt surfaces as a single `message` event. The handler accepts an event when it is either a thread reply (`event.thread_ts && event.thread_ts !== event.ts`) or a DM (channel ID starting with `D`), and the subtype is empty / `file_share` / `thread_broadcast`. In channels, messages containing a bot mention are skipped here because `app_mention` already handles them; in DMs, mention-containing messages are processed here because `app_mention` does not fire for DMs. Note that Archie only receives private-channel events for channels it has been invited to.
+2. **`message`** -- Fires for thread replies and DM messages. Slack delivers these via three subscribed event types — `message.channels` (public channels), `message.groups` (private channels), and `message.im` (DMs) — all of which Bolt surfaces as a single `message` event. The handler accepts an event when it is either a thread reply (`event.thread_ts && event.thread_ts !== event.ts`) or a DM (channel ID starting with `D`), and the subtype is empty / `file_share` / `thread_broadcast`. In channels, messages containing a bot mention are skipped here because `app_mention` already handles them; in DMs, mention-containing messages are processed here because `app_mention` does not fire for DMs. Note that Archie only receives private-channel events for channels it has been invited to.
 
 Both handlers run the same pipeline:
 

--- a/slack-manifest.yaml
+++ b/slack-manifest.yaml
@@ -52,7 +52,6 @@ settings:
       - message.channels
       - message.groups
       - message.im
-      - message.mpim
   org_deploy_enabled: false
   socket_mode_enabled: false
   token_rotation_enabled: false


### PR DESCRIPTION
## Context

Follow-up to #66, which added private-channel support. That PR also added a `message.mpim` (group DM) subscription as a bonus.

## Why remove it

`message.mpim` is half-wired on its own: receiving group-DM messages is fine, but reading group-DM thread history requires an `mpim:history` scope that isn't declared in the manifest. So Archie would receive the event and then fail with `missing_scope` the moment it tried to fetch thread context. Rather than ship an incomplete subscription, this removes it.

The manifest stays scoped to the cases that are fully supported end-to-end:
- `message.channels` + `channels:history` (public channels)
- `message.groups` + `groups:history` (private channels)
- `message.im` + `im:history` (DMs)

Group DMs can be added later as a complete unit (event **and** `mpim:history` scope) if needed.

## Changes

- Remove `message.mpim` from `bot_events`
- Update `docs/architecture/slack-integration.md` to match

## Deployment

Re-import the manifest in the Slack app config after merge. No reinstall needed — this only removes an event subscription, no new scopes.

https://claude.ai/code/session_01G4gANWEdxPXJHdaofYaCwj

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4gANWEdxPXJHdaofYaCwj)_