### PR TITLE
fix(tasks): repair idle-recovery target so waiting tasks don't hit the wall-clock

### DIFF
--- a/src/tasks/recovery.ts
+++ b/src/tasks/recovery.ts
@@ -123,23 +123,37 @@ async function triggerRecovery(task: Task): Promise<void> {
     const newTask = await TaskClass.get(task.taskId);
     await recoverTaskAgents(newTask);
   } else {
-    // Reinforcement: nudge the lead agent
-    const target = (task.metadata.task_owner || 'pm-agent') as AgentName;
-    const agent = task.agentProcesses.get(target);
+    // Reinforcement: nudge a *live, idle* agent so it ends its turn properly
+    // (report_completion when waiting on the user, or re-delegate).
+    //
+    // Prefer the task owner, then fall back to the PM. The fallback is the
+    // whole fix: a message-driven resume only spawns the PM (Task.get →
+    // sendMessage(pm)), so a blind nudge at `task_owner` — often a specialist
+    // like ops-agent that was NOT respawned — hit no live process, set
+    // recoveryAttempts=2, and silently stalled (no new agent:inactive event
+    // ever re-arms the idle check). The task then hung until the 30-min
+    // wall-clock. The PM owns the user conversation and is the right agent to
+    // either continue or park. (Playstorm 2026-06-11 stall.)
+    const owner = (task.metadata.task_owner || 'pm-agent') as AgentName;
+    const candidates: AgentName[] =
+      owner === 'pm-agent' ? ['pm-agent'] : [owner, 'pm-agent'];
+    const target = candidates.find((name) => task.agentProcesses.get(name)?.isRunning);
+    const targetAgent = target ? task.agentProcesses.get(target) : undefined;
 
-    // Only nudge if the agent process is actually running (not crashed)
-    if (agent && agent.isRunning) {
+    if (targetAgent) {
       const prompt = target === 'pm-agent'
         ? AGENT_PROMPTS.reinforcePM
         : AGENT_PROMPTS.reinforceAgent;
-      agent.queue.addMessage(prompt);
+      targetAgent.queue.addMessage(prompt);
 
       // Mark agent as active after nudge
-      agent.updateSession(true);
+      targetAgent.updateSession(true);
       task.save();
     } else {
-      // Agent process is dead — skip straight to nuclear on next idle check
-      task.recoveryAttempts = 2;
+      // No live agent to nudge — re-spawn rather than silently stalling.
+      // recoverTaskAgents re-sends the recovery prompt to previously-active
+      // agents, falling back to the PM, which re-arms the lifecycle.
+      await recoverTaskAgents(task);
     }
   }
 }

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -964,16 +964,27 @@ export class Task {
   private startTaskTimeout(): void {
     this.taskTimeoutTimer = setInterval(async () => {
       const elapsed = Date.now() - this.budgets.taskStartTime.getTime();
-      if (elapsed >= this.budgets.taskTimeoutMs) {
-        logger.warn(
-          'budget',
-          `Task ${this.taskId} exceeded wall-clock timeout (${Math.round(elapsed / 60_000)}min)`,
-        );
-        await this.postToUser(
-          `⏱️ Task timed out after ${Math.round(elapsed / 60_000)} minutes. Stopping task.`,
-        ).catch((err: unknown) => logger.error('budget', 'Failed to post timeout message', err));
-        await this.stop();
-      }
+      if (elapsed < this.budgets.taskTimeoutMs) return;
+
+      const mins = Math.round(elapsed / 60_000);
+      // The wall-clock cap is a backstop, not a failure verdict. A task that's
+      // simply waiting on a human reply (all agents idle) must not announce a
+      // scary "timed out" — it was working as intended. Reframe as a pause and
+      // `complete()` (park) so it reopens cleanly on the next reply, rather
+      // than `stop()`. Only when an agent is still mid-turn is this a genuinely
+      // long-running task being capped.
+      const anyAgentActive = [...this.agentProcesses.values()].some((a) => a.session.active);
+      logger.warn(
+        'budget',
+        `Task ${this.taskId} hit wall-clock cap (${mins}min, agents ${anyAgentActive ? 'active' : 'idle'}) — pausing`,
+      );
+      const msg = anyAgentActive
+        ? `⏸️ This task has been running for ${mins} minutes, so I'm pausing it here. Reply in this thread and I'll pick it back up.`
+        : `⏸️ Pausing this task — I'd been waiting on a reply for a while. Just respond in this thread whenever you're ready and I'll continue.`;
+      await this.postToUser(msg).catch((err: unknown) =>
+        logger.error('budget', 'Failed to post pause message', err),
+      );
+      await this.complete();
     }, 60_000);
   }
 


### PR DESCRIPTION
## Problem

In the 2026-06-10/11 Playstorm session, a task that had **finished its turn and was waiting on the user** hung until the 30-minute wall-clock fired, then posted a misleading **"⏱️ Task timed out after 30 minutes. Stopping task."** It wasn't stuck — it was correctly waiting for the rep's confirmation.

### Root cause (from the prod debug session)

The final turn resumed at 07:58:40 (both `agent:active` events were **pm-agent** — ops was never respawned). PM posted a clarification, went inactive at 08:07:18 — then nothing until the wall-clock at 08:28:40. Two stacked failures:

**1. Idle-recovery nudged the wrong agent — the real bug.**
When the PM went idle, `checkAllAgentsInactive` was true → `triggerRecovery`. But it nudged `task.metadata.task_owner` = **ops-agent**, which a message-driven resume never respawns (`Task.get` → `sendMessage(pm)` spawns the PM only). So:

```js
const target = (task.metadata.task_owner || 'pm-agent'); // 'ops-agent'
const agent = task.agentProcesses.get(target);           // undefined
if (agent && agent.isRunning) { /* nudge */ }
else { task.recoveryAttempts = 2; }   // ← silent dead-end
```

`recoveryAttempts` was bumped to 2 and **nothing else happened**. Idle checks only re-arm on a *new* `agent:inactive` event, so the "skip to nuclear next time" never came. The [`reinforcePM`](src/agents/prompts.ts) nudge — which literally says *"report_completion: Task done **or waiting for user input**"* — never reached the PM.

**2. The wall-clock message read as a failure** — but it's a backstop, not a verdict.

## Fix

**`src/tasks/recovery.ts`** — resolve the reinforcement target to a **live, idle** agent: prefer `task_owner`, then fall back to the **PM** (the entry agent that owns the user conversation and can either continue or park). When no candidate is a live process, **re-spawn via `recoverTaskAgents`** instead of silently stalling. With this, the existing `reinforcePM` nudge reaches the PM, which then `report_completion`s (waiting on user) → the task parks → reopens on the next reply.

**`src/tasks/task.ts`** — reframe the wall-clock cap as a **pause**: `complete()` (park, reopens on reply) instead of `stop()`, and word the message by whether an agent was still active (a genuinely long turn) vs idle (just waiting on the user). No more "timed out".

## Why not a PM-prompt change

[pm-agent.md](prompts/pm-agent.md) correctly distinguishes *waiting-for-USER* (must `report_completion`) from *waiting-for-AGENT* / *pinged-while-waiting* (`post_to_user` + bare turn-end, **no** completion — the peer's reply reopens the turn). Telling the PM to "always `report_completion`" would conflict with that and with the peer-guard. The right layer is the recovery mechanism: `checkAllAgentsInactive == true` proves no agent is working, so the orphaned turn *should* be recovered — the nudge just needed to reach a live agent.

## Verification
- `npm run typecheck` ✓ · `eslint` on touched files ✓
- (Full `vitest` run is blocked locally by a missing native `rolldown` binding — unrelated to this change. No tests cover recovery/timeout.)

## Notes
- Companion offer-duplication fix (same debug session) ships separately in `archie-plugins`: sweatco/archie-plugins#43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)