### PR TITLE
fix(pm): contain work in the current task/thread by default

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -54,7 +54,7 @@ One PM agent instance is spawned per task. It is the orchestrator: it receives a
 | Tool | Purpose |
 |---|---|
 | `send_message_to_agent` | Send instructions/questions to any agent |
-| `post_to_user` | Send a message to the user. Routes to the default linked channel, an existing linked thread (`target.channel`), a new DM (`target.new_dm`), or a new thread in a channel (`target.new_thread`). The Slack/CLI/GitHub specifics live in `Task.postToUser`, so the PM never picks a transport directly. |
+| `post_to_user` | Send a message to the user. Routes to the default linked channel, an existing linked thread (`target.channel`), a new DM (`target.new_dm`), or a new thread in a channel (`target.new_thread`). The Slack/CLI/GitHub specifics live in `Task.postToUser`, so the PM never picks a transport directly. The prompt steers the PM to stay where the task lives (in a channel thread, `@mention` people there; in a DM, stay 1:1); `new_dm`/`new_thread` are reserved for explicit user requests or cases a loaded skill/workflow requires. |
 | `post_files_to_user` | Upload files to an already-linked thread (default channel or `channel` key). Does not open new destinations. |
 | `share_artifact` | Publish an immutable, deduped snapshot of a file under `<task>/shared/artifacts/` for inter-agent sharing. |
 | `find_slack_user` / `find_slack_channel` | Look up Slack user/channel IDs and metadata before opening a DM or new thread. |
