### PR TITLE
fix(docker): build prod image under TypeScript 6

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -28,14 +28,14 @@ COPY package.json package-lock.json* ./
 RUN npm ci
 
 # Copy source code
-COPY tsconfig.json ./
+COPY tsconfig.json tsconfig.scripts.json ./
 COPY src/ ./src/
 COPY prompts/ ./prompts/
 COPY scripts/ ./scripts/
 
-# Build TypeScript
+# Build TypeScript (main app, then the standalone git-askpass token helper)
 RUN npm run build && \
-    npx tsc scripts/github-token.ts --outDir dist/scripts --module ESNext --moduleResolution node --esModuleInterop --skipLibCheck
+    npx tsc -p tsconfig.scripts.json
 
 # Remove devDependencies
 RUN npm prune --production

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./scripts",
+    "outDir": "./dist/scripts",
+    "types": ["node"],
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["scripts/github-token.ts"]
+}


### PR DESCRIPTION
## Problem

The `docker-publish` workflow (build of `Dockerfile.prod`, runs on push to `main`) has been failing since the TypeScript 6 bump (#97) and is red on current `main` (#98, #100 too). It can't be caught by Dependabot PRs because `docker-publish` only runs on push to `main`, not on PRs.

`ci.yml`'s build job runs plain `tsc` (via `tsconfig.json`) and passes under TS 6. But `Dockerfile.prod` separately compiles the git-askpass token helper with a bespoke invocation:

```
npx tsc scripts/github-token.ts --outDir dist/scripts --module ESNext --moduleResolution node --esModuleInterop --skipLibCheck
```

TS 6 breaks this:
- **TS5112** — a `tsconfig.json` on disk is no longer silently ignored when files are passed on the command line
- **TS5107** — `--moduleResolution node` (node10) is now a deprecation *error*
- once those clear, with no node types loaded `process` is unresolved (and `process.exit` isn't typed `never`, tripping a definite-assignment error)

## Fix

- Add **`tsconfig.scripts.json`** extending the project config (NodeNext, strict, esModuleInterop, skipLibCheck) with `types: ["node"]`, scoped to the helper script.
- **`Dockerfile.prod`**: compile via `tsc -p tsconfig.scripts.json` and copy the new config into the image.

Emitted `dist/scripts/github-token.js` is functionally unchanged (valid ESM, `node --check` passes).

## Verification

Ran the exact Dockerfile build steps locally on current `main` + this fix:
- `npm run build` → exit 0
- `tsc -p tsconfig.scripts.json` → exit 0
- artifacts present: `dist/index.js`, `dist/scripts/github-token.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vz8uMbyLkv1knurTtgeW3z)_