### PR TITLE
Sync plugin submodules on refresh

### DIFF
--- a/src/system/workdir.ts
+++ b/src/system/workdir.ts
@@ -167,6 +167,9 @@ export async function refreshPlugins(): Promise<boolean> {
         await execAsync('git fetch --all --prune', { cwd: PLUGINS_DIR });
         await execAsync(`git checkout "${branch}"`, { cwd: PLUGINS_DIR });
         await execAsync(`git reset --hard "origin/${branch}"`, { cwd: PLUGINS_DIR });
+        // `reset --hard` moves the gitlink but not submodule working trees, so sync
+        // submodules onto their recorded commits (and init any newly added ones).
+        await execAsync('git submodule update --init --recursive', { cwd: PLUGINS_DIR });
         logger.system('Plugins refreshed from remote');
         // Re-scan plugin definitions (picks up new/changed agents, prompts, etc.)
         initPlugins();


### PR DESCRIPTION
## What

Add `git submodule update --init --recursive` after the `reset --hard` in the plugins on-demand refresh path (`src/system/workdir.ts`, `refreshPlugins()`).

## Why

The fresh plugins clone already uses `git clone --recurse-submodules`, so first boot handles submodules correctly. But the refresh path (run on every task start when the remote branch moves) only ran `reset --hard`, which moves the submodule gitlink **without** updating the submodule's working tree — and never initializes a newly added submodule at all. The result: after a pointer bump on the plugins branch, Archie could serve stale or empty submodule content.

This unblocks hosting shared analytics skills as a submodule inside `archie-plugins`, so on-demand plugin pulls respect submodules.

## Notes

- One line added; reuses the existing `execAsync(..., { cwd: PLUGINS_DIR })` pattern from the adjacent lines.
- The local-dev symlinked-plugins path is untouched (it skips refresh by design).
- Submodule path is flexible — any location works as long as shared skill dirs end up as direct children of a plugin's `skills/` folder (skill discovery requirement, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M8AoRGpna9iJZfsMNudwR

---
_Generated by [Claude Code](https://claude.ai/code/session_019M8AoRGpna9iJZfsMNudwR)_