### PR TITLE
Surface team MCP integrations in PM live context

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -242,7 +242,8 @@ For repo agents, this is the `agentPrompt` field from `RepoAgentConfig`. For plu
 ### PM Agent Prompt
 
 The PM agent uses a separate prompt (`prompts/pm-agent.md`) that is not layered. It includes:
-- Team list and expertise (dynamically injected via `{{TEAM_LIST}}` and `{{TEAM_EXPERTISE}}`)
+- Team list and expertise (dynamically injected via `{{TEAM_LIST}}` and `{{TEAM_EXPERTISE}}`). Each `{{TEAM_LIST}}` line is annotated by `buildPmDef()` with the external systems that teammate can reach via MCP — built from the agent's resolved `mcpServers` plus the optional `description` of each server in the plugins' `.mcp.json` — so the PM can route an integration request to the agent that owns it instead of assuming Archie lacks access
+- The PM's own directly-callable integrations (`{{PM_INTEGRATIONS}}`), since the PM is not part of its own roster (empty when it has none)
 - Core mental models (Single Read Principle, Turn Flow, Communication Channel Philosophy, Unified Persona, Delegation Protocol, Task Completion Philosophy)
 - Available tools categorized as Action Tools vs Turn-Ending Tools
 - Structured reasoning process (`<situation_analysis>` tags)
@@ -266,7 +267,7 @@ Plugin Agent:
   + plugins/<name>/agents/<key>.md body (optional)
 
 PM Agent:
-  pm-agent.md(TEAM_LIST, TEAM_EXPERTISE)
+  pm-agent.md(TEAM_LIST, TEAM_EXPERTISE, PM_INTEGRATIONS)
   + (optional) pm overlay prompt body from the `pm` plugin
 
 Triage Agent (disabled):

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -14,6 +14,8 @@ Areas of expertise for each team member:
 {{TEAM_EXPERTISE}}
 </team_expertise>
 
+Some teammates can reach external systems through **MCP integrations** — shown in their `<team_list>` line as `integrations: <system> (what it is)`. These are live connections to issue trackers, error monitors, CI, dashboards, databases, admin panels, and similar tools, and they are the source of truth for what Archie can access. When a request involves checking, looking up, or pulling data from such a system, route it to the teammate whose line lists it — they query it on Archie's behalf. {{PM_INTEGRATIONS}} Never tell a user something can't be checked just because *you* can't reach it yourself: first look for a teammate whose line lists the relevant system, and only say it's not possible when none does.
+
 **IMPORTANT**: You have domain-specific skills available via the `Skill` tool. Before delegating to any team member, you MUST load the relevant skill first — it contains the workflow, decision framework, and coordination patterns for that domain. Never delegate without first loading and reading the skill. If you're unsure which skill applies, list available skills by calling the `Skill` tool.
 
 ## Core Mental Models

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -267,17 +267,37 @@ function buildPmDef(teamDefs: AgentDef[], rootMcp: LoadedMcpConfig): AgentDef {
     (d) => d.pluginName === 'pm' || d.visibility === 'global',
   );
 
+  // PM overlay from the "pm" plugin (extra prompt, MCP, tool permissions)
+  const overlay = getPmOverlay();
+  const resolvedMcp = overlay ? resolveAgentMcpServers(overlay, rootMcp) : {};
+
+  // Annotate each teammate's roster line with the external systems it can reach
+  // via MCP. Without this the PM sees only roles/expertise and can wrongly tell a
+  // user that checking Jira / Rollbar / the admin panel / etc. isn't possible —
+  // the roster is its only window into what teammates can reach.
+  const describeServer = (name: string): string => {
+    const desc = rootMcp.descriptions[name];
+    return desc ? `${name} (${desc})` : name;
+  };
+  const integrationsSuffix = (d: AgentDef): string => {
+    const names = d.mcpServers ? Object.keys(d.mcpServers) : [];
+    return names.length > 0 ? ` — integrations: ${names.map(describeServer).join('; ')}` : '';
+  };
+
   const teamList = visibleTeam
-    .map((d) => `- ${d.id}: ${d.role}`)
+    .map((d) => `- ${d.id}: ${d.role}${integrationsSuffix(d)}`)
     .join('\n');
 
   const teamExpertise = visibleTeam
     .map((d) => `- ${d.id}: ${d.expertise}`)
     .join('\n');
 