@@ -63,7 +63,7 @@ One PM agent instance is spawned per task. It is the orchestrator: it receives a
 | `request_edit_mode` | Post an interactive Approve/Deny prompt to the default channel and pause the task |
 | `get_agents_status` | Check which agents are spawned and active |
 | `mute_channel` | Disengage from one Slack channel/thread (the one named via `channel`, or the task's default channel) until the bot is @mentioned there again. DM channels cannot be muted |
-| `launch_task` | Launch a new independent background task (with notification posted to the current channel) |
+| `launch_task` | Launch a new independent background task (with notification posted to the current channel). The prompt steers the PM to keep follow-up work inside the current task and reserve this for explicit user requests or workflow-driven background work, since a launched task has no trace back to the originating one. |
 | `parse_datetime` / `set_reminder` / `cancel_reminder` | Schedule a reminder that wakes the task at an ISO datetime |
 
 The `Skill` tool is provided by the Claude Agent SDK itself (not by `pm-agent-tools`); skills are mounted from the `pm` plugin's `skills/` directory and surfaced via `.claude/skills/` symlinks plus `settingSources: ['project']`. Built-in `Read`, `Glob`, and `Grep` tools are available against the PM workspace and the shared task folder (which is mounted read-only via `additionalDirectories`); `WebSearch` and `WebFetch` are explicitly disallowed.

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -250,7 +250,7 @@ Tools are defined in `src/agents/tools.ts` and exposed via MCP servers created p
 | Tool | Description |
 |---|---|
 | `send_message_to_agent` | Send a message to another agent (spawns target if needed) |
-| `post_to_user` | Post a message to the user — default channel, an existing linked thread, a new DM, or a new thread in a channel (`target.channel` / `target.new_dm` / `target.new_thread`) |
+| `post_to_user` | Post a message to the user — default channel, an existing linked thread, a new DM, or a new thread in a channel (`target.channel` / `target.new_dm` / `target.new_thread`). Default is where the task lives; `new_dm`/`new_thread` are reserved for explicit user requests or cases a loaded skill/workflow requires |
 | `post_files_to_user` | Upload one or more files as Slack attachments to an already-linked channel; does not open new threads |
 | `share_artifact` | Publish an immutable snapshot to `shared/artifacts/` for inter-agent file sharing (deduped by hash) |
 | `find_slack_user` / `find_slack_channel` | Look up Slack user/channel metadata (used before opening new DMs/threads) |
@@ -259,7 +259,7 @@ Tools are defined in `src/agents/tools.ts` and exposed via MCP servers created p
 | `request_edit_mode` | Post Approve/Deny buttons to the default channel and stop the task until the user responds |
 | `get_agents_status` | Return active/idle status of all spawned agents |
 | `mute_channel` | Stop processing a Slack channel/thread until the bot is @mentioned there again. Takes optional `channel` key; defaults to the task's `default_channel`. DM channels cannot be muted |
-| `launch_task` | Start a new background task (delegates to `src/tasks/launch.ts`) |
+| `launch_task` | Start a new background task (delegates to `src/tasks/launch.ts`). Reserved for explicit user requests or workflow-driven background work — follow-up work normally stays in the current task to preserve the trace |
 | `parse_datetime` / `set_reminder` / `cancel_reminder` | Schedule/cancel reactivation of the task at a future time (via `src/system/reminder-scheduler.ts`) |
 
 Outbound posting flow: PM-style tools (`post_to_user`, `post_files_to_user`,

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -49,6 +49,11 @@ Understanding your communication channels is critical:
 
 **Mentioning users**: When you need to mention someone (e.g. to notify them), use the `@<ID:Name>` format you see in the conversation history (e.g. `@<U1234567:John Smith>`). This ensures they receive a notification. If you don't know the user's ID, just use their plain name without any special formatting.
 
+**Stay in one place by default**: Talk to people where this task already lives, and keep follow-up work in this task by delegating to an agent here. Opening new channels (`post_to_user` with `target.new_dm`/`target.new_thread`) or launching separate tasks (`launch_task`) fragments the conversation and severs the trace back to the request — do it only when the user explicitly asks, or a loaded skill/workflow requires it.
+
+- **In a channel thread**: reply in the thread; to involve someone, `@mention` them there rather than DMing them.
+- **In a DM**: you are 1:1 with that user — keep it private and don't pull others in.
+
 **Message reactions (capability reference)**: Each Slack message in the conversation history is tagged with a `msg:<ts>` id in its source line (e.g. `... in #channel | msg:1716998400.123456`). That id is what the reaction tools take as `message_id`, and it lets them target any message in the thread, not only the most recent one. `react_to_message` adds an emoji reaction to a message, `unreact_from_message` removes one you added, and `get_message_reactions` reports the reactions currently on a message and who left them. This describes what the tools do — it is not an instruction to react. Reactions are not part of any standard workflow; reach for them only on the rare occasion a reaction is genuinely the most fitting response.
 
 **The key insight**: Match your communication to the channel where the audience lives. The user exists only in the channel. Inter-agent messages (`send_message_to_agent`) and the shared knowledge log (`knowledge.log`) are internal — the user cannot see them. If an agent reports findings to you, the user does not automatically learn about it. You must explicitly relay any information the user needs via `post_to_user`. Never assume the user has visibility into agent replies or log entries.
@@ -121,7 +126,7 @@ Use `send_message_to_agent`, `post_to_user`, and `log_finding` for short text �
 
 ### Task Management Tools
 
-- `launch_task(prompt, reason)`: Launch a new independent background task. Use for fire-and-forget work that shouldn't block the current conversation. The launched task starts with no channel — its own PM will decide where to reach someone (DM, new thread) or complete silently. A notification about the launch is automatically posted to the current channel, so don't repost. Not available to tasks that have no channel of their own.
+- `launch_task(prompt, reason)`: Launch a SEPARATE, independent background task with no link back to this one — its origin is invisible to whoever picks it up. Use rarely: keep follow-up work in the current task by delegating to an agent here, and launch only when the user explicitly asks for separate/background work or a loaded skill/workflow requires it. The launched task starts with no channel; its own PM decides where to reach someone or completes silently. A launch notification is auto-posted to the current channel, so don't repost. Not available to tasks with no channel of their own.
 
 ### Scheduling Reminders
 
@@ -129,7 +134,7 @@ When a user asks to be reminded at a specific time, look up their IANA timezone 
 
 ### Cross-Channel Communication
 
-You can reach people and channels beyond the originating thread:
+Reach beyond where this task lives only when the user explicitly asks, or a loaded skill/workflow requires it (see "Stay in one place by default"). When it does:
 1. Use `find_slack_user` to look up a user's ID, or `find_slack_channel` to look up a channel's ID
 2. Use `post_to_user` with `target.new_dm` to start a DM, or `target.new_thread` to post in a channel — both link the conversation to the current task
 3. Use the returned channel key with `target.channel` for follow-up messages to the same thread

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -246,10 +246,12 @@ function createShareArtifactTool(agent: Agent, task: Task) {
 function createPostToUserTool(agent: Agent, task: Task) {
   return tool(
     'post_to_user',
-    'Send a message to the user. Without target, posts to the default channel. ' +
-    'Use target.channel to post to a specific linked thread. ' +
-    'Use target.new_dm with a user ID to start a DM conversation (links it to this task). ' +
-    'Use target.new_thread with a channel ID to start a new thread in a channel (links it to this task). ' +
+    'Send a message to the user. Without target, posts to the default channel — wherever this task already lives. ' +
+    'Use that default almost always; use target.channel to reach another already-linked thread. ' +
+    'target.new_dm (user ID) and target.new_thread (channel ID) OPEN A NEW conversation and link it to this task — ' +
+    'use them ONLY when the user explicitly asks you to reach someone elsewhere, or a loaded skill/workflow requires it. ' +
+    'If this task lives in a channel thread, bring someone in by @mentioning them in that thread, not by DMing them. ' +
+    'If it lives in a DM, you are 1:1 with that user — keep it private and don\'t pull others in. ' +
     'When creating new DMs/threads, returns the channel key for future use. ' +
     'To attach files, send the message first, then call `post_files_to_user` with the same target.',
     {
@@ -652,10 +654,11 @@ function createGetMessageReactionsTool(_agent: Agent, task: Task) {
 function createLaunchTaskTool(_agent: Agent, task: Task) {
   return tool(
     'launch_task',
-    'Launch a new independent task that runs in the background. Use for fire-and-forget ' +
-    'work that should not block the current conversation. The launched task starts with no ' +
-    'channel — its own PM will decide whether to ping someone (DM, new thread) or complete ' +
-    'silently based on the task. Cannot be called from a task that has no channel of its own.',
+    'Launch a SEPARATE, independent background task with NO link back to this one — its origin is invisible to whoever picks it up. ' +
+    'Keep follow-up work inside the current task by delegating to an agent here, so everything stays on one traceable thread. ' +
+    'Use this ONLY when the user explicitly asks for separate/background work, or a loaded skill/workflow requires it. ' +
+    'The launched task starts with no channel — its own PM decides whether to reach someone or complete silently. ' +
+    'Cannot be called from a task that has no channel of its own.',
     {
       prompt: z.string().describe('The task prompt for the launched PM agent'),
       reason: z.string().describe('Why this task is being launched (shown to the new PM and in the notification)'),


### PR DESCRIPTION
## Problem

The PM was over-using two PM-only tools:

- **`launch_task`** — spinning off follow-up work (e.g. a fix following a triaged bug) into a new, independent background task. The launched task has **no link back** to the originating one, so its origin is invisible to whoever picks it up.
- **`post_to_user` with `target.new_dm` / `target.new_thread`** — opening unsolicited DMs or new threads to ping people, instead of reaching them where the task already lives. Annoying and fragments the conversation.

The old wording actively encouraged this: `launch_task` was described as "for fire-and-forget work that should not block the current conversation," and `post_to_user` listed `new_dm`/`new_thread` as equal options with no steer toward the existing channel.

## Change

Guidance only — **no tool schemas or runtime behavior change**. Reframe both tool descriptions and the PM prompt so the default is to **keep follow-up work and conversation where the task already lives**, and reserve `launch_task` / `new_dm` / `new_thread` for cases the user **explicitly requests** or a **loaded skill/workflow** drives.

Differentiate the two homes a task can have:
- **In a channel thread** → reply there; `@mention` people to involve them.
- **In a DM** → 1:1 with that user; keep it private, don't pull others in.

### Files
- `src/agents/tools.ts` — `launch_task` and `post_to_user` descriptions
- `prompts/pm-agent.md` — "Stay in one place by default" principle, `launch_task` bullet, Cross-Channel Communication intro
- `docs/architecture/{agents,orchestration}.md` — table notes kept consistent

## Notes
- No changes to `archie-plugins` — its only `new_thread`/`new_dm` uses are legitimate workflow-driven flows, which the new wording explicitly permits.
- `npm run typecheck` clean; tool-contract + pr-tools tests pass (31/31).

https://claude.ai/code/session_01H7fLY4t8GXHFAuFv85HyzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7fLY4t8GXHFAuFv85HyzB)_