### PR TITLE
Handle Slack message edits and wake tasks for reassessment

### DIFF
--- a/docs/architecture/slack-integration.md
+++ b/docs/architecture/slack-integration.md
@@ -81,12 +81,14 @@ When a user edits a message, Slack delivers a `message` event with subtype `mess
 - **A task already follows the thread.** Resolved via `findTaskByThread(message.thread_ts || message.ts)`; edits in threads the bot was never part of are ignored, mirroring plain-reply handling.
 - **The editor is internal.** The same external/guest bail-out (`isExternalUser`) used by `handleSlackEvent` applies, and a muted channel is not woken.
 
-When they hold, mentions in both versions are resolved to the `@<ID:Name>` form (`cleanSlackText`) and `task.appendSlackEdit` writes a **fresh** knowledge-log entry — the log is append-only, so edits are never mutations of the original line. The entry reuses the original message's `msg:<ts>` id (so it correlates to the message it edits) and its body, built by the pure `renderEditForContext`, shows the new text with the previous text recorded underneath:
+When they hold, mentions in the new text are resolved to the `@<ID:Name>` form (`cleanSlackText`) and `task.appendSlackEdit` writes a **fresh** knowledge-log entry — the log is append-only, so edits are never mutations of the original line. The entry reuses the original message's `msg:<ts>` id and its body, built by the pure `renderEditForContext`, is just the new text tagged as an edit:
 
 ```
-[edited] deploy to prod
-  [previous text: "deploy to staging"]
+@<U123:Egor> in slack:#<C456:deploys>:1700000000.000100 | msg:1700000000.000100
+  [edited] deploy to prod
 ```
+
+The pre-edit text is deliberately **not** duplicated — the original message already sits in the log under the same `msg:<ts>` id, so the agent correlates the edit to it by id rather than us re-logging now-stale text.
 
 Crucially, `appendSlackEdit` does **not** advance `last_processed_ts`: an edit reuses the original message's `ts`, so touching the watermark would cause genuinely new replies to be skipped. After logging, the task is woken with the standard `AGENT_PROMPTS.existingTask` ("new input received") prompt — the agent reads the edit from the log and decides whether the change is material, taking no action when it is merely cosmetic.
 

--- a/docs/architecture/slack-integration.md
+++ b/docs/architecture/slack-integration.md
@@ -58,6 +58,8 @@ The server registers two Bolt event handlers:
 
 2. **`message`** -- Fires for thread replies and DM messages. Slack delivers these via three subscribed event types — `message.channels` (public channels), `message.groups` (private channels), and `message.im` (DMs) — all of which Bolt surfaces as a single `message` event. The handler accepts an event when it is either a thread reply (`event.thread_ts && event.thread_ts !== event.ts`) or a DM (channel ID starting with `D`), and the subtype is empty / `file_share` / `thread_broadcast`. In channels, messages containing a bot mention are skipped here because `app_mention` already handles them; in DMs, mention-containing messages are processed here because `app_mention` does not fire for DMs. Note that Archie only receives private-channel events for channels it has been invited to.
 
+   The `message` handler also branches on the **`message_changed`** subtype (a user editing a message) and routes it to `handleSlackEdit` — see [Message Edits](#message-edits) below.
+
 Both handlers run the same pipeline:
 
 ```
