### PR TITLE
feat(git): migrate repo-agent branches to archie/ prefix

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -123,7 +123,7 @@ Repo agents are specialized for a single repository. They investigate code, make
 
 **Dual mode system**: The agent's mode is set per-task by `metadata.edit_allowed`. In read-only mode the sandbox makes the clone read-only and write-side MCP tools are disallowed; in edit mode the clone is writable and all `repo-tools` entries are exposed. The agent observes its mode through the available tool set and the injected `READ-ONLY` / `READ-WRITE` annotation in its system prompt.
 
-**Working directory**: The agent's cwd is its per-agent workspace at `sessions/{taskId}/agents/{key}/`. The repository itself lives at a task-local shared clone under `sessions/{taskId}/repos/{repoKey}` and is exposed via `additionalDirectories`. In read-only mode the clone is checked out on the base branch; in edit mode it carries a `feature/{taskId}` branch (or a previously persisted one). Shared task state at `sessions/{taskId}/shared/` is also mounted read-only.
+**Working directory**: The agent's cwd is its per-agent workspace at `sessions/{taskId}/agents/{key}/`. The repository itself lives at a task-local shared clone under `sessions/{taskId}/repos/{repoKey}` and is exposed via `additionalDirectories`. In read-only mode the clone is checked out on the base branch; in edit mode it carries an `archie/{taskId}` branch (or a previously persisted one). Shared task state at `sessions/{taskId}/shared/` is also mounted read-only.
 
 ### Plugin Agents
 

