### PR TITLE
Fix stream-closed loop when edit mode is approved fast

### DIFF
--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -957,6 +957,15 @@ export class Task {
   // ---- Approval handlers ----
 
   async handleEditModeApproval(): Promise<void> {
+    // Cancel any park armed by request_edit_mode on the PM this turn. The tool
+    // defers task.stop() to the PM's turn-end so it doesn't close the input
+    // stream under an in-flight hook. If the user approves *before* that turn
+    // ends, the stop is still armed and fires right after approval — stopping
+    // the task we just approved and tearing the stream out from under the PM's
+    // delegation (the "stream closed" loop). Approval means "continue", so drop
+    // the park: the PM stays read-only; the repo agent it delegates to is what
+    // spawns read-write off edit_allowed.
+    this.agentProcesses.get('pm-agent')?.clearPendingTeardown();
     this.metadata.edit_allowed = true;
     this.debouncedSave();
     await appendAgentFinding(this.taskId, 'system', 'Edit mode approved by user', 'decision');


### PR DESCRIPTION
## What

Clears the PM's deferred `task.stop()` in `Task.handleEditModeApproval()` so a fast edit-mode approval can't fire a stale park.

## Why

`request_edit_mode` defers `task.stop()` to the PM's turn-end so the stop doesn't close the SDK input stream under an in-flight hook. But if the user approves edit mode **before** that turn ends, `handleEditModeApproval` flipped `edit_allowed` and queued the continue-prompt **without clearing the armed teardown**. The deferred `task.stop()` then fired right after approval — stopping the just-approved task and tearing the input stream out from under the PM's delegation, while the enqueued continue-prompt was already driving the next turn.

The symptom in production was a tight, repeating loop from the orphaned `pm-agent` subprocess:

```
[pm-agent] stderr: Error in hook callback hook_0: …
error: Stream closed
  at sendRequest (/$bunfs/root/src/entrypoints/cli.js:32276:133)
```

(`sendRequest` throws `Stream closed` when `inputClosed` is true — a hook's control round-trip hitting a stream that was closed out from under it.) Observed when approving within ~4s of the request: `Task stopped` + a re-spawn collided in the same second, then ~3.5 min of the loop.

## Fix

On approval, cancel the park: `this.agentProcesses.get('pm-agent')?.clearPendingTeardown()`.

- **Fast click** (turn still running): park is cancelled, PM proceeds straight into its delegation.
- **Slow click** (turn already ended, task already parked): the stop already fired; the clear is a harmless no-op and `sendMessage` respawns as before.

Either way the stale stop can't fire post-approval, so the stream is never yanked mid-delegation.

Edit mode is a **repo-agent** grant (RW clones + Write/Edit + git are gated by `edit_allowed` only inside the `isRepoAgent` branch at spawn). The PM stays read-only and needs no respawn — the repo agent it delegates to is what spawns read-write off `edit_allowed`.

## Verification

- `npm run typecheck` — clean
- `vitest` (PR-tools + task suites) — 66 passed, including the existing `request_edit_mode` tests

## Follow-ups (not in this PR)

- `handleResearchBudgetApproval` has the same uncleared-teardown race, but the teardown is armed on whichever agent called `web_research` (not necessarily the PM), so it needs a slightly different fix.
- A real-`Task` regression test for the fast-approval case (deferred heavy mock scaffolding for a one-line fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016X418RifwJQNA65ZDtEpYM)_