### PR TITLE
Symlink plugin skills for repo agents, not just plugin agents

### DIFF
--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -256,7 +256,9 @@ sessions/{task-id}/agents/{agentKey}/.claude/skills/{skillName} -> plugins/{plug
 
 The PM agent also gets its own workspace with skills symlinked from its plugin at spawn time.
 
-**Source:** `src/agents/spawn.ts` (`setupAgentWorkspace`)
+Skill symlinking is uniform across all tracks: every agent — repo, plugin, and PM — gets its own workspace, and `setupAgentWorkspace` symlinks the owning plugin's `skills/` the same way regardless of track. A repo agent whose plugin ships a `skills/` directory loads those skills via the `Skill` tool exactly like a plugin agent does. (For this to resolve, the agent def carries `pluginPath` so the symlink targets — which live under the plugins dir inside `WORKDIR` — are inside the agent's sandbox read paths; the registry sets `pluginPath`/`skillsPath` on both repo and plugin agents.)
+
+**Source:** `src/agents/spawn.ts` (`setupAgentWorkspace`), `src/agents/registry.ts`
 
 ## Task Directory Structure
 

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -75,6 +75,7 @@ export function scanAgentDefs(): AgentDef[] {
           pluginName: plugin.name,
           visibility,
           agentPrompt: agent.prompt || undefined,
+          pluginPath: plugin.dir,
           repo: {
             repos: agent.repo.repos.map((r) => ({
               github: r.github,
@@ -83,6 +84,7 @@ export function scanAgentDefs(): AgentDef[] {
             primary: agent.repo.primary,
           },
           pluginDataPath: join(PLUGINS_DATA_DIR, plugin.name),
+          skillsPath: plugin.skillsPath || undefined,
           pluginHooks: plugin.hooks || undefined,
           allowedNetworkDomains: agent.allowedNetworkDomains,
           ...resolvedMcp,


### PR DESCRIPTION
## Summary

Skill loading shouldn't depend on an agent's track. Every agent already gets its own workspace, and `setupAgentWorkspace` symlinks the owning plugin's `skills/` the same way for any agent — but the registry only set `pluginPath` and `skillsPath` on the **plugin-agent** branch, so **repo agents silently never received their plugin's skills**. Harmless until now only because no repo plugin shipped a `skills/` directory.

This sets `pluginPath` and `skillsPath` on the repo-agent `AgentDef` too, mirroring the plugin-agent branch.

## Why both fields

- **`skillsPath`** — what `setupAgentWorkspace` uses to symlink the plugin's `skills/` into the agent workspace (`.claude/skills/<name>`).
- **`pluginPath`** — required for those symlinks to actually *resolve*: they target the plugin dir under `WORKDIR`, so the dir must be in the agent's sandbox read paths. As a side effect the plugin dir becomes write-denied (exactly as it already is for plugin agents), and `${CLAUDE_PLUGIN_ROOT}` resolves for repo agents.

The `AgentDef` type already documents `pluginPath` as set on every non-PM agent, so this aligns the code with the intended contract rather than changing it. No tests referenced these fields.

## Effect

A repo agent whose plugin ships a `skills/` dir now loads those skills via the `Skill` tool, exactly like a plugin agent. This unblocks the new `archie` self-improvement agent in `archie-plugins` (its `improving-archie` runbook is a plugin skill).

## Testing

- `npm run typecheck` — clean
- `npm test` — 426/426 pass

## Changes

- `src/agents/registry.ts` — set `pluginPath` + `skillsPath` on the repo-agent branch
- `docs/architecture/plugin-system.md` — note skill symlinking is uniform across tracks

## Related

Pairs with the self-improvement system PR in `sweatco/archie-plugins` (same branch). **Deploy this first** — the plugins side's `improving-archie` skill only loads once this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zNvFxS3FLxpiEMwwUse8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_015zNvFxS3FLxpiEMwwUse8Q)_