### PR TITLE
migrate docker build into gh actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7 # 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0 # d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4.2.0 # 650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare image tag
+        id: image_tag
+        shell: bash
+        run: |
+          branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          branch="${branch//[^a-zA-Z0-9_.-]/-}"
+          echo "tag=${REGISTRY}/${IMAGE_NAME}:${branch}-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish Docker image
+        uses: docker/build-push-action@v7.2.0 # f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: .
+          file: Dockerfile.prod
+          # push only from default branch builds
+          push: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+          tags: ${{ steps.image_tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Jenkinsfile.build
+++ b/Jenkinsfile.build
@@ -1,7 +1,0 @@
-// https://www.notion.so/sweatco/Using-Jenkins-shared-libs-to-build-container-images-1c1964d3bcdd80ac8a2fe4b3a87d9500
-@Library('SweatcoinSharedLibs') _
-
-containerBuildPipeline_v1 (
-    containerRepoName: 'sweatcoin-archie-hq',
-    dockerfilePath: "./Dockerfile.prod"
-)

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -57,9 +57,9 @@ GitHub access is via a GitHub App installation token (auto-rotating, through Oct
 
 Continuous integration runs via GitHub Actions: on every push and pull request it installs dependencies, type-checks, builds, runs the test suite, and runs a [gitleaks](https://github.com/gitleaks/gitleaks) secret scan over the working tree and full history. A merge that fails any of these gates is blocked. The workflow lives at `.github/workflows/ci.yml`.
 
-Building and publishing the production container image currently runs through an internal Jenkins pipeline defined in `Jenkinsfile.build` (the image is built from `Dockerfile.prod`). The operator then pulls the new tag on the host, restarts the service, and verifies health via `GET /health`.
+Building and publishing the production container image also runs via GitHub Actions. `.github/workflows/docker-publish.yml` runs on pushes to `main` and via manual `workflow_dispatch`, builds `Dockerfile.prod` with Docker Buildx, and publishes to GitHub Container Registry as `ghcr.io/<owner>/<repo>:main-<commit-sha>`.
 
-The GitHub Actions workflow above (CI: typecheck/build/test/secret-scan) is independent of and coexists with that deploy pipeline. The internal Jenkins deploy path is being migrated/genericized separately; self-hosters can instead wire image build/publish into GitHub Actions (or their own CI) using their registry credentials as repository secrets.
+Deployment to the VM remains operator-driven: the operator pulls the published image tag on the host, restarts the service, and verifies health via `GET /health`.
 
 ## Docker Configuration
 


### PR DESCRIPTION
Let's use GH Actions to build docker image to simplify collaboration with the project.
Notes:
- images will be published to ghcr.io (we need to enable this in GH settings)
- we build images only for x86_64 for now
- we publish image only from the main branch