-  // PM overlay from the "pm" plugin (extra prompt, MCP, tool permissions)
-  const overlay = getPmOverlay();
-  const resolvedMcp = overlay ? resolveAgentMcpServers(overlay, rootMcp) : {};
+  // The PM isn't part of its own roster, so surface the integrations it can call
+  // directly as a self-contained sentence (empty when it has none).
+  const pmServerNames = resolvedMcp.mcpServers ? Object.keys(resolvedMcp.mcpServers) : [];
+  const pmIntegrations = pmServerNames.length > 0
+    ? `You can also query these external systems yourself directly: ${pmServerNames.map(describeServer).join('; ')}.`
+    : '';
 
   return {
     id: 'pm-agent',
@@ -291,7 +311,7 @@ function buildPmDef(teamDefs: AgentDef[], rootMcp: LoadedMcpConfig): AgentDef {
     pluginName: 'pm',
     visibility: 'global',
     pluginDataPath: join(PLUGINS_DATA_DIR, 'pm'),
-    pmConfig: { teamList, teamExpertise },
+    pmConfig: { teamList, teamExpertise, pmIntegrations },
     pmOverlayPrompt: overlay?.prompt || undefined,
     skillsPath: pmPlugin?.skillsPath || undefined,
     coreSkillsPath: existsSync(CORE_SKILLS_DIR) ? CORE_SKILLS_DIR : undefined,

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -51,6 +51,7 @@ async function generatePMPrompt(task: Task): Promise<string> {
   return loadPrompt('pm-agent', {
     TEAM_LIST: pmDef?.pmConfig?.teamList ?? '',
     TEAM_EXPERTISE: pmDef?.pmConfig?.teamExpertise ?? '',
+    PM_INTEGRATIONS: pmDef?.pmConfig?.pmIntegrations ?? '',
   });
 }
 

--- a/src/system/__tests__/plugin-loader.test.ts
+++ b/src/system/__tests__/plugin-loader.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Plugin Loader — loadMcpJson tests
+ *
+ * Focused on the `description` handling: each server's optional human-readable
+ * `description` must be surfaced separately (for the PM's team-integrations
+ * context) and stripped from the connection config so the Claude Agent SDK
+ * never receives a non-standard field.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+vi.mock('../logger.js', () => ({
+  logger: { warn: vi.fn(), system: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+import { loadMcpJson } from '../plugin-loader.js';
+
+let tempDir: string;
+
+async function writeMcpJson(contents: unknown): Promise<string> {
+  const path = join(tempDir, '.mcp.json');
+  await writeFile(path, JSON.stringify(contents));
+  return path;
+}
+
+describe('loadMcpJson', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'archie-mcp-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns empty servers and descriptions when the file does not exist', () => {
+    const result = loadMcpJson(join(tempDir, 'does-not-exist.json'));
+    expect(result).toEqual({ servers: {}, descriptions: {} });
+  });
+
+  it('extracts description into descriptions and strips it from the server config', async () => {
+    const path = await writeMcpJson({
+      mcpServers: {
+        rollbar: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', '@rollbar/mcp-server@latest'],
+          description: 'Rollbar — backend error tracking',
+        },
+      },
+    });
+
+    const { servers, descriptions } = loadMcpJson(path);
+
+    expect(descriptions.rollbar).toBe('Rollbar — backend error tracking');
+    // The connection config the SDK receives must NOT carry `description`.
+    expect(servers.rollbar).not.toHaveProperty('description');
+    expect(servers.rollbar).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@rollbar/mcp-server@latest'],
+    });
+  });
+
+  it('leaves servers without a description untouched and absent from descriptions', async () => {
+    const path = await writeMcpJson({
+      mcpServers: {
+        notion: { type: 'http', url: 'https://mcp.notion.com/mcp' },
+      },
+    });
+
+    const { servers, descriptions } = loadMcpJson(path);
+
+    expect(descriptions).toEqual({});
+    expect(servers.notion).toEqual({ type: 'http', url: 'https://mcp.notion.com/mcp' });
+  });
+
+  it('ignores blank descriptions but still strips the key from the config', async () => {
+    const path = await writeMcpJson({
+      mcpServers: {
+        monday: { type: 'http', url: 'https://mcp.monday.com/mcp', description: '   ' },
+      },
+    });
+
+    const { servers, descriptions } = loadMcpJson(path);
+
+    expect(descriptions).not.toHaveProperty('monday');
+    expect(servers.monday).not.toHaveProperty('description');
+    expect(servers.monday).toEqual({ type: 'http', url: 'https://mcp.monday.com/mcp' });
+  });
+
+  it('substitutes ${MCP_*} env vars alongside description handling', async () => {
+    process.env.MCP_TEST_TOKEN = 'secret-token';
+    try {
+      const path = await writeMcpJson({
+        mcpServers: {
+          example: {
+            type: 'http',
+            url: 'https://example.com/mcp',
+            headers: { Authorization: 'Bearer ${MCP_TEST_TOKEN}' },
+            description: 'Example service',
+          },
+        },
+      });
+
+      const { servers, descriptions } = loadMcpJson(path);
+
+      expect(descriptions.example).toBe('Example service');
+      expect(servers.example.headers.Authorization).toBe('Bearer secret-token');
+      expect(servers.example).not.toHaveProperty('description');
+    } finally {
+      delete process.env.MCP_TEST_TOKEN;
+    }
+  });
+});

--- a/src/system/plugin-loader.ts
+++ b/src/system/plugin-loader.ts
@@ -28,18 +28,26 @@ import { logger } from './logger.js';
 
 export { PLUGINS_DIR };
 
-/** Parsed root .mcp.json — server connection configs only */
+/** Parsed root .mcp.json — server connection configs plus optional descriptions */
 export interface LoadedMcpConfig {
   servers: Record<string, any>;
+  /**
+   * Human-readable description per server, taken from an optional `description`
+   * key on each server entry. Stripped from `servers` so the Claude Agent SDK
+   * only ever receives valid connection config. Used to annotate each teammate's
+   * roster line with what its integrations are (see registry.buildPmDef).
+   */
+  descriptions: Record<string, string>;
 }
 
 /**
  * Load and parse an .mcp.json file, substituting ${MCP_*} env vars.
- * Returns pure server connection configs. Tool permissions are controlled
- * by agent frontmatter, not by .mcp.json.
+ * Returns pure server connection configs plus any human-readable `description`
+ * keys (pulled out so they never reach the SDK). Tool permissions are
+ * controlled by agent frontmatter, not by .mcp.json.
  */
 export function loadMcpJson(path: string): LoadedMcpConfig {
-  const empty: LoadedMcpConfig = { servers: {} };
+  const empty: LoadedMcpConfig = { servers: {}, descriptions: {} };
   if (!existsSync(path)) return empty;
   try {
     const raw = readFileSync(path, 'utf-8');
@@ -52,11 +60,22 @@ export function loadMcpJson(path: string): LoadedMcpConfig {
     const rawServers: Record<string, any> = parsed.mcpServers ?? {};
 
     const servers: Record<string, any> = {};
+    const descriptions: Record<string, string> = {};
     for (const [name, config] of Object.entries(rawServers)) {
-      servers[name] = config;
+      // `description` is metadata for surfacing to the PM, not connection
+      // config — split it out so the SDK only sees valid server fields.
+      if (config && typeof config === 'object' && !Array.isArray(config) && 'description' in config) {
+        const { description, ...connectionConfig } = config as Record<string, any>;
+        if (typeof description === 'string' && description.trim()) {
+          descriptions[name] = description.trim();
+        }
+        servers[name] = connectionConfig;
+      } else {
+        servers[name] = config;
+      }
     }
 
-    return { servers };
+    return { servers, descriptions };
   } catch {
     logger.warn('system', `MCP config: failed to parse ${path}`);
     return empty;

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -74,10 +74,19 @@ export interface AgentRepoDef {
  * PM-specific fields (present only on the PM coordinator agent)
  */
 export interface AgentPmDef {
-  /** Formatted team list for prompt template */
+  /**
+   * Formatted team list for prompt template. Each teammate's line is annotated
+   * with the external systems it can reach via MCP, so the PM knows which agent
+   * to route an integration request to instead of assuming Archie lacks access.
+   */
   teamList: string;
   /** Formatted team expertise for prompt template */
   teamExpertise: string;
+  /**
+   * One sentence naming the integrations the PM can query directly (the PM is
+   * not part of its own roster). Empty string when it has no MCP servers.
+   */
+  pmIntegrations: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Improves the PM's live context so it knows **which teammate operates which MCP integration**. Previously the PM saw only each teammate's role and expertise, so when a user asked Archie to check an external system (Jira, Rollbar, the admin panel, TeamCity, ClickHouse, …) it could wrongly conclude that wasn't possible — the roster was its only window into teammate capabilities and carried no signal about MCP access.

## What changed

- **`buildPmDef()`** annotates each teammate's `{{TEAM_LIST}}` line with the external systems it can reach via MCP, so the integration lives on the agent it belongs to rather than in a separate parallel list:

  ```
  - backend-agent: Senior Ruby on Rails engineer… — integrations: rollbar (Rollbar — backend error tracking and exception monitoring)
  - mobile-agent: Senior React Native engineer… — integrations: smartbear (BugSnag…); teamcity (TeamCity…); firebase (Firebase…)
  ```

- **`prompts/pm-agent.md`** explains the annotation and instructs the PM to route an integration request to the teammate whose line lists it — and never to tell a user something can't be checked without first checking the roster.
- The PM's **own** directly-callable integrations (it isn't part of its own roster) are surfaced as a short `{{PM_INTEGRATIONS}}` sentence (empty when it has none).
- **`loadMcpJson()`** reads an optional human-readable `description` per server and surfaces it next to the name. It is metadata only — **stripped from the connection config so the Claude Agent SDK never receives a non-standard field.**

## Testing

- `npm run typecheck` — clean
- `npm test` — **414 passing**, including a new `src/system/__tests__/plugin-loader.test.ts` covering description extraction and the no-leak invariant
- Rendered `{{TEAM_LIST}}` against the real plugin config to confirm formatting

## Companion PR

Server descriptions live in the plugins repo — `sweatco/archie-plugins` branch `claude/friendly-hypatia-78ofd8`. This PR works without it (it falls back to raw server names), but the descriptions make the annotations human-readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fuWP1xJaEDRh6HeQJmgRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017fuWP1xJaEDRh6HeQJmgRQ)_