### PR TITLE
Allow targeting specific Slack threads for interactive approvals

### DIFF
--- a/docs/architecture/edit-mode.md
+++ b/docs/architecture/edit-mode.md
@@ -31,7 +31,7 @@ The PM agent calls the `request_edit_mode` MCP tool (defined in `src/agents/tool
 [ Approve ]  [ Deny ]
 ```
 
-The buttons use action IDs `approve_edit_mode` and `deny_edit_mode`, with the task ID as the button value. `postInteractiveToUser` posts to the task's default channel (Slack today; other connectors may not surface the buttons).
+The buttons use action IDs `approve_edit_mode` and `deny_edit_mode`, with the task ID as the button value. `postInteractiveToUser` posts to the channel passed via the tool's optional `channel` argument, falling back to the task's default channel when omitted (Slack today; other connectors may not surface the buttons). The explicit `channel` lets an agent target a linked thread even when the task has no default channel yet — e.g. a self-launched task that just opened a thread via `post_to_user`.
 
 ### 3. Task Pauses
 

--- a/docs/architecture/slack-integration.md
+++ b/docs/architecture/slack-integration.md
@@ -158,7 +158,7 @@ There is no `post_to_slack` MCP tool and no event-bus subscription that ferries 
 
 ## Interactive Messages
 
-Some system events require user decisions via Slack buttons. The PM calls `task.postInteractiveToUser(text, blocks, approvalType)`, which routes to `postInteractiveToThreads()` for the task's default Slack channel. Currently implemented interactive flows:
+Some system events require user decisions via Slack buttons. The PM calls `task.postInteractiveToUser(text, blocks, approvalType, channelKey?)`, which routes to `postInteractiveToThreads()` for the given channel — or the task's default Slack channel when `channelKey` is omitted. Currently implemented interactive flows:
 
 - **Edit mode approval**: "Approve" / "Deny" buttons (action IDs: `approve_edit_mode`, `deny_edit_mode`). See [Edit Mode](./edit-mode.md).
 - **Research budget approval**: "Approve (+5)" / "Deny" buttons (action IDs: `approve_research_budget`, `deny_research_budget`).

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -400,12 +400,28 @@ function createAssignTaskOwnerTool(agent: Agent, task: Task) {
 function createRequestEditModeTool(agent: Agent, task: Task) {
   return tool(
     'request_edit_mode',
-    'Request permission to make code changes. Call this AFTER explaining to the user what changes are needed and why. Task will pause until user approves or denies.',
+    'Request permission to make code changes. Call this AFTER explaining to the user what changes are needed and why. Task will pause until user approves or denies. ' +
+    'Without `channel`, the request posts to the task\'s default channel. Pass `channel` (a channel key like "slack:C123:456.789") to post it to a specific linked thread — useful when the task has no default channel yet or you opened a new thread to talk to the user.',
     {
       reason: z.string().describe('Brief summary of what changes need to be made'),
+      channel: z.string().optional().describe('Channel key of an existing linked thread to post the request to (e.g., "slack:C123:456.789"). Omit to use the task\'s default channel.'),
     },
     async (args) => {
       const agentName = agent.def.id as AgentName;
+
+      // Validate an explicit target before posting so a bad key surfaces as
+      // actionable feedback instead of silently dropping to the CLI log. The
+      // task is left running so the agent can retry with a valid channel.
+      if (args.channel) {
+        const ch = task.metadata.channels[args.channel];
+        if (!ch) {
+          return ok(`Channel ${args.channel} is not linked to this task. Open one with post_to_user(target.new_thread/new_dm), or omit channel to use the default.`);
+        }
+        if (ch.type !== 'slack') {
+          return ok(`Channel ${args.channel} is not a Slack channel (type: ${ch.type}).`);
+        }
+      }
+
       logger.agentAction(agentName, 'Requesting edit mode', args.reason);
       task.touch();
 
@@ -436,7 +452,7 @@ function createRequestEditModeTool(agent: Agent, task: Task) {
           ],
         },
       ];
-      await task.postInteractiveToUser(`Edit mode request: ${args.reason}`, blocks, 'edit_mode');
+      await task.postInteractiveToUser(`Edit mode request: ${args.reason}`, blocks, 'edit_mode', args.channel);
 
       await task.stop();
       return { content: [{ type: 'text' as const, text: 'Edit mode request sent. Task paused pending user approval.' }] };

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -460,19 +460,24 @@ export class Task {
   }
 
   /**
-   * Post an interactive message (with blocks) to the user via the default channel.
+   * Post an interactive message (with blocks) to the user.
+   *
+   * Routes to `channelKey` when provided, otherwise to the task's default
+   * channel (both resolved via `resolveSlackChannel`). This lets callers target
+   * a specific linked thread even when the task has no default channel. Falls
+   * back to a CLI log line when no Slack channel resolves — interactive
+   * approvals are also surfaced in the CLI via the `approval:requested` event
+   * regardless of Slack delivery.
    */
-  async postInteractiveToUser(text: string, blocks: unknown[], approvalType: 'edit_mode' | 'research_budget'): Promise<void> {
+  async postInteractiveToUser(text: string, blocks: unknown[], approvalType: 'edit_mode' | 'research_budget', channelKey?: string): Promise<void> {
     emitEvent('approval:requested', this.taskId, { text, approvalType });
 
-    const defaultCh = this.metadata.default_channel
-      ? this.metadata.channels[this.metadata.default_channel]
-      : null;
-    if (defaultCh?.type === 'slack') {
+    const ch = this.resolveSlackChannel(channelKey);
+    if (ch) {
       await postInteractiveToThreads([{
-        thread_id: defaultCh.thread_id,
-        channel_id: defaultCh.channel_id,
-        last_processed_ts: defaultCh.last_processed_ts,
+        thread_id: ch.thread_id,
+        channel_id: ch.channel_id,
+        last_processed_ts: ch.last_processed_ts,
       }], text, blocks);
     } else {
       logger.slack(`POST (interactive): ${text}`);

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -584,6 +584,13 @@ export class Task {
 
   /**
    * Register a new Slack channel/thread in the task metadata.
+   *
+   * Promotes the channel to `default_channel` when the task has none yet. This
+   * matters for self-launched tasks, which start with zero channels (and a null
+   * default): the first channel the PM opens via `post_to_user(new_thread/new_dm)`
+   * becomes the default so subsequent default-routed messages — including
+   * interactive approval prompts like edit-mode requests — reach Slack instead of
+   * being dropped to the CLI log.
    */
   private registerSlackChannel(channelId: string, threadTs: string, channelName: string): string {
     const key = `slack:${channelId}:${threadTs}`;
@@ -595,6 +602,7 @@ export class Task {
       last_processed_ts: threadTs,
       url: buildThreadUrl(channelId, threadTs) ?? undefined,
     };
+    this.metadata.default_channel ??= key;
     this.debouncedSave();
     return key;
   }


### PR DESCRIPTION
## Summary

Enable agents to post interactive approval requests (edit mode, research budget) to specific linked Slack threads, not just the task's default channel. This is especially useful for self-launched tasks that start with no default channel — an agent can now open a thread via `post_to_user` and immediately target it for approval prompts.

## Key Changes

- **`Task.postInteractiveToUser()`**: Added optional `channelKey` parameter to route interactive messages to a specific linked thread. Falls back to the task's default channel when omitted, preserving backward compatibility.

- **`Task.registerSlackChannel()`**: Auto-promotes the first registered channel to `default_channel` for tasks with none yet. This ensures self-launched tasks (which start with zero channels) have a default target for subsequent messages.

- **`request_edit_mode` tool**: Added optional `channel` parameter (e.g., `"slack:C123:456.789"`) to let agents explicitly target a linked thread. Includes validation to surface bad channel keys as actionable feedback instead of silently falling back to CLI logs.

- **Documentation**: Updated architecture docs to reflect the new routing behavior and use cases.

## Implementation Details

- Channel resolution uses the existing `resolveSlackChannel()` method, which handles both explicit keys and default fallback.
- Validation in the tool prevents silent failures: if an agent passes an invalid or non-Slack channel key, it returns an error message rather than degrading to CLI output.
- The auto-promotion of the first channel to `default_channel` is idempotent (`??=`), so it only applies when no default exists.
- All changes are backward compatible — existing code that omits `channel` continues to work as before.

https://claude.ai/code/session_01BQ1e5AbJ7rmt3z7U8Dasoi