### PR TITLE
fix(spawn): pass HOME in agent env so hook `~` expands

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -513,10 +513,15 @@ Shared folder: ${sharedPath} [READ-ONLY]
     additionalDirectories: additionalDirectories as any,
     executable: 'node' as const,
     settingSources: ['project'] as any,
+    // The SDK replaces (not merges) process.env with this object, so any var the
+    // spawned CLI needs must be listed here explicitly. HOME in particular must be
+    // set: without it `~` fails to expand in unsandboxed hook commands, silently
+    // resolving to a literal `~` directory instead of the real home.
     env: {
       NODE_ENV: process.env.NODE_ENV || 'development',
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
       PATH: process.env.PATH,
+      HOME: process.env.HOME,
       CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
       ...(useClaudeDirs ? {
         CLAUDE_CONFIG_DIR: claudeConfigDir,


### PR DESCRIPTION
## What

Add `HOME: process.env.HOME` to the agent spawn `env` block in `src/agents/spawn.ts`.

## Why

The Claude Agent SDK **replaces** (does not merge) `process.env` with the `env` object passed to `query()`. The spawn env block only listed `NODE_ENV`/`ANTHROPIC_API_KEY`/`PATH`/`CLAUDE_*` — never `HOME`. This was harmless under SDK 0.2.x (which merged `env` with `process.env`), but the **0.3.x upgrade (commit `1838791`, 2026-05-29) switched to full-replace**, dropping `HOME` from the spawned CLI's environment.

Consequences with empty `HOME`:
- **Unsandboxed SessionStart hooks** inherit this env, so `~` no longer expands — it resolves to a literal `~` directory. The ops plugin's gws-credentials hook (`cp /app/secrets/gws-credentials.json ~/.config/gws/credentials.json`) silently wrote to the wrong path.
- The agent's Bash is bwrap-sandboxed and bwrap sets `HOME=/home/archie`, so the agent's own `~` resolved fine → classic "agent can read, but the file isn't there" after a fresh deploy.
- The npm-install hook was unaffected because it uses absolute `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PLUGIN_DATA}` paths (no `~`).

## Verification

Reproduced in the real Linux/bwrap dev container with the app's exact env, running the actual ops `hooks.json`:
- Before (no `HOME`): `HOME=` empty → creds copied to literal `~/.config/gws/credentials.json`.
- After (`HOME` set): `HOME=/home/archie` → creds land at `/home/archie/.config/gws/credentials.json`, `cp_exit=0`.

`npm run typecheck` passes. No plugin changes required.

## Reviewer notes

The SDK env-replace also drops other inherited vars (`SHELL`, `USER`, …). Only `HOME` caused a known issue; if other shell/hook oddities surface, add them to this same block.