### PR TITLE
Fix Dockerfile.dev scripts build (TS5112) — use tsconfig.scripts.json

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,13 +29,13 @@ COPY package.json package-lock.json* ./
 # Install ALL dependencies (keep devDependencies for tsx)
 RUN npm ci
 
-# Copy tsconfig (needed for tsx)
-COPY tsconfig.json ./
+# Copy tsconfig (needed for tsx) and the scripts build config
+COPY tsconfig.json tsconfig.scripts.json ./
 
 # Copy and compile scripts for git authentication
 COPY scripts/ ./scripts/
 RUN chmod +x /app/scripts/git-askpass.sh && \
-    npx tsc scripts/github-token.ts --outDir dist/scripts --module ESNext --moduleResolution node --esModuleInterop --skipLibCheck
+    npx tsc -p tsconfig.scripts.json
 ENV GIT_ASKPASS=/app/scripts/git-askpass.sh
 
 # Create non-root user (required: bypassPermissions refuses to run as root)


### PR DESCRIPTION
## Problem

`docker compose build` fails on `Dockerfile.dev` at the scripts-compile step:

```
error TS5112: tsconfig.json is present but will not be loaded if files are
specified on commandline. Use '--ignoreConfig' to skip this error.
```

The dev image compiled the git-auth helper with a bare `tsc <file> --flags`:

```dockerfile
npx tsc scripts/github-token.ts --outDir dist/scripts --module ESNext \
  --moduleResolution node --esModuleInterop --skipLibCheck
```

Newer TypeScript now **errors** (TS5112) when you pass a file on the command line while a `tsconfig.json` is present, instead of silently ignoring the config — so the build breaks.

## Fix

Mirror `Dockerfile.prod`, which already moved to a dedicated project file. Copy `tsconfig.scripts.json` and build with `-p`:

```dockerfile
COPY tsconfig.json tsconfig.scripts.json ./
...
RUN chmod +x /app/scripts/git-askpass.sh && \
    npx tsc -p tsconfig.scripts.json
```

`tsconfig.scripts.json` already exists and pins the same output (`dist/scripts/github-token.js`, `rootDir: scripts`, `types: [node]`), so nothing downstream changes — `Dockerfile.dev` just drifted when `Dockerfile.prod` was updated.

## Verification

`npx tsc -p tsconfig.scripts.json` compiles cleanly (exit 0) and emits `dist/scripts/github-token.js` — the same artifact the dev image expects, with no TS5112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPnLfPUXjryLmF3aDjS2T5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPnLfPUXjryLmF3aDjS2T5)_