### PR TITLE
Fix web research tool: empty reports + broken preset routing

### DIFF
--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -17,9 +17,8 @@ import { join } from 'path';
 import { query, tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import type { HookCallbackMatcher, HookJSONOutput } from '@anthropic-ai/claude-agent-sdk';
 import { z, toJSONSchema } from 'zod';
-import { processAgentEventForLogging, logger } from '../system/logger.js';
+import { logger } from '../system/logger.js';
 import { appendAgentFinding } from '../tasks/persistence.js';
-import { SESSIONS_DIR } from '../system/workdir.js';
 
 // ============================================================================
 // Callbacks Interface
@@ -43,22 +42,31 @@ const PresetSchema = z.object({
   reasoning: z.string(),
 });
 
-const presetJsonSchema = toJSONSchema(PresetSchema) as Record<string, unknown>;
+// Mirror the title-generator pattern: strip the JSON Schema dialect URL
+// ($schema) — the SDK's structured-output validator rejects it, which caused
+// classification to silently fail and always fall back to pro-search.
+const rawPresetSchema = toJSONSchema(PresetSchema) as Record<string, unknown>;
+const { $schema: _dropSchema, ...presetJsonSchema } = rawPresetSchema;
 
-/**
- * Classify query complexity to select the right Perplexity preset.
- * Uses Haiku with structured JSON output (same pattern as triage).
- * Falls back to pro-search on any failure.
- */
-async function classifyPreset(topic: string, context?: string): Promise<string> {
-  const input = `Classify this research query and select the appropriate Perplexity preset.
+const CLASSIFIER_SYSTEM_PROMPT = `You are a research query classifier. Analyze the query and select the most appropriate Perplexity search preset.
 
-Research topic: ${topic}${context ? `\nContext: ${context}` : ''}
-
-Guidelines:
+Presets:
 - fast-search: Simple factual lookups, definitions, single-entity queries, quick answers
 - pro-search: Multi-faceted questions, comparisons, current events, moderate research
 - deep-research: Comprehensive analysis, market research, technical deep-dives, broad strategic topics
+
+Respond with JSON only.`;
+
+/**
+ * Classify query complexity to select the right Perplexity preset.
+ * Uses Haiku with structured JSON output (same lean shape as the title
+ * generator, which is the proven-working one-shot pattern).
+ * Falls back to pro-search on any failure.
+ */
+async function classifyPreset(topic: string, context?: string): Promise<string> {
+  const prompt = `Classify this research query and select the appropriate Perplexity preset.
+
+Research topic: ${topic}${context ? `\nContext: ${context}` : ''}
 
 Respond with JSON only.`;
 
@@ -66,31 +74,35 @@ Respond with JSON only.`;
     let result: z.infer<typeof PresetSchema> | null = null;
 
     for await (const event of query({
-      prompt: input,
+      prompt,
       options: {
         model: 'haiku',
-        systemPrompt: 'You are a research query classifier. Analyze the query and select the most appropriate search preset. Respond with JSON only.',
-        cwd: SESSIONS_DIR,
+        systemPrompt: CLASSIFIER_SYSTEM_PROMPT,
         executable: 'node',
         env: {
           NODE_ENV: process.env.NODE_ENV || 'development',
           ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
           PATH: process.env.PATH,
         },
-        allowedTools: [],
+        tools: [],
+        maxTurns: 2,
         outputFormat: {
           type: 'json_schema',
           schema: presetJsonSchema,
         },
       },
     })) {
-      processAgentEventForLogging(event, 'research-classifier', [SESSIONS_DIR]);
-      if (event.type === 'result' && event.subtype === 'success') {
+      if (event.type !== 'result') continue;
+      if (event.subtype === 'success') {
         const parsed = PresetSchema.safeParse((event as any).structured_output);
         if (parsed.success) {
           result = parsed.data;
           logger.agent('research', `Classified as ${result.preset}: ${result.reasoning}`);
+        } else {
+          logger.warn('research', `preset schema validation failed: ${parsed.error.message}`);
         }
+      } else {
+        logger.warn('research', `preset classification failed: ${event.subtype}`);
       }
     }
 

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -142,8 +142,9 @@ async function callPerplexity(preset: string, input: string): Promise<Perplexity
       // Anthropic models proxied through Perplexity require an explicit output
       // cap — without it the backend rejects the request with
       // "max_output_tokens is required when using Anthropic models" and returns
-      // an empty report. Overridable via env for deep-research headroom.
-      max_output_tokens: Number(process.env.PERPLEXITY_MAX_OUTPUT_TOKENS) || 8192,
+      // an empty report. Set to the Sonnet output ceiling so we don't truncate
+      // long deep-research reports; overridable via env.
+      max_output_tokens: Number(process.env.PERPLEXITY_MAX_OUTPUT_TOKENS) || 64000,
     }),
   });
 

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -139,6 +139,11 @@ async function callPerplexity(preset: string, input: string): Promise<Perplexity
       model: 'anthropic/claude-sonnet-4-6',
       input,
       stream: false,
+      // Anthropic models proxied through Perplexity require an explicit output
+      // cap — without it the backend rejects the request with
+      // "max_output_tokens is required when using Anthropic models" and returns
+      // an empty report. Overridable via env for deep-research headroom.
+      max_output_tokens: Number(process.env.PERPLEXITY_MAX_OUTPUT_TOKENS) || 8192,
     }),
   });
 


### PR DESCRIPTION
## Summary

Two small, independent bug fixes that restore the `web_research` tool, both confined to `src/mcp/research-tools.ts`. This is the essential subset of the research fix from #70 — **without** the web-research extension restructure (file moves, extension loader, host hooks, tool-budget framework).

## The two bugs

**1. Every search returned an empty report (the tool was effectively down).**
`callPerplexity` calls the Perplexity Agent API with an Anthropic model (`anthropic/claude-sonnet-4-6`) but never sent `max_output_tokens`. Perplexity requires it when proxying to Anthropic models, so every request failed with `max_output_tokens is required when using Anthropic models` and returned nothing.
→ Add `max_output_tokens` to the request body (default `8192`, overridable via `PERPLEXITY_MAX_OUTPUT_TOKENS`).

**2. Preset routing never worked — always fell back to `pro-search`.**
`classifyPreset` passed the generated JSON schema with its `$schema` dialect URL to the SDK's structured-output validator, which rejects it. Classification silently failed on every call, so fast/pro/deep routing never happened.
→ Strip `$schema`, align with the proven title-generator one-shot shape (`tools: []` + `maxTurns: 2`, drop the unnecessary `cwd`), and log error result subtypes instead of swallowing them.

## Why not just merge #70

#70 fixes the classifier but bundles it with a drastic refactor (moving the tool into `src/extensions/web-research/`, an extension loader/manifest, host-side hooks, and a generic tool-budget system) across many files in one squashed commit. This PR takes only the essentials and additionally fixes the `max_output_tokens` failure, which #70 does not address.

## Test plan

- [x] `npm run typecheck` clean
- [x] Full suite passes (426 tests)
- [ ] Manual: fire a `web_research` call and confirm a non-empty report with correct preset classification in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT8GjB67f2CjnDwtEfjyVn

---
_Generated by [Claude Code](https://claude.ai/code/session_01YT8GjB67f2CjnDwtEfjyVn)_