### PR TITLE
Defer mid-turn task teardowns to turn-end (fix "Stream closed" hook errors)

### DIFF
--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -27,10 +27,47 @@ export class Agent {
    */
   sandbox?: SandboxOptions;
 
+  /**
+   * A task teardown (complete/stop) deferred until this agent's current turn
+   * ends. The spawn loop runs it when it sees the SDK `result` event, so the
+   * triggering tool's response and the Stop hook's control round-trip both
+   * finish over an open input stream. Tearing down mid-turn closes the stream
+   * while a hook is still doing its control round-trip, which the SDK surfaces
+   * as a "stream closed" error. Set via `deferTeardown`.
+   */
+  private _pendingTeardown?: () => Promise<void>;
+
   constructor(def: AgentDef) {
     this.def = def;
     this.queue = new MessageQueue();
     this.session = { active: false };
+  }
+
+  /**
+   * Defer a task teardown (e.g. `task.complete()` / `task.stop()`) until this
+   * agent's current turn ends — see {@link pendingTeardown}. First request wins;
+   * later calls in the same turn are ignored, so a tool that fires twice can't
+   * trigger a double teardown or duplicate side-effects.
+   */
+  deferTeardown(action: () => Promise<void>): void {
+    this._pendingTeardown ??= action;
+  }
+
+  /**
+   * The teardown queued by {@link deferTeardown}, run by the spawn loop once the
+   * SDK emits this turn's `result` event. Undefined when nothing is pending.
+   */
+  get pendingTeardown(): (() => Promise<void>) | undefined {
+    return this._pendingTeardown;
+  }
+
+  /**
+   * Drop any queued teardown. Called at the start of each spawn so a flag armed
+   * in a previous run on this reused Agent object (tasks park via `complete()`
+   * and reopen onto the same agents) can't fire against the next run.
+   */
+  clearPendingTeardown(): void {
+    this._pendingTeardown = undefined;
   }
 
   /**

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -311,7 +311,7 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     getCallerAgentId: () => def.id,
     checkResearchBudget: () => task.checkResearchBudget(),
     incrementResearchCount: () => task.incrementResearchCount(),
-    onResearchBudgetExceeded: () => task.onResearchBudgetExceeded(),
+    onResearchBudgetExceeded: () => task.onResearchBudgetExceeded(agent),
   });
 
   // ---- Per-agent config ----
@@ -563,6 +563,13 @@ Shared folder: ${sharedPath} [READ-ONLY]
 
   // ---- Session recovery (try → reset → retry → give up) ----
 
+  // Start each spawn with a clean teardown slot. Agent objects are reused when a
+  // task parks (complete()) and reopens onto the same agents, so a teardown armed
+  // by report_completion/request_edit_mode/research-budget in a previous run would
+  // otherwise still be set here and fire against this fresh run. deferTeardown
+  // re-arms it within this run as needed.
+  agent.clearPendingTeardown();
+
   const existingSessionId = agent.session.session_id;
   const recoverable = createRecoverableInputGenerator(agent.queue);
 
@@ -600,6 +607,26 @@ Shared folder: ${sharedPath} [READ-ONLY]
               additionalDirectories,
               isRepoAgent(def) && metadata.edit_allowed === true,
             );
+
+            // Deferred teardown (report_completion / request_edit_mode / research
+            // budget): now that the turn has fully ended (the SDK `result` event),
+            // run it. The teardown stops this agent's queue, which closes the input
+            // stream and lets the query generator terminate *naturally* on the next
+            // pull — the same path the pre-change code relied on.
+            //
+            // Do NOT `return` here. `Query` is an AsyncGenerator, so returning from
+            // the for-await calls its .return(), abruptly tearing down the SDK
+            // subprocess mid-stream instead of letting it exit gracefully. That left
+            // the session in a state that broke the next `resume`, so the first
+            // attempt completed cleanly but every reopened attempt after it fell
+            // into recovery.
+            if (event.type === 'result' && agent.pendingTeardown) {
+              const teardown = agent.pendingTeardown;
+              agent.clearPendingTeardown();
+              await teardown().catch((err) =>
+                logger.error(def.id, 'Error during deferred teardown', err)
+              );
+            }
           }
 
           return;

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -411,6 +411,12 @@ function createRequestEditModeTool(agent: Agent, task: Task) {
     async (args) => {
       const agentName = agent.def.id as AgentName;
 
+      // Already pausing this turn — the spawn loop tears the task down at turn
+      // end. Skip a duplicate approval post if the tool fires twice.
+      if (agent.pendingTeardown) {
+        return ok('Edit mode request already sent — task is pausing pending user approval.');
+      }
+
       // Validate an explicit target before posting so a bad key surfaces as
       // actionable feedback instead of silently dropping to the CLI log. The
       // task is left running so the agent can retry with a valid channel.
@@ -456,7 +462,9 @@ function createRequestEditModeTool(agent: Agent, task: Task) {
       ];
       await task.postInteractiveToUser(`Edit mode request: ${args.reason}`, blocks, 'edit_mode', args.channel);
 
-      await task.stop();
+      // Defer the pause to turn-end (see report_completion) so stopping the queue
+      // doesn't close the input stream under an in-flight hook ("stream closed").
+      agent.deferTeardown(() => task.stop());
       return { content: [{ type: 'text' as const, text: 'Edit mode request sent. Task paused pending user approval.' }] };
     },
   );
@@ -476,6 +484,11 @@ function createReportCompletionTool(agent: Agent, task: Task) {
       // (the previous complete() tore down the agent mid-response, so the retry is spurious).
       if (!task.isActive) {
         return ok('Task already completed.');
+      }
+      // Already asked to complete this turn — the spawn loop tears the task down
+      // when the turn ends. Skip duplicate side-effects (e.g. a second Slack post).
+      if (agent.pendingTeardown) {
+        return ok('Task already completing.');
       }
       // Refuse completion while a peer agent is still mid-turn — completing now
       // would stop their queue and drop the reply they're about to send back,
@@ -508,14 +521,12 @@ function createReportCompletionTool(agent: Agent, task: Task) {
       }
       logger.agentAction(agentName, 'Reporting completion', '');
       task.touch();
-      // Run complete() on next tick so this tool response streams back to the agent
-      // before the runtime tears it down. Without this, the response is lost and the
-      // agent's SDK reports "stream closed", causing a retry loop.
-      setImmediate(() => {
-        task.complete().catch((err) =>
-          logger.error('report_completion', 'Error completing task', err)
-        );
-      });
+      // Defer teardown to the spawn loop: it runs this once the agent's turn
+      // fully ends (the SDK `result` event), so this tool response and the Stop
+      // hook's control round-trip both finish over an open input stream. Stopping
+      // the queue here (mid-turn) closes the stream under an in-flight hook, which
+      // the SDK surfaces as a "stream closed" error.
+      agent.deferTeardown(() => task.complete());
       return ok(args.message ? 'Posted message to Slack and stopped task.' : 'Stopped task.');
     },
   );

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -827,7 +827,11 @@ export class Task {
     this.debouncedSave();
   }
 
-  async onResearchBudgetExceeded(): Promise<void> {
+  async onResearchBudgetExceeded(agent: Agent): Promise<void> {
+    // Already pausing this turn — the spawn loop stops the task at turn-end.
+    // Skip a duplicate approval post if web_research goes over budget again.
+    if (agent.pendingTeardown) return;
+
     logger.warn(
       'budget',
       `Research budget exceeded for task ${this.taskId} (${this.budgets.researchRequestCount}/${this.budgets.researchRequestLimit})`,
@@ -867,7 +871,10 @@ export class Task {
       'research_budget',
     ).catch((err: unknown) => logger.error('budget', 'Failed to post budget approval request', err));
 
-    await this.stop();
+    // Defer the stop to the calling agent's turn-end (see report_completion):
+    // web_research is mid-turn here, so stopping the queue now would close the
+    // input stream under an in-flight hook ("stream closed" error).
+    agent.deferTeardown(() => this.stop());
   }
 
   // ---- Approval handlers ----


### PR DESCRIPTION
## Problem

When an agent-invoked tool tore the task down, it stopped the agent's message queue **mid-turn**. That closed the SDK input stream while the turn was still finishing, so the **Stop hook** then tried its control round-trip over the now-closed stream and the SDK logged:

```
[pm-agent] stderr: Error in hook callback hook_3: ... error: Stream closed
```

`report_completion` already tried to dodge this with `setImmediate`, but one tick is nowhere near enough — the model still needs several ticks to end the turn and run the Stop hook.

## Fix

Drive teardown from the harness loop instead of from inside the tool. A new per-agent mechanism on `Agent`:

- `deferTeardown(action)` — queue a teardown closure (first-wins; later calls in the same turn are ignored)
- `pendingTeardown` — getter the spawn loop checks

The spawn loop runs whatever's queued when it observes the turn's SDK `result` event. By then the tool response has streamed back **and** the Stop hook's round-trip is done, so stopping the queue can no longer close the stream out from under an in-flight hook.

Applied to **all three** agent-invoked mid-turn teardown paths:

| Tool / path | Teardown |
| --- | --- |
| `report_completion` | `task.complete()` |
| `request_edit_mode` | `task.stop()` |
| `web_research` budget exceeded → `onResearchBudgetExceeded()` | `task.stop()` |

Each path also skips its side-effects (duplicate Slack posts) when a teardown is already pending, since the task now stays active until turn-end.

## Deliberately out of scope

The wall-clock timeout (`task.ts` `setupTaskTimeout` → `complete()`) is left as an **immediate** teardown — its job is to cap a stuck/runaway turn, so deferring to turn-end would defeat it. That path wants a hard stop (e.g. `AbortController`), not deferral.

## Verification

- `npm run typecheck` — clean
- Full test suite — **406/406 passing** (includes the `tool-contract` test covering `report_completion`)
- Confirmed against the installed SDK types (`@anthropic-ai/claude-agent-sdk@0.3.156`) that `result` is the per-turn terminal message
- No stale references to the old flag remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CC9YK1otNwCmNk9G5cpfU4)_