### PR TITLE
fix(oauth): token-refresh correctness (timestamps + RFC 8707 resource) + MCP failure observability

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -502,7 +502,13 @@ Shared folder: ${sharedPath} [READ-ONLY]
 
   // Inject OAuth Bearer tokens into any HTTP/SSE MCP servers that have
   // a vault record. Drops entries whose tokens can't be refreshed.
-  await applyOAuthBindings(mcpServers);
+  const oauthBindings = await applyOAuthBindings(mcpServers);
+  if (oauthBindings.injected.length > 0) {
+    logger.agent(def.id, `OAuth tokens bound: ${oauthBindings.injected.join(', ')}`);
+  }
+  for (const { serverName, error } of oauthBindings.dropped) {
+    logger.error(def.id, `MCP "${serverName}" dropped before connect — OAuth bind failed: ${error.message}`);
+  }
 
   // ---- Build query options (session ID may change on retry) ----
 
@@ -588,9 +594,29 @@ Shared folder: ${sharedPath} [READ-ONLY]
               task.updateAgentState(def.id, true, event.session_id);
               logger.agent(def.id, `Model: ${(event as any).model || 'unknown'}`);
               if (Array.isArray(event.mcp_servers)) {
+                // The init snapshot only carries { name, status }. Pull the
+                // richer status so a non-connected server records WHY (its
+                // error) and its true status — instead of a bare "FAILED" that
+                // forces the agent (and us) to guess.
+                let errorByName = new Map<string, string>();
+                try {
+                  const detailed = await agentQuery.mcpServerStatus();
+                  errorByName = new Map(
+                    detailed.filter((m) => m.error).map((m) => [m.name, m.error as string]),
+                  );
+                } catch {
+                  // Control request unavailable — fall back to the snapshot status.
+                }
                 for (const mcp of event.mcp_servers) {
-                  const status = mcp.status === 'connected' ? 'connected' : `FAILED`;
-                  logger.agent(def.id, `MCP ${mcp.name}: ${status}`);
+                  if (mcp.status === 'connected') {
+                    logger.agent(def.id, `MCP ${mcp.name}: connected`);
+                    continue;
+                  }
+                  const reason = errorByName.get(mcp.name);
+                  const line = `MCP ${mcp.name}: ${mcp.status || 'unknown'}${reason ? ` — ${reason}` : ''}`;
+                  // 'failed' is a hard error; pending/needs-auth/disabled are not.
+                  if (mcp.status === 'failed') logger.error(def.id, line);
+                  else logger.warn(def.id, line);
                 }
               }
             }

