### PR TITLE
Block premature task completion while peers still working

### DIFF
--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -34,6 +34,8 @@ The key to managing your turns is understanding who you're waiting for after you
 
 - **Neither**: You have more actions to take. Continue working, then re-evaluate.
 
+**Pinged by the user while still waiting on an agent**: You're still *waiting for AGENT*. Reassure with `post_to_user`, then end your turn — do NOT `report_completion`. It would pause the task and tear down the agent you're waiting on, dropping its reply. The agent's report reopens your turn.
+
 ### 3. Communication Channel Philosophy
 
 Understanding your communication channels is critical:
@@ -75,6 +77,8 @@ When assigning work to an agent via `send_message_to_agent`, ALWAYS start your m
 ### 6. Task Completion Philosophy
 
 Calling `report_completion` doesn't abandon work - it means "I've responded to my requester and am now waiting for their next input." Tasks automatically reopen when users respond or new events arrive.
+
+**Only complete when no agent work is outstanding.** Completing stops every agent, so a teammate still mid-task (e.g. an awaited review or deliverable) loses their reply. The tool enforces this: if a peer is still active, `report_completion` refuses and names who. That's not an error — stop and wait, their report reopens your turn.
 
 **When to include a message with report_completion** (user-facing milestones):
 

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -459,6 +459,18 @@ function createReportCompletionTool(agent: Agent, task: Task) {
       if (!task.isActive) {
         return ok('Task already completed.');
       }
+      // Refuse completion while a peer agent is still mid-turn — completing now
+      // would stop their queue and drop the reply they're about to send back,
+      // orphaning the relay. Non-destructive: nothing posted, task stays active,
+      // the peer's reply reopens this turn. (report_completion is PM-only.)
+      const activePeers = task.activePeers(agentName);
+      if (activePeers.length > 0) {
+        return ok(
+          `Completion refused: ${activePeers.join(', ')} still working. ` +
+          `Not an error, nothing to retry — stop and wait, their report reopens your turn. ` +
+          `Need to update the user meanwhile? Use post_to_user.`
+        );
+      }
       if (args.message) {
         if (Object.keys(task.metadata.channels).length === 0) {
           return ok(

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -698,6 +698,24 @@ export class Task {
   }
 
   /**
+   * Names of spawned agents currently mid-turn (active), excluding `exclude`.
+   *
+   * An agent can only emit inter-agent messages while its turn is running, and a
+   * turn is exactly the window in which `session.active` is true (the `inactive`
+   * marker fires from the Stop hook *after* the turn ends). So "any peer active"
+   * is a reliable signal that a delegated round-trip is still in flight — used by
+   * report_completion to refuse premature completion that would tear down a peer
+   * mid-work and orphan its reply.
+   */
+  activePeers(exclude: AgentName): AgentName[] {
+    const peers: AgentName[] = [];
+    for (const [name, agent] of this.agentProcesses) {
+      if (name !== exclude && agent.session.active) peers.push(name);
+    }
+    return peers;
+  }
+
+  /**
    * Touch — update last activity timestamp.
    */
   touch(): void {


### PR DESCRIPTION
## What

PM could complete a task while a delegated peer agent was still mid-turn, orphaning the relay back to PM. This makes `report_completion` refuse (non-destructively) while any peer is still active, and updates the PM prompt to match.

## Why

Observed in task `task-20260608-1152-ag25iy` (gift-card challenge naming). Chain: `PM → copywriter → tov-reviewer → copywriter → PM`. Two messages got dropped:

- `copywriter → tov-reviewer` sent **39s after** the task was marked `completed` — tov-reviewer never woke.
- `tov-reviewer → copywriter` (the PASS verdict) sent **after** completion + copywriter went inactive — copywriter never received it, never relayed the approval to PM.

Root cause, two layers:
1. `report_completion` → `complete()` tears down **all** agent queues with no "are peers busy?" check. PM completed while waiting on an internal verdict (not the user).
2. An inter-agent message to an inactive task is logged but **not delivered** and does **not** reopen the task (`toolSendMessage` early-returns on `!isActive`). Only a user ping re-activates — hence the repeated manual pings to recover.

Key insight: an agent can only send inter-agent messages **during** its turn, and a turn is exactly the window where `session.active` is true (the `inactive` marker fires after, via the Stop hook). So "any peer active" reliably means a delegated reply is still in flight — refusing completion then keeps the task alive and lets the reply reopen PM's turn naturally. No reopen-on-inactive change needed.

## Changes

- **`src/tasks/task.ts`** — `Task.activePeers(exclude)`: spawned agents currently `active`, minus the caller.
- **`src/agents/tools.ts`** — `report_completion` refuses when `activePeers` is non-empty: nothing posted, `complete()` not scheduled, task stays active. Returns a short message telling PM it's not an error and to stop and wait. (`report_completion` is PM-only — wired only inside the `isPmAgent` block in `spawn.ts` — so no extra gating added.)
- **`prompts/pm-agent.md`** — Section 2: when pinged by the user while still waiting on an agent, reassure via `post_to_user` and end the turn; don't `report_completion`. Section 6: only complete when no agent work is outstanding; the refusal is not an error.

## Reviewer notes

- Non-destructive by design — the refusal posts nothing and leaves the task active, so a premature call is now a no-op instead of a teardown.
- Behavior limited to PM in practice because only PM has the `report_completion` tool.
- `npm run typecheck` clean. Vitest does not run in this environment (pre-existing missing native binding `rolldown-binding.darwin-universal.node`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)