--- a/docs/architecture/edit-mode.md
+++ b/docs/architecture/edit-mode.md
@@ -12,7 +12,7 @@ In readonly mode the clone is checked out on the base branch (`{ type: 'base' }`
 
 ### Edit Mode (After Approval)
 
-Once edit mode is approved for a task, the repo path's sandbox flips from read-only to read-write (`Write`, `Edit`, and write-capable `Bash` commands are now allowed against the clone), and the previously-disallowed MCP tools become available: `push_branch`, `create_pull_request`, `update_pr`, `add_pr_comment`, `add_review_comment`, `reply_to_review_comment`, `resolve_review_thread`, `request_re_review`, `merge_pull_request`, `close_pull_request`, and `create_branch`. The next time a repo agent is spawned, the clone is set up on a fresh feature branch (`{ type: 'new_branch', name: 'feature/{taskId}' }`). Edit mode is a one-way, permanent transition for the task — once approved, it cannot be revoked. Clones for tasks with `edit_allowed === true` are NOT removed on stop/complete (they hold local commits, branches, and PR state).
+Once edit mode is approved for a task, the repo path's sandbox flips from read-only to read-write (`Write`, `Edit`, and write-capable `Bash` commands are now allowed against the clone), and the previously-disallowed MCP tools become available: `push_branch`, `create_pull_request`, `update_pr`, `add_pr_comment`, `add_review_comment`, `reply_to_review_comment`, `resolve_review_thread`, `request_re_review`, `merge_pull_request`, `close_pull_request`, and `create_branch`. The next time a repo agent is spawned, the clone is set up on a fresh feature branch (`{ type: 'new_branch', name: 'archie/{taskId}' }`). Edit mode is a one-way, permanent transition for the task — once approved, it cannot be revoked. Clones for tasks with `edit_allowed === true` are NOT removed on stop/complete (they hold local commits, branches, and PR state).
 
 ## Human-in-the-Loop Approval Flow
 
@@ -44,7 +44,7 @@ Immediately after posting the approval request, `request_edit_mode` calls `task.
 - `handleEditModeApproval()` in `src/tasks/task.ts` is called.
 - Sets `metadata.edit_allowed = true` on the task and persists via `debouncedSave()`.
 - Appends the system finding `Edit mode approved by user` (decision) to `knowledge.log`.
-- Reactivates the PM agent by sending the `existingTask` agent prompt (which reactivates the task and re-spawns agents — repo agents now spawn into a fresh `feature/{taskId}` branch).
+- Reactivates the PM agent by sending the `existingTask` agent prompt (which reactivates the task and re-spawns agents — repo agents now spawn into a fresh `archie/{taskId}` branch).
 
 **Deny** (handled in `src/connectors/slack/events.ts: app.action("deny_edit_mode")`, with the same API equivalent):
 - The original message is updated to replace the buttons with `Edit mode denied by <@user>`.
@@ -102,7 +102,7 @@ spawnAgent() called (repo track)
   -> If task-local path is a legacy worktree → migrateWorktreeToClone()
   -> If a shared clone already exists at the path → reuse it
   -> Otherwise pick a CloneCheckout from previous branch state + edit mode:
-       editAllowed && (no previous branch || previous == base) → new_branch (feature/{taskId})
+       editAllowed && (no previous branch || previous == base) → new_branch (archie/{taskId})
        editAllowed && previous != base                          → branch (restore previous_branch)
        readonly                                                 → base
      Then call setupSharedClone(...) with that checkout.
@@ -191,10 +191,10 @@ The full single allowed-tool list (set as `def.tools` on the repo agent definiti
 
 ## Branch Strategy
 
-The first feature branch follows the pattern `feature/{taskId}`, where `taskId` is the full task identifier (e.g., `task-20260101-1823-abc123`) and so already begins with `task-`. If the agent calls `create_branch` again on the same task, additional branches are auto-numbered as `feature/{taskId}-2`, `feature/{taskId}-3`, etc. This naming serves double duty:
+The first feature branch follows the pattern `archie/{taskId}`, where `taskId` is the full task identifier (e.g., `task-20260101-1823-abc123`) and so already begins with `task-`. If the agent calls `create_branch` again on the same task, additional branches are auto-numbered as `archie/{taskId}-2`, `archie/{taskId}-3`, etc. Branch naming lives in `src/connectors/github/branch-naming.ts` (`taskBranchName()`). This naming serves double duty:
 
 1. **Isolation**: Each task gets its own branch (or family of branches), preventing cross-task interference.
-2. **Webhook routing**: The webhook router uses `extractTaskIdFromBranch()` in `src/connectors/github/webhooks.ts` to match incoming GitHub events (pushes, CI results, reviews) back to the correct task. The regex `^feature\/(task-\d{8}-\d{4}-[a-z0-9]+)(?:-\d+)?$` extracts the task ID, allowing the optional `-N` suffix from multi-branch tasks.
+2. **Webhook routing**: The webhook router uses `extractTaskIdFromBranch()` (re-exported from `src/connectors/github/webhooks.ts`) to match incoming GitHub events (pushes, CI results, reviews) back to the correct task. The regex `^(?:archie|feature)\/(task-\d{8}-\d{4}-[a-z0-9]+)(?:-\d+)?$` extracts the task ID, allowing the optional `-N` suffix from multi-branch tasks. The legacy `feature/` prefix remains accepted so pull requests opened before the migration keep attributing to their task.
 
 ## Cross-Agent Isolation
 
@@ -217,13 +217,13 @@ sessions/
 Key isolation properties:
 
 - **Separate clones**: Each repo agent gets its own task-local shared clone derived from a different base repository, so there is no cross-contamination between repositories.
-- **Separate branches**: Each clone has its own `feature/{taskId}` branch (created in RW mode), branched from the respective repository's base branch.
+- **Separate branches**: Each clone has its own `archie/{taskId}` branch (created in RW mode), branched from the respective repository's base branch.
 - **Base repo isolation**: Clones are created with `git clone --shared` from the base repository. They borrow objects via `objects/info/alternates` but have independent refs/index, and `origin` is rewritten to GitHub so pushes never go back to the base repo. Multiple tasks can share the same base repo without conflict.
 - **Git identity**: `configureGitIdentity(clonePath)` runs after clone creation so commits get the configured user name and email.
 
 ## Session Handling on Mode Transition
 
-The PM agent's reactivation after approval/denial uses `task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent')`, which routes through the standard task-reactivation path. When the PM later sends work to a repo agent, `ensureAgentSpawned()` calls `spawnAgent()` for that agent. Because the readonly clone was deleted on the earlier `task.stop()`, `cloneExists()` returns false and a brand-new clone is created — in RW mode that means `setupSharedClone({ type: 'new_branch', name: 'feature/{taskId}' })`. The SDK session for the repo agent is started without a prior `session_id`, so it starts fresh against the new clone path.
+The PM agent's reactivation after approval/denial uses `task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent')`, which routes through the standard task-reactivation path. When the PM later sends work to a repo agent, `ensureAgentSpawned()` calls `spawnAgent()` for that agent. Because the readonly clone was deleted on the earlier `task.stop()`, `cloneExists()` returns false and a brand-new clone is created — in RW mode that means `setupSharedClone({ type: 'new_branch', name: 'archie/{taskId}' })`. The SDK session for the repo agent is started without a prior `session_id`, so it starts fresh against the new clone path.
 
 If a clone is reused across stop/reactivate cycles (e.g., RW reactivation where the clone was preserved), the existing SDK `session_id` (stored in `metadata.agent_sessions[agentId]`) is passed via `resume`, and the spawn flow runs `fetch origin` on the reused clone before continuing.
 

--- a/docs/architecture/github-integration.md
+++ b/docs/architecture/github-integration.md
@@ -46,7 +46,7 @@ The webhook router (`src/connectors/github/webhooks.ts`) uses purely determinist
 The router identifies which task an event belongs to by:
 
 1. **Branch name extraction** -- For events with a `pull_request` object, extracts `head.ref`. For `push` events, extracts from `refs/heads/...`. For `workflow_run`, uses `head_branch`.
-2. **Task ID extraction** -- Matches the branch name against the pattern `feature/task-{taskId}` via `extractTaskIdFromBranch()`.
+2. **Task ID extraction** -- Matches the branch name against the pattern `archie/task-{taskId}` via `extractTaskIdFromBranch()`. The legacy `feature/task-{taskId}` prefix is also accepted so pull requests opened before the branch-naming migration keep attributing to their task.
 3. **PR number fallback** -- For `issue_comment` events (which lack branch info), looks up the task by PR number using `findTaskByPRNumber()`.
 
 If no task ID is found, the event is discarded as "Not our branch pattern."
@@ -83,8 +83,8 @@ Route actions map to handler types:
 
 - `from=alice, destination=PR #42, message=approved`
 - `from=bob, destination=PR #42, message=requested changes: needs more tests`