@@ -67,6 +69,26 @@ Slack webhook
 ```
 
 Events are processed inline with no queue — the Bolt receiver acknowledges the webhook immediately and processing continues asynchronously. The shutdown flag short-circuits handlers during graceful shutdown. See `src/connectors/slack/events.ts`.
+
+## Message Edits
+
+When a user edits a message, Slack delivers a `message` event with subtype `message_changed`, carrying both the new (`message`) and prior (`previous_message`) versions. The `message` handler routes these to `handleSlackEdit`, which treats a substantive edit like any other new input: it records the change and wakes the owning task. This matters because an edit can alter the *meaning* of an instruction (e.g. "deploy to staging" → "deploy to prod") that Archie would otherwise act on from stale text.
+
+`handleSlackEdit` only acts when **all** of these hold, otherwise it returns silently:
+
+- **The text actually changed.** Slack fires `message_changed` for link unfurls and attachment re-renders too, where `message.text === previous_message.text`. These are dropped up front — they're the dominant source of edit-event noise.
+- **The edit is not bot-authored.** Edits carrying a `bot_id`, a `bot_message` subtype, or authored by Archie's own user are skipped.
+- **A task already follows the thread.** Resolved via `findTaskByThread(message.thread_ts || message.ts)`; edits in threads the bot was never part of are ignored, mirroring plain-reply handling.
+- **The editor is internal.** The same external/guest bail-out (`isExternalUser`) used by `handleSlackEvent` applies, and a muted channel is not woken.
+
+When they hold, mentions in both versions are resolved to the `@<ID:Name>` form (`cleanSlackText`) and `task.appendSlackEdit` writes a **fresh** knowledge-log entry — the log is append-only, so edits are never mutations of the original line. The entry reuses the original message's `msg:<ts>` id (so it correlates to the message it edits) and its body, built by the pure `renderEditForContext`, shows the new text with the previous text recorded underneath:
+
+```
+[edited] deploy to prod
+  [previous text: "deploy to staging"]
+```
+
+Crucially, `appendSlackEdit` does **not** advance `last_processed_ts`: an edit reuses the original message's `ts`, so touching the watermark would cause genuinely new replies to be skipped. After logging, the task is woken with the standard `AGENT_PROMPTS.existingTask` ("new input received") prompt — the agent reads the edit from the log and decides whether the change is material, taking no action when it is merely cosmetic.
 
 ## Triage Agent (Disabled)
 

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -559,12 +559,10 @@ async function handleSlackEdit(event: any): Promise<void> {
     return;
   }
 
-  // Resolve <@U…>/<#C…> mentions in both versions to the @<ID:Name> form used
-  // throughout the knowledge log.
-  const [newText, oldText] = await Promise.all([
-    cleanSlackText(newRaw, channelId),
-    cleanSlackText(oldRaw, channelId),
-  ]);
+  // Resolve <@U…>/<#C…> mentions to the @<ID:Name> form used throughout the
+  // knowledge log. Only the new text is logged — the pre-edit text already
+  // lives in the log under the same `msg:<ts>` id.
+  const newText = await cleanSlackText(newRaw, channelId);
   const author: SlackAuthor = {
     id: msg.user,
     username: authorInfo?.name ?? msg.user,
@@ -574,7 +572,7 @@ async function handleSlackEdit(event: any): Promise<void> {
     isUltraRestricted: authorInfo?.isUltraRestricted,
   };
 
-  const recorded = await task.appendSlackEdit(channelKey, author, editedTs, oldText, newText);
+  const recorded = await task.appendSlackEdit(channelKey, author, editedTs, newText);
   if (!recorded) return;
 
   const channelLabel = channel?.type === 'slack' ? channel.channel_name : channelId;

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -25,6 +25,7 @@ import {
   isChannelShared,
   postEphemeral,
   getSlackClient,
+  cleanSlackText,
 } from './client.js';
 import { Task } from '../../tasks/task.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
@@ -33,7 +34,7 @@ import { getIsShuttingDown } from '../../system/shutdown.js';
 import { findTaskByThread } from '../../tasks/persistence.js';
 import { generateTaskTitle } from '../../tasks/title-generator.js';
 import { setAssistantThreadTitle } from './title.js';
-import type { SlackThread } from '../../types/task.js';
+import type { SlackThread, SlackAuthor } from '../../types/task.js';
 // import { triageSlackMessage } from '../../system/triage.js';
 
 /**
@@ -143,6 +144,22 @@ export async function mountSlackApp(
   // Handle thread messages (replies without @mention) and DM messages
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   app!.event('message', async ({ event }: { event: any }) => {
+    // Message edits arrive as a `message_changed` subtype carrying both the new
+    // (`message`) and prior (`previous_message`) versions. Handle these on a
+    // dedicated path: we log the edit and wake the owning task so the agent can
+    // reassess if the change is material. (Slack also fires `message_changed`
+    // for link unfurls and attachment re-renders with unchanged text — those are
+    // filtered out inside `handleSlackEdit`.)
+    if (event.subtype === 'message_changed') {
+      if (getIsShuttingDown()) {
+        logger.system('Ignoring Slack edit during shutdown');
+        return;
+      }
+      handleSlackEdit(event).catch((err: unknown) =>
+        logger.error('Server', 'Error processing Slack message edit', err));
+      return;
+    }
+
     const isDm = event.channel?.startsWith('D');
     const isThreadReply = event.thread_ts && event.thread_ts !== event.ts;
     if (
@@ -480,6 +497,89 @@ async function handleSlackEvent(event: {
     await task.sendMessage(AGENT_PROMPTS.newTask);
   }
   // Otherwise: thread reply in a thread the bot was never part of — ignore
+}
+
+/**
+ * Handle a `message_changed` event — a user edited a previously sent message.
+ *
+ * We only act when all of these hold:
+ *  - the text actually changed (Slack also fires this subtype for link unfurls
+ *    and attachment re-renders, where new and previous text are identical),
+ *  - the edit isn't bot-authored (our own posts or other integrations),
+ *  - a task already follows this thread (mirrors plain-reply handling — we never
+ *    engage a thread the bot wasn't invited to), and
+ *  - the editor is an internal (non-external/guest) user.
+ *
+ * When they hold we append an edit notice to the task's knowledge log and wake
+ * the task with the standard "new input" prompt. The agent decides whether the
+ * change is material; a cosmetic edit can simply be a no-op on its end.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function handleSlackEdit(event: any): Promise<void> {
+  const msg = event.message;
+  const prev = event.previous_message;
+  if (!msg || !msg.ts) return;
+
+  // Skip bot-authored edits (our own messages or other integrations).
+  if (msg.bot_id || msg.subtype === 'bot_message' || msg.user === getBotUserId()) return;
+
+  const oldRaw: string = prev?.text ?? '';
+  const newRaw: string = msg.text ?? '';
+  // Unchanged text = an unfurl/attachment re-render, not a human edit. Drop it.
+  if (newRaw === oldRaw) return;
+
+  const channelId: string = event.channel;
+  const editedTs: string = msg.ts;
+  const threadId: string = msg.thread_ts || msg.ts;
+
+  // Only act on threads a task already follows — same rule as plain replies.
+  const taskId = await findTaskByThread(threadId);
+  if (!taskId) return;
+
+  // External-author bail-out + author resolution in one (cached) lookup.
+  let authorInfo: Awaited<ReturnType<typeof getUserInfo>> | undefined;
+  try {
+    authorInfo = await getUserInfo(msg.user);
+    if (isExternalUser(authorInfo)) {
+      logger.system(`Skipping edit from external/guest user ${msg.user}`);
+      return;
+    }
+  } catch (error) {
+    // Fail open — if we can't classify, don't silently drop the edit.
+    logger.warn('Slack', `Failed to classify edit author ${msg.user}`, error);
+  }
+
+  const task = await Task.get(taskId);
+  const channelKey = `slack:${channelId}:${threadId}`;
+  const channel = task.metadata.channels[channelKey];
+
+  // Respect mute — a muted channel isn't woken by edits either.
+  if (channel?.type === 'slack' && channel.muted) {
+    logger.system(`Skipping edit in muted channel ${threadId}`);
+    return;
+  }
+
+  // Resolve <@U…>/<#C…> mentions in both versions to the @<ID:Name> form used
+  // throughout the knowledge log.
+  const [newText, oldText] = await Promise.all([
+    cleanSlackText(newRaw, channelId),
+    cleanSlackText(oldRaw, channelId),
+  ]);
+  const author: SlackAuthor = {
+    id: msg.user,
+    username: authorInfo?.name ?? msg.user,
+    realName: authorInfo?.realName ?? msg.user,
+    teamId: authorInfo?.teamId,
+    isRestricted: authorInfo?.isRestricted,
+    isUltraRestricted: authorInfo?.isUltraRestricted,
+  };
+
+  const recorded = await task.appendSlackEdit(channelKey, author, editedTs, oldText, newText);
+  if (!recorded) return;
+
+  const channelLabel = channel?.type === 'slack' ? channel.channel_name : channelId;
+  logger.system(`Processing edit in #${channelLabel} (msg: ${editedTs})`);
+  await task.sendMessage(AGENT_PROMPTS.existingTask);
 }
 
 const SHARED_CHANNEL_WARNING_TEXT =