--- a/src/cli/oauth.ts
+++ b/src/cli/oauth.ts
@@ -181,9 +181,9 @@ async function runRevoke(args: string[]): Promise<void> {
 async function runRefresh(args: string[]): Promise<void> {
   const serverName = args[0];
   if (!serverName) fatal('Usage: oauth:refresh <server-name>');
-  // Force a refresh by claiming the token already expired.
-  const farFuture = Date.now() + 365 * 24 * 60 * 60 * 1000;
-  const result = await ensureFreshToken(serverName, farFuture).catch((err) => {
+  // Force a refresh regardless of remaining token lifetime. (Faking "now" would
+  // also force it, but that timestamp leaks into the stored updated_at/expires_at.)
+  const result = await ensureFreshToken(serverName, { force: true }).catch((err) => {
     fatal(err);
   });
   if (!result) return;

--- a/src/connectors/oauth/routes.ts
+++ b/src/connectors/oauth/routes.ts
@@ -133,6 +133,7 @@ async function completeFlow(state: string, code: string): Promise<CallbackOutcom
       state,
       redirectUri: pending.redirect_uri,
       codeVerifier: sealed.code_verifier,
+      resource: pending.resource,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -158,6 +159,7 @@ async function completeFlow(state: string, code: string): Promise<CallbackOutcom
       issuer: pending.issuer,
       token_endpoint: pending.token_endpoint,
       scopes: pending.scopes,
+      resource: pending.resource,
     },
     {
       access_token: tokens.access_token,

--- a/src/system/oauth/__tests__/refresh.test.ts
+++ b/src/system/oauth/__tests__/refresh.test.ts
@@ -141,6 +141,68 @@ describe('ensureFreshToken', () => {
     expect(result.expiresAt).toBe(reread!.expires_at);
   });
 
+  it('replays the stored RFC 8707 resource indicator on refresh and carries it forward', async () => {
+    // Regression: without resource on the refresh request, an audience-enforcing
+    // resource server (e.g. Monday) rejects the rotated token with 401 even
+    // though the refresh itself returned 200.
+    const { refresh, storage } = await importFresh();
+    const nowSec = Math.floor(Date.now() / 1000);
+    await storage.writeOAuthRecord(
+      {
+        server_name: 'audience',
+        expires_at: nowSec + 5,
+        created_at: nowSec, updated_at: nowSec,
+        issuer: 'https://auth.example.com',
+        token_endpoint: 'https://auth.example.com/token',
+        scopes: [],
+        resource: 'https://mcp.example.com/mcp',
+      },
+      { access_token: 'AT-old', refresh_token: 'RT', client_id: 'cli', token_type: 'Bearer' },
+    );
+    let bodyCaptured: URLSearchParams | null = null;
+    globalThis.fetch = vi.fn(async (_url: any, init: any) => {
+      bodyCaptured = new URLSearchParams(init.body);
+      return new Response(
+        JSON.stringify({ access_token: 'AT-new', token_type: 'Bearer', expires_in: 3600 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as any;
+
+    await refresh.ensureFreshToken('audience');
+    expect(bodyCaptured!.get('grant_type')).toBe('refresh_token');
+    expect(bodyCaptured!.get('resource')).toBe('https://mcp.example.com/mcp');
+    // The indicator survives the rotated record so the next refresh replays it too.
+    const reread = await storage.readOAuthRecord('audience');
+    expect(reread!.resource).toBe('https://mcp.example.com/mcp');
+  });
+
+  it('omits the resource parameter on refresh for legacy records without one', async () => {
+    const { refresh, storage } = await importFresh();
+    const nowSec = Math.floor(Date.now() / 1000);
+    await storage.writeOAuthRecord(
+      {
+        server_name: 'legacy',
+        expires_at: nowSec + 5,
+        created_at: nowSec, updated_at: nowSec,
+        issuer: 'https://auth.example.com',
+        token_endpoint: 'https://auth.example.com/token',
+        scopes: [],
+      },
+      { access_token: 'AT-old', refresh_token: 'RT', client_id: 'cli', token_type: 'Bearer' },
+    );
+    let bodyCaptured: URLSearchParams | null = null;
+    globalThis.fetch = vi.fn(async (_url: any, init: any) => {
+      bodyCaptured = new URLSearchParams(init.body);
+      return new Response(
+        JSON.stringify({ access_token: 'AT-new', token_type: 'Bearer', expires_in: 3600 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as any;
+
+    await refresh.ensureFreshToken('legacy');
+    expect(bodyCaptured!.has('resource')).toBe(false);
+  });
+
   it('keeps the old refresh_token when the issuer does not rotate it', async () => {
     const { refresh, storage } = await importFresh();
     const nowSec = Math.floor(Date.now() / 1000);

--- a/src/system/oauth/__tests__/refresh.test.ts
+++ b/src/system/oauth/__tests__/refresh.test.ts
@@ -101,6 +101,46 @@ describe('ensureFreshToken', () => {
     expect(sealed.refresh_token).toBe('RT-new');
   });
 
+  it('force-refreshes a token that is nowhere near expiry and stamps real timestamps', async () => {
+    // Regression: the `oauth:refresh` CLI used to force a refresh by passing a
+    // fake far-future `now`, which leaked into updated_at/expires_at (the
+    // "-31535788s ago" / "in 372d" bug). With `force`, timestamps stay real.
+    const { refresh, storage } = await importFresh();
+    const nowSec = Math.floor(Date.now() / 1000);
+    await storage.writeOAuthRecord(
+      {
+        server_name: 'forced',
+        expires_at: nowSec + 3600, // plenty of life left — would normally be cached
+        created_at: nowSec - 600, updated_at: nowSec - 600,
+        issuer: 'https://auth.example.com',
+        token_endpoint: 'https://auth.example.com/token',
+        scopes: [],
+      },
+      { access_token: 'AT-old', refresh_token: 'RT', client_id: 'cli', token_type: 'Bearer' },
+    );
+    let fetchCalled = false;
+    globalThis.fetch = vi.fn(async () => {
+      fetchCalled = true;
+      return new Response(
+        JSON.stringify({ access_token: 'AT-new', token_type: 'Bearer', expires_in: 600 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as any;
+
+    const result = await refresh.ensureFreshToken('forced', { force: true });
+    expect(fetchCalled).toBe(true); // force bypasses the freshness short-circuit
+    expect(result.accessToken).toBe('AT-new');
+
+    const reread = await storage.readOAuthRecord('forced');
+    // updated_at must be ~real now, never a far-future sentinel.
+    expect(reread!.updated_at).toBeGreaterThanOrEqual(nowSec);
+    expect(reread!.updated_at).toBeLessThan(nowSec + 5);
+    // expires_at must be ~now + expires_in (600s), not a year-plus out.
+    expect(reread!.expires_at).toBeGreaterThanOrEqual(nowSec + 595);
+    expect(reread!.expires_at).toBeLessThan(nowSec + 700);
+    expect(result.expiresAt).toBe(reread!.expires_at);
+  });
+
   it('keeps the old refresh_token when the issuer does not rotate it', async () => {
     const { refresh, storage } = await importFresh();
     const nowSec = Math.floor(Date.now() / 1000);

--- a/src/system/oauth/connect.ts
+++ b/src/system/oauth/connect.ts
@@ -131,6 +131,11 @@ export async function beginConnect(input: ConnectInput): Promise<ConnectResult> 
   const state = generateState();
   const scopes = resource.scopes_supported ?? [];
 
+  // RFC 8707 resource indicator — the audience the resource server enforces.
+  // Persisted so it can be replayed on every token-endpoint request (initial
+  // exchange + refresh), not just the authorize step.
+  const resourceIndicator = resource.resource || serverUrl;
+
   const authorizeUrl = buildAuthorizeUrl({
     authorizationEndpoint: authServer.authorization_endpoint,
     clientId,
@@ -138,7 +143,7 @@ export async function beginConnect(input: ConnectInput): Promise<ConnectResult> 
     scope: scopes.length ? scopes.join(' ') : undefined,
     state,
     codeChallenge: pkce.challenge,
-    resource: resource.resource || serverUrl,
+    resource: resourceIndicator,
   });
 
   await writePendingRecord(
@@ -150,6 +155,7 @@ export async function beginConnect(input: ConnectInput): Promise<ConnectResult> 
       token_endpoint: authServer.token_endpoint,
       authorization_endpoint: authServer.authorization_endpoint,
       scopes,
+      resource: resourceIndicator,
       redirect_uri: redirectUri,
       created_at: Math.floor(Date.now() / 1000),
     },

--- a/src/system/oauth/flow.ts
+++ b/src/system/oauth/flow.ts
@@ -68,6 +68,8 @@ export interface TokenExchangeInput {
   state: string;
   redirectUri: string;
   codeVerifier: string;
+  /** RFC 8707 resource indicator — audience-binds the issued token. */
+  resource?: string;
 }
 
 /**
@@ -85,6 +87,7 @@ export async function exchangeCodeForTokens(input: TokenExchangeInput): Promise<
     validated,
     input.redirectUri,
     input.codeVerifier,
+    input.resource ? { additionalParameters: { resource: input.resource } } : undefined,
   );
   return await oauth.processAuthorizationCodeResponse(input.as, input.client, res);
 }
@@ -94,6 +97,8 @@ export interface RefreshInput {
   client: oauth.Client;
   clientAuth: oauth.ClientAuth;
   refreshToken: string;
+  /** RFC 8707 resource indicator — must be replayed so the rotated token keeps its audience. */
+  resource?: string;
 }
 
 export async function refreshAccessToken(input: RefreshInput): Promise<oauth.TokenEndpointResponse> {
@@ -102,6 +107,7 @@ export async function refreshAccessToken(input: RefreshInput): Promise<oauth.Tok
     input.client,
     input.clientAuth,
     input.refreshToken,
+    input.resource ? { additionalParameters: { resource: input.resource } } : undefined,
   );
   return await oauth.processRefreshTokenResponse(input.as, input.client, res);
 }

--- a/src/system/oauth/refresh.ts
+++ b/src/system/oauth/refresh.ts
@@ -83,6 +83,9 @@ export async function ensureFreshToken(
         client: { client_id: sealed.client_id },
         clientAuth: clientAuthFor(sealed.client_secret),
         refreshToken: sealed.refresh_token,
+        // Replay the RFC 8707 audience binding. Legacy records without a stored
+        // resource send nothing (preserving prior behavior); reconnect to populate.
+        resource: record.resource,
       });
     } catch (err) {
       throw new OAuthRefreshError(serverName, err);

--- a/src/system/oauth/refresh.ts
+++ b/src/system/oauth/refresh.ts
@@ -35,18 +35,34 @@ export class OAuthRefreshError extends Error {
   }
 }
 
+export interface EnsureFreshTokenOptions {
+  /** Current time as unix epoch ms. Overridable for tests; defaults to Date.now(). */
+  now?: number;
+  /**
+   * Refresh regardless of how much life the cached token has left. Used by the
+   * `oauth:refresh` CLI to rotate a token on demand. Without this, a caller
+   * would have to fake `now` to force a refresh — and that fake value would
+   * leak into the stamped `updated_at`/`expires_at`, corrupting the record.
+   */
+  force?: boolean;
+}
+
 /**
- * Read the vault record, refresh if near expiry, and return a live
- * access token. Writes back the rotated record atomically. Concurrent
- * callers for the same server name share one refresh.
+ * Read the vault record, refresh if near expiry (or when `force` is set), and
+ * return a live access token. Writes back the rotated record atomically.
+ * Concurrent callers for the same server name share one refresh.
  */
-export async function ensureFreshToken(serverName: string, now = Date.now()): Promise<FreshToken> {
+export async function ensureFreshToken(
+  serverName: string,
+  options: EnsureFreshTokenOptions = {},
+): Promise<FreshToken> {
+  const { now = Date.now(), force = false } = options;
   return withKeyMutex(`oauth:${serverName}`, async () => {
     const record = await readOAuthRecord(serverName);
     if (!record) throw new OAuthRecordMissingError(serverName);
 
     const nowSec = Math.floor(now / 1000);
-    if (record.expires_at - nowSec > REFRESH_LEEWAY_SECONDS) {
+    if (!force && record.expires_at - nowSec > REFRESH_LEEWAY_SECONDS) {
       const sealed = await readOAuthSealed(record);
       return {
         accessToken: sealed.access_token,

--- a/src/system/oauth/types.ts
+++ b/src/system/oauth/types.ts
@@ -22,6 +22,13 @@ export interface OAuthRecordMeta {
   issuer: string;
   token_endpoint: string;
   scopes: string[];
+  /**
+   * RFC 8707 resource indicator (the MCP server's canonical URL). Replayed on
+   * every token-endpoint request so refreshed tokens keep the audience binding
+   * the resource server enforces. Optional: records connected before this was
+   * tracked won't have it — reconnect to populate.
+   */
+  resource?: string;
 }
 
 /** What we encrypt inside the OAuth vault record. */
@@ -48,6 +55,8 @@ export interface OAuthPendingMeta {
   token_endpoint: string;
   authorization_endpoint: string;
   scopes: string[];
+  /** RFC 8707 resource indicator, carried from connect through to the token exchange. */
+  resource?: string;
   redirect_uri: string;
   created_at: number;
 }


### PR DESCRIPTION
Three related fixes from one debugging session: two OAuth token-refresh correctness bugs, plus the observability gap that made them hard to diagnose in the first place.

---

## Fix 1 — CLI refresh corrupts `updated_at` / `expires_at`

**Symptom.** After `oauth:refresh <server>`, `oauth:list` shows nonsense:
```
monday   in 372d   -31535788s ago
```

**Root cause.** The `oauth:refresh` CLI forced a refresh by passing a fake "now" **365 days in the future** to `ensureFreshToken()`. That value isn't only used to decide *whether* to refresh — it also stamps the record:
```js
const nowSec = Math.floor(now / 1000);        // realNow + 365d
updated_at: nowSec,                            // → "Updated -31535788s ago"
expires_at: nowSec + response.expires_in,      // realNow + 365d + lifetime → "in 372d"
```

**Why it matters (not cosmetic).** The inflated `expires_at` keeps `expires_at - now` far above the 60s leeway, so the daemon's proactive auto-refresh never fires. Once the provider's *real* token lapses, MCP calls fail with no self-recovery.

**Fix.** Add an explicit `force` option to `ensureFreshToken()` so forced refreshes stamp **real** timestamps; the CLI uses `{ force: true }` instead of faking `now`.

---

## Fix 2 — RFC 8707 `resource` indicator not replayed on token requests

**Root cause.** The resource indicator (the MCP server's canonical URL, audience-binding the token) was sent **only on the authorize request** (`connect.ts`). It was never persisted, and never sent to the **token endpoint** — neither on the initial `authorization_code` exchange (`routes.ts`) nor on `refresh_token` (`flow.ts`). Per RFC 8707 §2.2 and the MCP authorization spec, `resource` must be included on token requests too.

For an authorization server that enforces audience restriction (e.g. Monday), a refreshed token then comes back with a missing/wrong audience, and the resource server rejects it with **401 — even though the refresh returned HTTP 200 and the token looks "valid."**

**Fix.**
- Persist the resource indicator on the pending record and the vault record (`types.ts`, `connect.ts`, `routes.ts`).
- Replay it via `additionalParameters` on both the `authorization_code` and `refresh_token` grants (`flow.ts`, `refresh.ts`).
- Legacy records without a stored resource send nothing — preserving today's behavior and avoiding `invalid_target` on a guessed value. They self-heal on reconnect (see follow-up).

---

## Fix 3 — MCP connection failures logged as a bare "FAILED"

**Root cause.** Two blind spots made every MCP failure look identical, which is why a transient Monday hiccup got reported as "MCP is down":
- `spawn.ts` discarded the `{ injected, dropped }` result from `applyOAuthBindings`, so a server dropped because its OAuth token couldn't be refreshed left **no trace** at the spawn site.
- The init-event handler collapsed every non-connected status to a bare `"FAILED"`, throwing away the real status.

**Fix.**
- Log which servers got tokens and which were **dropped, with the bind error**.
- Log each server's **true status** (`connected` / `failed` / `needs-auth` / `pending` / `disabled`) — note `pending` (still connecting) is no longer mislabeled as failed.
- Enrich non-connected servers with the per-server **error** via `query.mcpServerStatus()` (the init snapshot only carries `{ name, status }`). `failed` logs at error level; the rest at warn.

---

## Testing
- `npm run typecheck` — clean
- All OAuth tests pass (34), including new regression tests: force-refresh stamps real timestamps; refresh replays a stored `resource`; legacy records omit it.

## Operational follow-up after deploy
1. Re-run `oauth:refresh <server>` with this build to overwrite any record whose timestamps were corrupted by Fix 1.
2. To give existing servers (e.g. `monday`, `notion`) an audience-bound refresh path under Fix 2, **reconnect** them (`oauth:revoke <server>` + `oauth:connect <server>`) so the resource indicator is persisted. Until then they refresh exactly as before (no regression).

https://claude.ai/code/session_01PxHUPEsCLhg3Q55V2mTfrn