-- `from=ci, destination=branch:feature/task-abc123, message=workflow failure`
-- `from=alice, destination=branch:feature/task-abc123, message=pushed`
+- `from=ci, destination=branch:archie/task-abc123, message=workflow failure`
+- `from=alice, destination=branch:archie/task-abc123, message=pushed`
 
 These entries are written to the task's knowledge log so the PM agent can understand what happened.
 
@@ -116,7 +116,7 @@ All tools below are registered on the same `repo-tools` MCP server. Whether a to
 |---|---|
 | `push_branch` | Push commits from the local shared clone to origin via `git push -u origin HEAD:{branch}`. |
 | `create_pull_request` | Create a PR on GitHub. Stores the PR number in the current branch's `BranchState`. |
-| `create_branch` | Create a new branch (auto-named `feature/{taskId}` or `feature/{taskId}-N`) and switch to it. |
+| `create_branch` | Create a new branch (auto-named `archie/{taskId}` or `archie/{taskId}-N`) and switch to it. |
 | `update_pr` | Update the title, description, and/or base branch of an existing PR (all fields optional). |
 | `add_pr_comment` | Add a general comment to a PR (issue comment). |
 | `add_review_comment` | Start a NEW review thread on a specific file and line. |

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -437,8 +437,9 @@ type GitHubRouteResult =
   | { action: 'direct'; handler: 'merge_check' | 'existing_task'; taskId: string };
 ```
 
-The router extracts a task ID from the branch name pattern (`feature/task-{id}`) or,
-for `issue_comment` events, looks up the task by PR number via `findTaskByPRNumber()`.
+The router extracts a task ID from the branch name pattern (`archie/task-{id}`, with
+the legacy `feature/task-{id}` prefix still accepted) or, for `issue_comment` events,
+looks up the task by PR number via `findTaskByPRNumber()`.
 
 **Deterministic routing** (no triage step exists for GitHub):
 - `pull_request_review` (approved) -> `merge_check`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -101,7 +101,7 @@ Each task gets its own `Task` instance (a class that encapsulates runtime state)
 
 ### Shared Git Clones
 
-All repo agents work in isolated `git clone --shared` checkouts (`src/connectors/github/repo-clone.ts`), regardless of mode. Each clone has its own `.git/` directory, refs, index, and HEAD, but borrows objects from the base repo's object store via alternates. In **readonly mode**, the clone is checked out on `origin/{baseBranch}`. In **edit mode**, the clone has a feature branch (`feature/task-{taskId}`) based on the repository's default branch. Agents can track multiple branches per clone via `BranchState` records. Agents commit locally and manage their own PRs via the `repo-tools` MCP server; clones for readonly tasks are cleaned up on task stop/complete. Legacy worktrees are migrated to shared clones on first encounter (`migrateWorktreeToClone`).
+All repo agents work in isolated `git clone --shared` checkouts (`src/connectors/github/repo-clone.ts`), regardless of mode. Each clone has its own `.git/` directory, refs, index, and HEAD, but borrows objects from the base repo's object store via alternates. In **readonly mode**, the clone is checked out on `origin/{baseBranch}`. In **edit mode**, the clone has a feature branch (`archie/task-{taskId}`) based on the repository's default branch. Agents can track multiple branches per clone via `BranchState` records. Agents commit locally and manage their own PRs via the `repo-tools` MCP server; clones for readonly tasks are cleaned up on task stop/complete. Legacy worktrees are migrated to shared clones on first encounter (`migrateWorktreeToClone`).
 
 ### Plugin Architecture
 
@@ -155,7 +155,7 @@ See [plugin-system.md](plugin-system.md) for details.
    → connectors/github/events.ts receives via Express endpoint
 
 2. connectors/github/webhooks.ts performs deterministic routing:
-   → Matches task by branch name (feature/task-{id}) or PR number
+   → Matches task by branch name (archie/task-{id}, legacy feature/task-{id}) or PR number
    → Routes to: direct (reviews, CI, comments), merge_check, or discard
 
 3. Events are appended to the matched task and the PM agent is messaged

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -25,6 +25,7 @@ import {
   createSchedulingMcpServer,
 } from './tools.js';
 import { hydrateBranchState } from '../connectors/github/branch-state.js';
+import { taskBranchName } from '../connectors/github/branch-naming.js';
 import { createResearchMcpServer, createResearchPostToolHook, createResearchDefenseTagHook } from '../mcp/research-tools.js';
 import { buildPeerListForSender } from './registry.js';
 import {
@@ -207,7 +208,7 @@ async function prepareRepoClone(agent: Agent, task: Task): Promise<RepoCloneSetu
     let checkout: CloneCheckout;
     if (editAllowed && wasOnBaseBranch) {
       // RW mode, was on base branch (or no branch) — create feature branch for new work
-      checkout = { type: 'new_branch', name: `feature/${taskId}` };
+      checkout = { type: 'new_branch', name: taskBranchName(taskId) };
     } else if (editAllowed && !wasOnBaseBranch) {
       // RW but was on a specific branch — restore it
       checkout = { type: 'branch', name: previousBranch! };

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -20,6 +20,7 @@ import { getAgentIds, getVisiblePeerIdsForSender, getAgentDef } from './registry
 import { getGitHubClient, parseCheckRef } from '../connectors/github/client.js';
 import { gitExec } from '../connectors/github/repo-clone.js';
 import { mirrorLegacyFields, hydrateBranchState, findBranchStateByPR } from '../connectors/github/branch-state.js';
+import { taskBranchName } from '../connectors/github/branch-naming.js';
 import { appendAgentFinding, appendArtifactShared } from '../tasks/persistence.js';
 import { copyArtifactToShared, assertReadable } from './artifacts.js';
 import { launchTask } from '../tasks/launch.js';
@@ -776,7 +777,7 @@ function createPullRequestTool(agent: Agent, task: Task) {
       const repoInfo = task.metadata.repositories[repoKey];
       const branch = repoInfo?.current_branch;
       const state = branch ? repoInfo?.branch_states?.[branch] : undefined;
-      const head = branch || `feature/task-${task.taskId}`;
+      const head = branch || taskBranchName(task.taskId);
       const base = state?.base_branch || agent.def.repo!.baseBranch || 'main';
 
       const result = await client.createPullRequest(githubRepo, head, base, args.title, args.body);
@@ -1321,9 +1322,7 @@ function createCreateBranchTool(agent: Agent, task: Task) {
 
       // Count existing branches to generate unique name
       const existing = Object.keys(repoInfo.branch_states || {}).length;
-      const branchName = existing === 0
-        ? `feature/${task.taskId}`
-        : `feature/${task.taskId}-${existing + 1}`;
+      const branchName = taskBranchName(task.taskId, existing);
 
       const base = args.base || 'HEAD';
       await gitExec(repoInfo.clone_path, `checkout -b ${branchName} ${base}`);

--- a/src/connectors/github/__tests__/branch-naming.test.ts
+++ b/src/connectors/github/__tests__/branch-naming.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for repo-agent branch naming and task-ID extraction.
+ *
+ * These lock in the migration contract: new branches use the `archie/` prefix,
+ * while the webhook parser keeps attributing branches with the legacy `feature/`
+ * prefix so historical PRs continue routing to their task.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  BRANCH_PREFIX,
+  taskBranchName,
+  extractTaskIdFromBranch,
+} from '../branch-naming.js';
+
+const TASK_ID = 'task-20260101-1823-abc123';
+
+describe('taskBranchName', () => {
+  it('uses the archie prefix for the first branch', () => {
+    expect(taskBranchName(TASK_ID)).toBe(`archie/${TASK_ID}`);
+    expect(BRANCH_PREFIX).toBe('archie');
+  });
+
+  it('auto-numbers additional branches', () => {
+    expect(taskBranchName(TASK_ID, 1)).toBe(`archie/${TASK_ID}-2`);
+    expect(taskBranchName(TASK_ID, 2)).toBe(`archie/${TASK_ID}-3`);
+  });
+});
+
+describe('extractTaskIdFromBranch', () => {
+  it('extracts the task ID from a new archie/ branch', () => {
+    expect(extractTaskIdFromBranch(`archie/${TASK_ID}`)).toBe(TASK_ID);
+  });
+
+  it('extracts the task ID from a legacy feature/ branch (backward compat)', () => {
+    expect(extractTaskIdFromBranch(`feature/${TASK_ID}`)).toBe(TASK_ID);
+  });
+
+  it('handles the multi-branch suffix for both prefixes', () => {
+    expect(extractTaskIdFromBranch(`archie/${TASK_ID}-2`)).toBe(TASK_ID);
+    expect(extractTaskIdFromBranch(`feature/${TASK_ID}-3`)).toBe(TASK_ID);
+  });
+
+  it('round-trips generated branch names', () => {
+    expect(extractTaskIdFromBranch(taskBranchName(TASK_ID))).toBe(TASK_ID);
+    expect(extractTaskIdFromBranch(taskBranchName(TASK_ID, 4))).toBe(TASK_ID);
+  });
+
+  it('returns undefined for unrelated or malformed branches', () => {
+    expect(extractTaskIdFromBranch(undefined)).toBeUndefined();
+    expect(extractTaskIdFromBranch('main')).toBeUndefined();
+    expect(extractTaskIdFromBranch('archie/not-a-task')).toBeUndefined();
+    expect(extractTaskIdFromBranch(`release/${TASK_ID}`)).toBeUndefined();
+  });
+});

--- a/src/connectors/github/branch-naming.ts
+++ b/src/connectors/github/branch-naming.ts
@@ -1,0 +1,52 @@
+/**
+ * Branch naming for repo-agent feature branches.
+ *
+ * New branches use the `archie/` prefix (e.g. `archie/task-20260101-1823-abc123`).
+ * The legacy `feature/` prefix is still recognized when attributing webhooks so
+ * that pull requests opened before the migration keep routing to their task.
+ *
+ * Single source of truth for both branch generation (spawn, create_branch tool,
+ * PR head fallback) and branch parsing (webhook → task attribution).
+ */
+
+/** Prefix used for newly created repo-agent branches. */
+export const BRANCH_PREFIX = 'archie';
+
+/**
+ * Prefixes accepted when parsing a task ID out of a branch name, beyond the
+ * current {@link BRANCH_PREFIX}. Kept so historical PRs (and any in-flight task
+ * whose branch was created before the migration) keep attributing correctly.
+ */
+export const LEGACY_BRANCH_PREFIXES = ['feature'] as const;
+
+/**
+ * Build the branch name for a task.
+ *
+ * The first branch is `archie/{taskId}`. Additional branches are auto-numbered
+ * `archie/{taskId}-2`, `archie/{taskId}-3`, ... — `existingCount` is the number
+ * of branches already created for the task (0 for the first).
+ */
+export function taskBranchName(taskId: string, existingCount = 0): string {
+  return existingCount === 0
+    ? `${BRANCH_PREFIX}/${taskId}`
+    : `${BRANCH_PREFIX}/${taskId}-${existingCount + 1}`;
+}
+
+/** Regex matching `{prefix}/{taskId}` for any accepted prefix, capturing the task ID. */
+const BRANCH_TASK_ID_RE = new RegExp(
+  `^(?:${[BRANCH_PREFIX, ...LEGACY_BRANCH_PREFIXES].join('|')})\\/(task-\\d{8}-\\d{4}-[a-z0-9]+)(?:-\\d+)?$`,
+  'i',
+);
+
+/**
+ * Extract the task ID from a branch name.
+ *
+ * Branch format: `{prefix}/{taskId}` or `{prefix}/{taskId}-{N}` (multi-branch
+ * suffix), where prefix is the current `archie` prefix or a legacy prefix.
+ * Task ID format: `task-YYYYMMDD-HHMM-random`.
+ */
+export function extractTaskIdFromBranch(branch: string | undefined): string | undefined {
+  if (!branch) return undefined;
+  const match = branch.match(BRANCH_TASK_ID_RE);
+  return match ? match[1] : undefined;
+}

--- a/src/connectors/github/webhooks.ts
+++ b/src/connectors/github/webhooks.ts
@@ -9,6 +9,7 @@
  */
 
 import crypto from 'crypto';
+import { extractTaskIdFromBranch } from './branch-naming.js';
 import { checkAndMergeLinkedPRs } from './merge.js';
 import { findTaskByPRNumber, loadMetadata, appendGitHubEvent } from '../../tasks/persistence.js';
 import { Task } from '../../tasks/task.js';
@@ -150,16 +151,10 @@ export function extractBranchFromPayload(
   return undefined;
 }
 
-/**
- * Extract task ID from branch name
- * Branch format: feature/{taskId} or feature/{taskId}-{N} (multi-branch suffix)
- * Task ID format: task-YYYYMMDD-HHMM-random
- */
-export function extractTaskIdFromBranch(branch: string | undefined): string | undefined {
-  if (!branch) return undefined;
-  const match = branch.match(/^feature\/(task-\d{8}-\d{4}-[a-z0-9]+)(?:-\d+)?$/i);
-  return match ? match[1] : undefined;
-}
+// Task ID is parsed out of the branch name by `extractTaskIdFromBranch`
+// (re-exported from ./branch-naming), which accepts both the current `archie/`
+// prefix and the legacy `feature/` prefix so historical PRs keep attributing.
+export { extractTaskIdFromBranch };
 
 // ============================================================================
 // Event Message Formatting
@@ -435,7 +430,7 @@ export async function routeGitHubEvent(
   }
 
   // For check_suite events, fall back to PR-number lookup if the branch
-  // doesn't match our feature/{taskId} pattern (e.g. suite attached to base).
+  // doesn't match our {prefix}/{taskId} pattern (e.g. suite attached to base).
   if (!taskId && eventType === 'check_suite' && context.prNumber) {
     taskId = await findTaskByPRNumber(context.githubRepo, context.prNumber) ?? undefined;
   }


### PR DESCRIPTION
## What

Migrates repo-agent git branch naming from the `feature/` prefix to a new `archie/` prefix, while keeping GitHub PR webhook attribution working for branches/PRs created with the **old** prefix.

New branches: `archie/task-20260101-1823-abc123` (the task ID itself is unchanged).

## Why

Branch names should reflect that Archie owns them. The constraint was that existing open PRs (and in-flight tasks whose branch was already created) must keep routing to the correct task — webhook attribution parses the task ID straight out of the branch name.

## How

- **New module `src/connectors/github/branch-naming.ts`** — single source of truth for branch naming:
  - `BRANCH_PREFIX = 'archie'` and `LEGACY_BRANCH_PREFIXES = ['feature']`
  - `taskBranchName(taskId, existingCount)` — builds `archie/{taskId}` (and auto-numbered `-2`, `-3`, … for multi-branch tasks)
  - `extractTaskIdFromBranch()` — parses the task ID from a branch, accepting **both** `archie/` and legacy `feature/` prefixes
- **Generators switched** to `taskBranchName()` (prefix no longer scattered):
  - `spawn.ts` — edit-mode branch created on spawn
  - `tools.ts` — `create_branch` tool
  - `tools.ts` — `create_pull_request` head fallback (also fixes a latent double-`task-` bug)
- **Webhook parser widened** to `^(?:archie|feature)\/(task-…)…$`, still anchored and still exported from `webhooks.ts` (no importer breakage).
- **Docs** under `docs/architecture/` updated to `archie/` with legacy notes. `docs/plans/` (historical) left untouched.

## Backward compatibility

- Old PRs on `feature/` branches → still attributed via the widened parser.
- In-flight tasks → spawn restores the persisted `current_branch` rather than regenerating, so their `feature/` branch is untouched.
- Only brand-new branches get the `archie/` prefix.

## Testing

- New `src/connectors/github/__tests__/branch-naming.test.ts` covers both prefixes, the `-N` suffix, round-tripping, and negative cases.
- `npm run typecheck`: clean
- `npx vitest run`: 421 passed (23 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018v5HpebJK9f9zgTxgK7ypn)_