--- a/src/tasks/__tests__/persistence.test.ts
+++ b/src/tasks/__tests__/persistence.test.ts
@@ -34,7 +34,7 @@ vi.mock('./task.js', () => ({
   activeTasks: new Map(),
 }));
 
-import { renderMessageForContext } from '../persistence.js';
+import { renderMessageForContext, renderEditForContext } from '../persistence.js';
 
 describe('renderMessageForContext', () => {
   it('renders plain message text with no attachments', () => {
@@ -165,5 +165,22 @@ describe('renderMessageForContext', () => {
       { redacted: false },
     );
     expect(out).toBe('top\n[forwarded from @<UG:G> — external]\nguest content');
+  });
+});
+
+describe('renderEditForContext', () => {
+  it('shows the new text and records the previous text underneath', () => {
+    const out = renderEditForContext('deploy to staging', 'deploy to prod');
+    expect(out).toBe('[edited] deploy to prod\n  [previous text: "deploy to staging"]');
+  });
+
+  it('quotes the previous text so an empty prior message is unambiguous', () => {
+    const out = renderEditForContext('', 'added later');
+    expect(out).toBe('[edited] added later\n  [previous text: ""]');
+  });
+
+  it('escapes quotes/newlines in the previous text via JSON encoding', () => {
+    const out = renderEditForContext('a\n"b"', 'c');
+    expect(out).toBe('[edited] c\n  [previous text: "a\\n\\"b\\""]');
   });
 });

--- a/src/tasks/__tests__/persistence.test.ts
+++ b/src/tasks/__tests__/persistence.test.ts
@@ -169,18 +169,13 @@ describe('renderMessageForContext', () => {
 });
 
 describe('renderEditForContext', () => {
-  it('shows the new text and records the previous text underneath', () => {
-    const out = renderEditForContext('deploy to staging', 'deploy to prod');
-    expect(out).toBe('[edited] deploy to prod\n  [previous text: "deploy to staging"]');
+  it('tags the new text as an edit and omits the previous text', () => {
+    const out = renderEditForContext('deploy to prod');
+    expect(out).toBe('[edited] deploy to prod');
   });
 
-  it('quotes the previous text so an empty prior message is unambiguous', () => {
-    const out = renderEditForContext('', 'added later');
-    expect(out).toBe('[edited] added later\n  [previous text: ""]');
-  });
-
-  it('escapes quotes/newlines in the previous text via JSON encoding', () => {
-    const out = renderEditForContext('a\n"b"', 'c');
-    expect(out).toBe('[edited] c\n  [previous text: "a\\n\\"b\\""]');
+  it('preserves multi-line new text verbatim', () => {
+    const out = renderEditForContext('line one\nline two');
+    expect(out).toBe('[edited] line one\nline two');
   });
 });

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -301,6 +301,50 @@ export async function appendSlackMessage(
 }
 
 /**
+ * Render the body of a message-edit log entry: the new text, with the prior
+ * text recorded underneath so an agent can see exactly what changed. Pure —
+ * no I/O — so it can be unit tested directly (see persistence.test.ts).
+ */
+export function renderEditForContext(oldText: string, newText: string): string {
+  return `[edited] ${newText}\n  [previous text: ${JSON.stringify(oldText)}]`;
+}
+
+/**
+ * Append a message-edit notice to the knowledge log.
+ *
+ * Records that a Slack message previously ingested into this task (identified by
+ * `editedTs`) was edited, capturing both the new and previous text so an agent
+ * can judge whether the change is material. Written as a fresh entry rather than
+ * mutating the original line — the log stays append-only and the edit auditable.
+ * The `msg:<ts>` suffix matches the id stamped by `appendSlackMessage`, so the
+ * edit correlates to the original message.
+ */
+export async function appendSlackEdit(
+  taskId: string,
+  channelInfo: { id: string; name: string },
+  threadId: string,
+  userInfo: SlackAuthor,
+  editedTs: string,
+  oldText: string,
+  newText: string,
+): Promise<void> {
+  const body = renderEditForContext(oldText, newText);
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    source: `@<${userInfo.id}:${userInfo.realName}> in ${formatSlackChannelRef(channelInfo.id, channelInfo.name, threadId)} | msg:${editedTs}`,
+    message: body,
+  };
+
+  await appendFile(getKnowledgeLogPath(taskId), formatLogEntry(entry));
+  emitEvent('message', taskId, {
+    from: userInfo.realName,
+    to: 'pm-agent',
+    destination: formatSlackChannelDisplay(channelInfo.name),
+    message: body,
+  });
+}
+
+/**
  * Append an agent finding to the knowledge log
  */
 export async function appendAgentFinding(

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -301,23 +301,25 @@ export async function appendSlackMessage(
 }
 
 /**
- * Render the body of a message-edit log entry: the new text, with the prior
- * text recorded underneath so an agent can see exactly what changed. Pure —
- * no I/O — so it can be unit tested directly (see persistence.test.ts).
+ * Render the body of a message-edit log entry: the new text, tagged as an edit.
+ * The previous text is intentionally not included — the original message is
+ * already in the log under the same `msg:<ts>` id, so an agent correlates the
+ * two by id rather than us duplicating now-stale text. Pure — no I/O — so it can
+ * be unit tested directly (see persistence.test.ts).
  */
-export function renderEditForContext(oldText: string, newText: string): string {
-  return `[edited] ${newText}\n  [previous text: ${JSON.stringify(oldText)}]`;
+export function renderEditForContext(newText: string): string {
+  return `[edited] ${newText}`;
 }
 
 /**
  * Append a message-edit notice to the knowledge log.
  *
  * Records that a Slack message previously ingested into this task (identified by
- * `editedTs`) was edited, capturing both the new and previous text so an agent
- * can judge whether the change is material. Written as a fresh entry rather than
- * mutating the original line — the log stays append-only and the edit auditable.
- * The `msg:<ts>` suffix matches the id stamped by `appendSlackMessage`, so the
- * edit correlates to the original message.
+ * `editedTs`) was edited, capturing the new text. Written as a fresh entry
+ * rather than mutating the original line — the log stays append-only and the
+ * edit auditable. The `msg:<ts>` suffix matches the id stamped by
+ * `appendSlackMessage`, so the edit correlates to the original message (whose
+ * pre-edit text remains in the log under the same id).
  */
 export async function appendSlackEdit(
   taskId: string,
@@ -325,10 +327,9 @@ export async function appendSlackEdit(
   threadId: string,
   userInfo: SlackAuthor,
   editedTs: string,
-  oldText: string,
   newText: string,
 ): Promise<void> {
-  const body = renderEditForContext(oldText, newText);
+  const body = renderEditForContext(newText);
   const entry: LogEntry = {
     timestamp: new Date().toISOString(),
     source: `@<${userInfo.id}:${userInfo.realName}> in ${formatSlackChannelRef(channelInfo.id, channelInfo.name, threadId)} | msg:${editedTs}`,

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -6,7 +6,7 @@
  */
 
 import { mkdir, writeFile } from 'fs/promises';
-import type { AgentName, SlackChannel, SlackThread, SlackReaction, TaskMetadata } from '../types/task.js';
+import type { AgentName, SlackAuthor, SlackChannel, SlackThread, SlackReaction, TaskMetadata } from '../types/task.js';
 import { CLI_CHANNEL_KEY } from '../types/task.js';
 import type { AgentDef } from '../types/agent.js';
 
@@ -42,6 +42,7 @@ import {
   appendAgentMessage,
   appendMessageToUser,
   appendSlackMessage,
+  appendSlackEdit,
   renderAttachmentsSuffix,
   downloadMessageFiles,
   ensureSessionsDir,
@@ -268,6 +269,36 @@ export class Task {
     existing.last_processed_ts = thread.currentMessageTs;
     this.debouncedSave();
     return { linkedNewThread: false };
+  }
+
+  /**
+   * Record that a Slack message previously ingested into this task was edited.
+   *
+   * Writes a fresh knowledge-log entry (we never mutate prior entries) keyed to
+   * the original message via `msg:<ts>`, capturing the new and previous text.
+   * Deliberately does NOT advance `last_processed_ts` — an edit reuses the
+   * original message's `ts`, so touching the watermark would skip genuinely new
+   * replies. Returns false when the thread isn't a linked Slack channel.
+   */
+  async appendSlackEdit(
+    channelKey: string,
+    author: SlackAuthor,
+    editedTs: string,
+    oldText: string,
+    newText: string,
+  ): Promise<boolean> {
+    const ch = this.metadata.channels[channelKey];
+    if (ch?.type !== 'slack') return false;
+    await appendSlackEdit(
+      this.taskId,
+      { id: ch.channel_id, name: ch.channel_name },
+      ch.thread_id,
+      author,
+      editedTs,
+      oldText,
+      newText,
+    );
+    return true;
   }
 
   /**

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -275,16 +275,17 @@ export class Task {
    * Record that a Slack message previously ingested into this task was edited.
    *
    * Writes a fresh knowledge-log entry (we never mutate prior entries) keyed to
-   * the original message via `msg:<ts>`, capturing the new and previous text.
-   * Deliberately does NOT advance `last_processed_ts` — an edit reuses the
-   * original message's `ts`, so touching the watermark would skip genuinely new
-   * replies. Returns false when the thread isn't a linked Slack channel.
+   * the original message via `msg:<ts>`, capturing the new text. The pre-edit
+   * text stays in the log under that same id, so the change is recoverable by
+   * correlation. Deliberately does NOT advance `last_processed_ts` — an edit
+   * reuses the original message's `ts`, so touching the watermark would skip
+   * genuinely new replies. Returns false when the thread isn't a linked Slack
+   * channel.
    */
   async appendSlackEdit(
     channelKey: string,
     author: SlackAuthor,
     editedTs: string,
-    oldText: string,
     newText: string,
   ): Promise<boolean> {
     const ch = this.metadata.channels[channelKey];
@@ -295,7 +296,6 @@ export class Task {
       ch.thread_id,
       author,
       editedTs,
-      oldText,
       newText,
     );
     return true;


### PR DESCRIPTION
## Summary

Adds support for Slack message edits (`message_changed` events). When a user edits a message in a thread Archie is following, the system logs the edit and wakes the task so the agent can reassess whether the change is material — an edit can change the meaning of an instruction (e.g. "deploy to staging" → "deploy to prod") that Archie would otherwise act on from stale text.

No Slack manifest or scope change is needed: `message_changed` is already delivered via the existing `message.*` subscriptions; the handler previously dropped it.

## Key Changes

- **Event routing**: the `message` handler now branches on the `message_changed` subtype and routes to a new `handleSlackEdit`.
- **Edit filtering**: `handleSlackEdit` acts only on substantive edits, otherwise returns silently:
  - text must actually differ (drops link unfurls / attachment re-renders, where new and previous text are identical — the dominant source of edit-event noise);
  - the edit must not be bot-authored (own posts or other integrations);
  - a task must already follow the thread (mirrors plain-reply handling — never engages a thread the bot wasn't invited to);
  - the editor must be internal (same external/guest bail-out as `handleSlackEvent`);
  - the channel must not be muted.
- **Knowledge-log recording**: edits are appended as **fresh** entries (never mutating the original line) via new `appendSlackEdit` in `persistence.ts`, keyed to the original message's `msg:<ts>` id.
- **Task waking**: after logging, the task is woken with the standard `existingTask` ("new input received") prompt; the agent decides whether the change is material and no-ops on cosmetic edits.
- **Watermark preservation**: `appendSlackEdit` deliberately does **not** advance `last_processed_ts` — an edit reuses the original message's `ts`, so bumping the watermark would skip genuinely new replies.
- **Docs**: `docs/architecture/slack-integration.md` gains a "Message Edits" section covering the flow and filtering.
- **Tests**: unit tests for the pure `renderEditForContext` helper.

## Edit entry format

The log entry is just the new text tagged `[edited]`, keyed to the original message via the `msg:<ts>` id (mentions resolved with `cleanSlackText`):

```
@<U123:Egor> in slack:#<C456:deploys>:1700000000.000100 | msg:1700000000.000100
  [edited] deploy to prod
```

The pre-edit text is intentionally **not** duplicated — the original message already lives in the append-only log under the same `msg:<ts>` id, so the agent correlates the edit to it by id rather than re-logging now-stale text.

## Scope note

Reactions are intentionally out of scope here: reading reactions is already covered pull-side (the agent's `react_to_message` / `get_message_reactions` tools and ingest-time snapshots). This PR is edits only.

https://claude.ai/code/session_013sGBxbuQcudVHEKFaBnfJY