### PR TITLE
fix(cli): stop the task list collapsing to a bare header and jumping to the top

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/node": "^26.1.2",
         "@types/react": "^19.2.17",
         "@types/turndown": "^5.0.6",
+        "ink-testing-library": "^4.0.0",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"
@@ -116,9 +117,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -131,9 +129,6 @@
       "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -148,9 +143,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -163,9 +155,6 @@
       "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -3770,6 +3759,24 @@
       "peerDependencies": {
         "ink": ">=4.0.0",
         "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/ink-text-input": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/node": "^26.1.2",
     "@types/react": "^19.2.17",
     "@types/turndown": "^5.0.6",
+    "ink-testing-library": "^4.0.0",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/src/cli/components/TaskList.test.tsx
+++ b/src/cli/components/TaskList.test.tsx
@@ -44,11 +44,42 @@ function page(offset: number, count: number, total: number) {
   return { tasks: Array.from({ length: count }, (_, i) => task(offset + i)), total };
 }
 
-function renderList(refreshTrigger = 0) {
+function renderList(refreshTrigger = 0, active = false) {
   return render(
-    <TaskList onSelect={() => {}} onCreate={() => {}} refreshTrigger={refreshTrigger} active={false} />,
+    <TaskList onSelect={() => {}} onCreate={() => {}} refreshTrigger={refreshTrigger} active={active} />,
   );
 }
+
+/**
+ * The invariant the bug violated: a counted header must never appear without
+ * at least one task row beneath it. Independent of *why* the rows are there
+ * (freshly fetched or retained from before a failed refresh).
+ */
+function assertNoBareHeader(frame: string) {
+  if (/Tasks \(\d+\)/.test(frame)) {
+    expect(frame).toMatch(/\[[+\-?\S]\]\s+task-\d+/);
+  }
+}
+
+/** Serves pages out of a live array, so tests can prepend and refresh. */
+function serveFrom(list: ReturnType<typeof task>[]) {
+  return async ({ offset }: { offset: number }) => ({
+    tasks: list.slice(offset, offset + PAGE_SIZE),
+    total: list.length,
+  });
+}
+
+/** Which task the cursor (`>`) currently sits on. */
+function selectedTask(frame: string): string | null {
+  return frame.split('\n').find((l) => l.trimStart().startsWith('>'))?.match(/task-\d+/)?.[0] ?? null;
+}
+
+/** The task rows currently rendered, top to bottom. */
+function visibleTasks(frame: string): string[] {
+  return frame.split('\n').flatMap((l) => l.match(/task-\d+/) ?? []);
+}
+
+const DOWN = '\u001B[B'; // arrow-down key sequence
 
 /**
  * Flush pending fetches, React effects and Ink's throttled frame write.
@@ -98,10 +129,11 @@ describe('TaskList', () => {
   });
 
   it('never renders a header with no rows when page 0 fails after a refresh', async () => {
-    // The wedge from the bug report. A refresh (any task:* SSE event) resets
-    // the array; if page 0 then fails while `total` still says 40, the visible
-    // window is all placeholders and the list renders as `Tasks (40)` with
-    // nothing beneath it. Resetting `total` plus retrying page 0 prevents that.
+    // The wedge from the bug report. A refresh (any task:* SSE event) used to
+    // blank the array; if page 0 then failed while `total` still said 40, the
+    // visible window was all placeholders and the list rendered as `Tasks (40)`
+    // with nothing beneath it. Refreshing in place keeps the previous rows on
+    // screen while page 0 retries, so the window is never empty.
     let pageZeroFails = false;
     fetchTasksMock.mockImplementation(async ({ offset }: { offset: number }) => {
       if (offset === 0 && pageZeroFails) throw new Error('page 0 unavailable');
@@ -121,8 +153,9 @@ describe('TaskList', () => {
     await runRetry();
 
     // A header with a count but no task rows is the exact broken state.
-    expect(lastFrame()).not.toMatch(/Tasks \(\d+\)/);
-    expect(lastFrame()).toContain('Error: page 0 unavailable');
+    assertNoBareHeader(lastFrame()!);
+    // Rows from before the failed refresh are retained rather than blanked.
+    expect(lastFrame()).toContain('task-0');
 
     pageZeroFails = false;
     await runRetry();
@@ -163,6 +196,82 @@ describe('TaskList', () => {
     expect(lastFrame()).toContain('task-1');
     expect(lastFrame()).not.toContain('task-900');
     unmount();
+  });
+
+  describe('scroll position across refreshes', () => {
+    /** Render, scroll `steps` rows down, and return the harness. */
+    async function renderScrolledDown(list: ReturnType<typeof task>[], steps: number) {
+      fetchTasksMock.mockImplementation(serveFrom(list));
+      const h = renderList(0, true);
+      await settle();
+      for (let i = 0; i < steps; i++) h.stdin.write(DOWN);
+      await settle();
+      return h;
+    }
+
+    it('keeps the same task selected and on screen when a task is prepended', async () => {
+      const list = Array.from({ length: 60 }, (_, i) => task(i));
+      const { lastFrame, rerender, stdin, unmount } = await renderScrolledDown(list, 25);
+
+      const anchored = selectedTask(lastFrame()!);
+      const windowBefore = visibleTasks(lastFrame()!);
+      expect(anchored).not.toBe('task-0'); // genuinely scrolled away from the top
+
+      // A task:* SSE event: the API prepends the new task (newest-first) and
+      // App bumps refreshTrigger.
+      list.unshift(task(999));
+      rerender(
+        <TaskList onSelect={() => {}} onCreate={() => {}} refreshTrigger={1} active={true} />,
+      );
+      await settle();
+
+      // The list grew and the data refreshed...
+      expect(lastFrame()).toContain('Tasks (61)');
+      // ...but the viewport did not move: same selection, same rows on screen.
+      expect(selectedTask(lastFrame()!)).toBe(anchored);
+      expect(visibleTasks(lastFrame()!)).toEqual(windowBefore);
+      expect(lastFrame()).not.toContain('task-999'); // the new task is above, off screen
+
+      void stdin;
+      unmount();
+    });
+
+    it('holds position across a refresh that adds nothing (returning from detail)', async () => {
+      // App.handleBack() bumps refreshTrigger on every return from the detail
+      // view, which used to snap the list back to the top.
+      const list = Array.from({ length: 60 }, (_, i) => task(i));
+      const { lastFrame, rerender, unmount } = await renderScrolledDown(list, 25);
+
+      const anchored = selectedTask(lastFrame()!);
+      const windowBefore = visibleTasks(lastFrame()!);
+
+      rerender(
+        <TaskList onSelect={() => {}} onCreate={() => {}} refreshTrigger={1} active={true} />,
+      );
+      await settle();
+
+      expect(selectedTask(lastFrame()!)).toBe(anchored);
+      expect(visibleTasks(lastFrame()!)).toEqual(windowBefore);
+      unmount();
+    });
+
+    it('stays pinned to the top so new tasks are visible when not scrolled', async () => {
+      const list = Array.from({ length: 60 }, (_, i) => task(i));
+      fetchTasksMock.mockImplementation(serveFrom(list));
+      const { lastFrame, rerender, unmount } = renderList(0, true);
+      await settle();
+      expect(visibleTasks(lastFrame()!)[0]).toBe('task-0');
+
+      list.unshift(task(999));
+      rerender(
+        <TaskList onSelect={() => {}} onCreate={() => {}} refreshTrigger={1} active={true} />,
+      );
+      await settle();
+
+      // At the top the newest task should appear rather than be scrolled past.
+      expect(visibleTasks(lastFrame()!)[0]).toBe('task-999');
+      unmount();
+    });
   });
 
   it('still reports a genuinely empty list as "No tasks found"', async () => {

--- a/src/cli/components/TaskList.test.tsx
+++ b/src/cli/components/TaskList.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Regression tests for the task list collapsing to a bare header.
+ *
+ * The list keeps tasks in a sparse array and re-fetches paginated pages on
+ * every task:* SSE event. A transient failure used to be swallowed: the page
+ * was never retried, and because prefetch assumed pages load contiguously from
+ * 0, a missing page 0 was never re-requested. The visible window then held only
+ * `undefined` placeholders, which render as nothing — the `Tasks (N)` header
+ * with no rows beneath it, stuck until restart.
+ *
+ * These tests pin the three behaviours that fix it: failed pages retry, a
+ * window of placeholders never reads as "tasks exist", and a response from
+ * before a refresh cannot clobber the state that replaced it.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { TaskList } from './TaskList.js';
+
+const { fetchTasksMock } = vi.hoisted(() => ({ fetchTasksMock: vi.fn() }));
+vi.mock('../api.js', () => ({ fetchTasks: fetchTasksMock }));
+
+const PAGE_SIZE = 20;
+const RETRY_DELAY_MS = 1500;
+
+function task(index: number) {
+  return {
+    task_id: `task-${index}`,
+    status: 'completed',
+    task_owner: null,
+    participants: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    title: `Title ${index}`,
+    channel_name: 'cli',
+    reminder: null,
+    agents: [],
+  };
+}
+
+/** A page of `count` tasks starting at `offset`, out of `total` overall. */
+function page(offset: number, count: number, total: number) {
+  return { tasks: Array.from({ length: count }, (_, i) => task(offset + i)), total };
+}
+
+function renderList(refreshTrigger = 0) {
+  return render(
+    <TaskList onSelect={() => {}} onCreate={() => {}} refreshTrigger={refreshTrigger} active={false} />,
+  );
+}
+
+/**
+ * Flush pending fetches, React effects and Ink's throttled frame write.
+ * Advances well short of RETRY_DELAY_MS so it never triggers a retry itself.
+ */
+async function settle() {
+  for (let i = 0; i < 10; i++) await vi.advanceTimersByTimeAsync(10);
+}
+
+/** Advance past the debounced retry and let the resulting fetch settle. */
+async function runRetry() {
+  await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+  await settle();
+}
+
+describe('TaskList', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchTasksMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries page 0 after a transient failure instead of staying empty forever', async () => {
+    fetchTasksMock
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValue(page(0, 3, 3));
+
+    const { lastFrame, unmount } = renderList();
+    await settle();
+
+    // The previously-dead error UI is now wired up, so the failure is visible
+    // rather than silently rendering as "No tasks found".
+    expect(lastFrame()).toContain('Error: fetch failed');
+    expect(lastFrame()).toContain('Retrying');
+
+    await runRetry();
+
+    expect(fetchTasksMock).toHaveBeenCalledTimes(2);
+    expect(lastFrame()).toContain('Tasks (3)');
+    expect(lastFrame()).toContain('task-0');
+    expect(lastFrame()).toContain('task-2');
+    expect(lastFrame()).not.toContain('Error:');
+    unmount();
+  });
+
+  it('never renders a header with no rows when page 0 fails after a refresh', async () => {
+    // The wedge from the bug report. A refresh (any task:* SSE event) resets
+    // the array; if page 0 then fails while `total` still says 40, the visible
+    // window is all placeholders and the list renders as `Tasks (40)` with
+    // nothing beneath it. Resetting `total` plus retrying page 0 prevents that.
+    let pageZeroFails = false;
+    fetchTasksMock.mockImplementation(async ({ offset }: { offset: number }) => {
+      if (offset === 0 && pageZeroFails) throw new Error('page 0 unavailable');
+      return page(offset, PAGE_SIZE, 40);
+    });
+
+    const { lastFrame, rerender, unmount } = renderList(0);
+    await settle();
+    expect(lastFrame()).toContain('Tasks (40)');
+    expect(lastFrame()).toContain('task-0');
+
+    pageZeroFails = true;
+    rerender(
+      <TaskList onSelect={() => {}} onCreate={() => {}} refreshTrigger={1} active={false} />,
+    );
+    await settle();
+    await runRetry();
+
+    // A header with a count but no task rows is the exact broken state.
+    expect(lastFrame()).not.toMatch(/Tasks \(\d+\)/);
+    expect(lastFrame()).toContain('Error: page 0 unavailable');
+
+    pageZeroFails = false;
+    await runRetry();
+
+    expect(lastFrame()).toContain('Tasks (40)');
+    expect(lastFrame()).toContain('task-0');
+
+    const zeroOffsetCalls = fetchTasksMock.mock.calls.filter((c) => c[0].offset === 0);
+    expect(zeroOffsetCalls.length).toBeGreaterThan(2);
+    unmount();
+  });
+
+  it('discards a response from before a refresh so it cannot clobber the new list', async () => {
+    let releaseStale: (() => void) | undefined;
+    const stale = new Promise<void>((resolve) => { releaseStale = resolve; });
+
+    fetchTasksMock
+      // First mount: hangs until we release it, then resolves with old data.
+      .mockImplementationOnce(async () => {
+        await stale;
+        return { tasks: [task(900)], total: 1 };
+      })
+      // After the refresh: the authoritative data.
+      .mockResolvedValue({ tasks: [task(1)], total: 1 });
+
+    const { lastFrame, rerender, unmount } = renderList(0);
+    await settle();
+
+    rerender(
+      <TaskList onSelect={() => {}} onCreate={() => {}} refreshTrigger={1} active={false} />,
+    );
+    await settle();
+    expect(lastFrame()).toContain('task-1');
+
+    releaseStale!();
+    await settle();
+
+    expect(lastFrame()).toContain('task-1');
+    expect(lastFrame()).not.toContain('task-900');
+    unmount();
+  });
+
+  it('still reports a genuinely empty list as "No tasks found"', async () => {
+    fetchTasksMock.mockResolvedValue({ tasks: [], total: 0 });
+
+    const { lastFrame, unmount } = renderList();
+    await settle();
+
+    expect(lastFrame()).toContain('No tasks found');
+    unmount();
+  });
+});

--- a/src/cli/components/TaskList.tsx
+++ b/src/cli/components/TaskList.tsx
@@ -32,6 +32,11 @@ interface TaskListProps {
 
 const PAGE_SIZE = 20;
 const PREFETCH_BUFFER = 10;
+// How long to wait before retrying a page whose fetch failed (server restart,
+// transient network error). Without a retry, a failed page leaves a permanent
+// gap in the list — most visibly an all-empty page 0, which renders as a bare
+// header with no rows.
+const RETRY_DELAY_MS = 1500;
 
 function StatusIcon({ status }: { status: string }) {
   switch (status) {
@@ -54,14 +59,33 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
   const [scrollTop, setScrollTop] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [retryTick, setRetryTick] = useState(0);
   const fetchedPages = useRef(new Set<number>());
   const fetchingPages = useRef(new Set<number>());
+  const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Bumped on every refresh. A fetch started under an old generation must not
+  // write into the array (or mutate the page-tracking sets) belonging to a
+  // newer generation — otherwise a stale, in-flight response can repopulate a
+  // freshly-reset list out of order.
+  const generation = useRef(0);
 
-  const fetchPage = useCallback(async (page: number) => {
+  // Schedule a single debounced retry. Failed pages are left unmarked so the
+  // prefetch effect re-attempts them when this fires.
+  const scheduleRetry = useCallback(() => {
+    if (retryTimer.current) return;
+    retryTimer.current = setTimeout(() => {
+      retryTimer.current = null;
+      setRetryTick((n) => n + 1);
+    }, RETRY_DELAY_MS);
+  }, []);
+
+  const loadPage = useCallback(async (page: number) => {
     if (fetchedPages.current.has(page) || fetchingPages.current.has(page)) return;
+    const gen = generation.current;
     fetchingPages.current.add(page);
     try {
       const { tasks, total: t } = await fetchTasks({ limit: PAGE_SIZE, offset: page * PAGE_SIZE });
+      if (gen !== generation.current) return; // superseded by a refresh — discard
       fetchedPages.current.add(page);
       setTotal(t);
       setAllTasks((prev) => {
@@ -75,34 +99,65 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
         }
         return next;
       });
+      setError(null);
+      if (page === 0) setLoading(false);
+    } catch (err) {
+      if (gen !== generation.current) return; // superseded — ignore
+      // Leave the page unmarked so it is retried. Only surface an error when
+      // page 0 fails, since that is what leaves the list with nothing to show.
+      if (page === 0) {
+        setLoading(false);
+        setError(err instanceof Error ? err.message : 'Failed to load tasks');
+      }
+      scheduleRetry();
     } finally {
-      fetchingPages.current.delete(page);
+      // Only the owning generation may clear the marker, so a stale fetch can't
+      // delete the tracking entry of a fetch started after a refresh.
+      if (gen === generation.current) fetchingPages.current.delete(page);
     }
-  }, []);
+  }, [scheduleRetry]);
 
   // Initial load + reset on refresh
   useEffect(() => {
+    generation.current += 1;
     fetchedPages.current.clear();
     fetchingPages.current.clear();
+    if (retryTimer.current) {
+      clearTimeout(retryTimer.current);
+      retryTimer.current = null;
+    }
     setAllTasks([]);
+    setTotal(0);
     setCursor(0);
     setScrollTop(0);
+    setError(null);
     setLoading(true);
-    fetchPage(0).finally(() => setLoading(false));
-  }, [refreshTrigger, fetchPage]);
+    loadPage(0);
+  }, [refreshTrigger, loadPage]);
 
-  // Prefetch pages to cover visible area + buffer ahead of cursor
+  // Fetch (and retry) every page overlapping the visible window + buffer.
+  // This deliberately does NOT assume pages load contiguously from 0: it fills
+  // whichever pages in range are still missing, so a page that previously
+  // failed — including page 0 — gets re-fetched instead of being skipped.
   useEffect(() => {
-    const needed = cursor + visibleRows + PREFETCH_BUFFER;
-    const loadedCount = allTasks.filter(Boolean).length;
-    if (loadedCount < total) {
-      const startPage = Math.floor(loadedCount / PAGE_SIZE);
-      const endPage = Math.floor(Math.min(needed, total - 1) / PAGE_SIZE);
-      for (let p = startPage; p <= endPage; p++) {
-        fetchPage(p).catch(() => {});
-      }
+    if (total === 0) {
+      // Page 0 hasn't established the total yet (still loading or it failed).
+      // Re-attempt it; loadPage de-dupes if it is already in flight.
+      loadPage(0);
+      return;
     }
-  }, [cursor, allTasks, total, visibleRows, fetchPage]);
+    const needed = cursor + visibleRows + PREFETCH_BUFFER;
+    const firstPage = Math.max(0, Math.floor(scrollTop / PAGE_SIZE));
+    const lastPage = Math.floor(Math.min(needed, total - 1) / PAGE_SIZE);
+    for (let p = firstPage; p <= lastPage; p++) {
+      loadPage(p);
+    }
+  }, [cursor, scrollTop, total, visibleRows, retryTick, loadPage]);
+
+  // Cancel any pending retry on unmount.
+  useEffect(() => () => {
+    if (retryTimer.current) clearTimeout(retryTimer.current);
+  }, []);
 
   // Keep cursor in view
   useEffect(() => {
@@ -128,6 +183,10 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
     }
   });
 
+  // Count real entries, not the sparse array length: a page of `undefined`
+  // placeholders must not read as "tasks exist".
+  const loadedCount = allTasks.filter(Boolean).length;
+
   if (loading) {
     return (
       <Box flexDirection="column" padding={1}>
@@ -136,16 +195,16 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
     );
   }
 
-  if (error) {
+  if (error && loadedCount === 0) {
     return (
       <Box flexDirection="column" padding={1}>
         <Text color="red">Error: {error}</Text>
-        <Text dimColor>Is the Archie server running?</Text>
+        <Text dimColor>Is the Archie server running? Retrying…</Text>
       </Box>
     );
   }
 
-  if (allTasks.length === 0) {
+  if (loadedCount === 0) {
     return (
       <Box flexDirection="column" padding={1}>
         <Text bold>No tasks found</Text>

--- a/src/cli/components/TaskList.tsx
+++ b/src/cli/components/TaskList.tsx
@@ -68,6 +68,17 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
   // newer generation — otherwise a stale, in-flight response can repopulate a
   // freshly-reset list out of order.
   const generation = useRef(0);
+  // Only the very first load starts from a blank slate; every later refresh
+  // revalidates in place so the viewport survives (see the refresh effect).
+  const firstLoad = useRef(true);
+  // Set when a refresh is awaiting page 0, whose `total` reveals how many
+  // tasks were prepended since the last load.
+  const pendingShift = useRef(false);
+  const prevTotal = useRef(0);
+  // Mirrors scrollTop for reads inside async fetch handlers, where the state
+  // captured by the closure is stale.
+  const scrollTopRef = useRef(0);
+  useEffect(() => { scrollTopRef.current = scrollTop; }, [scrollTop]);
 
   // Schedule a single debounced retry. Failed pages are left unmarked so the
   // prefetch effect re-attempts them when this fires.
@@ -87,6 +98,28 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
       const { tasks, total: t } = await fetchTasks({ limit: PAGE_SIZE, offset: page * PAGE_SIZE });
       if (gen !== generation.current) return; // superseded by a refresh — discard
       fetchedPages.current.add(page);
+
+      // Tasks are served newest-first (the API sorts session dirs descending),
+      // so anything created since the last load is *prepended* and every
+      // existing row shifts down by the growth in `total`. Slide the array and
+      // the viewport by that delta together, before the page merge below writes
+      // the fresh rows, so indices stay aligned throughout and the selection
+      // keeps pointing at the same task instead of silently drifting.
+      if (page === 0 && pendingShift.current) {
+        pendingShift.current = false;
+        const shift = t - prevTotal.current;
+        if (shift > 0) {
+          setAllTasks((prev) => [...new Array<TaskSummary>(shift), ...prev]);
+          // Pinned to the top: let new tasks appear rather than scrolling away
+          // from them. Scrolled anywhere else: hold the viewport still.
+          if (scrollTopRef.current > 0) {
+            setScrollTop((s) => s + shift);
+            setCursor((c) => c + shift);
+          }
+        }
+      }
+      prevTotal.current = t;
+
       setTotal(t);
       setAllTasks((prev) => {
         const next = [...prev];
@@ -117,7 +150,14 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
     }
   }, [scheduleRetry]);
 
-  // Initial load + reset on refresh
+  // Initial load, then revalidate-in-place on every refresh.
+  //
+  // A refresh fires on every task:* SSE event and on returning from the detail
+  // view. It used to blank the array and reset cursor/scrollTop, which yanked
+  // the user to the top of the list mid-scroll each time anything happened —
+  // and made the list unnavigable on a busy instance. Now only the page cache
+  // is invalidated: rows, total and the viewport survive, pages are refetched
+  // underneath, and the fresh data replaces the old in place.
   useEffect(() => {
     generation.current += 1;
     fetchedPages.current.clear();
@@ -126,12 +166,19 @@ export function TaskList({ onSelect, onCreate, refreshTrigger, active }: TaskLis
       clearTimeout(retryTimer.current);
       retryTimer.current = null;
     }
-    setAllTasks([]);
-    setTotal(0);
-    setCursor(0);
-    setScrollTop(0);
     setError(null);
-    setLoading(true);
+
+    if (firstLoad.current) {
+      firstLoad.current = false;
+      setAllTasks([]);
+      setTotal(0);
+      setCursor(0);
+      setScrollTop(0);
+      setLoading(true);
+    } else {
+      // Keep everything on screen; page 0's `total` drives the index shift.
+      pendingShift.current = true;
+    }
     loadPage(0);
   }, [refreshTrigger, loadPage]);
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts', 'tools/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'tools/**/*.test.ts'],
   },
   resolve: {
     // TypeScript files import with .js extensions (NodeNext resolution).


### PR DESCRIPTION
Two defects in the CLI task list (`src/cli/components/TaskList.tsx`), both rooted in how it handles a refresh. The list re-fetches paginated 20-task pages on every `task:*` SSE event and on returning from the detail view, and that refresh path both wedged the list and threw away the user's place in it.

## Problem 1 — the list collapsed to a bare header

After running for a while the list would empty itself out, showing only the `Tasks (N)` header with no rows beneath it, and stay stuck there until the process was restarted.

Three interacting defects combined to wedge it:

1. **`fetchPage` had no error handling.** A transient failure — server hot-reload, SSE reconnect, or a 500 from `/api/tasks` racing a concurrent task write — dropped a page silently and never retried it. The rejected promise was also unhandled.
2. **Prefetch assumed pages load contiguously from 0** (`startPage = Math.floor(loadedCount / PAGE_SIZE)`). Once a higher page loaded, a missing page 0 was never re-fetched, so the visible window at the top held only `undefined` placeholders — which render as nothing. Header shows, rows don't.
3. **Refresh abandoned in-flight fetches.** It cleared the in-flight tracking set and reset the array while old fetches were still running, so a stale response could repopulate the freshly-reset list out of order (and its `finally` could delete a newer fetch's tracking marker).

## Problem 2 — the list jumped to the top on every event

Refresh blanked the array and reset `cursor`/`scrollTop`, so the view snapped back to row 1 whenever anything happened anywhere on the instance. On an instance with hundreds of tasks this made the list effectively unnavigable: scroll down to find something, an unrelated task changes state, and you are back at the top. Returning from a task's detail view did the same, via `handleBack`'s explicit `refresh()`.

## Fix

- **Retry on failure** — page fetches are wrapped in `try/catch` with a debounced retry. The previously-dead error UI ("Is the Archie server running?") is now wired up, shown only when page 0 fails with nothing to display.
- **Fill missing pages** — prefetch loads whichever pages overlap the visible window + buffer that are still missing, instead of assuming contiguous loading, so a missing page 0 is re-fetched.
- **Generation token** — each fetch is tagged with a generation; responses from before a refresh are discarded so they can't clobber the new generation's state.
- **Revalidate in place** — refresh no longer blanks the array or resets the viewport. Only the page cache is invalidated; rows, `total` and the scroll position survive while pages are refetched underneath. This also removes the `Loading tasks...` flash on every event, and means a refresh whose page 0 fails keeps showing the previous rows rather than dropping to the error screen.
- **Shift indices to hold the view still** — the API serves tasks newest-first (`routes.ts` sorts session dirs descending), so a new task is prepended at index 0 and every existing row moves down by one. `scrollTop` and `cursor` are indices, so they must grow by the same amount for the same rows to stay on screen and for the selection to keep pointing at the same task. The shift is derived from the growth in `total` and applied to the array and the viewport together, before the fresh page is merged, so indices never desync. When the user is already at the top the shift is skipped, so new tasks appear rather than being scrolled away from.
- **Count real entries** — the empty/error checks use the number of loaded tasks rather than the sparse `array.length`, so a window of `undefined` placeholders can never read as "tasks exist".

## Testing

The repo had no Ink rendering harness, so this adds `ink-testing-library` as a devDependency and widens the vitest glob to pick up `*.test.tsx`. `src/cli/components/TaskList.test.tsx` covers both problems with `fetchTasks` mocked per page.

Every regression test was verified in both directions — each one fails against the component as it was before the corresponding fix, and the failures reproduce the reported symptoms exactly (the bare-header case renders literally `Tasks (40)  1/40` followed by blank lines):

| Test | before | after |
| --- | --- | --- |
| retries page 0 after a transient failure | fails — "No tasks found" forever | passes |
| never renders a header with no rows after a refresh | fails — `Tasks (40)` with zero rows | passes |
| discards a response from before a refresh | fails — stale data clobbers the list | passes |
| keeps the same task selected and on screen when a task is prepended | fails — jumps to the top | passes |
| holds position across a refresh that adds nothing (back from detail) | fails — jumps to the top | passes |
| stays pinned to the top when not scrolled | passes | passes |
| reports a genuinely empty list as "No tasks found" | passes | passes |

The last two pass either way on purpose: they guard against over-correcting rather than pinning a regression.

Also verified live against an instance booted from this branch with 263 existing tasks (14 pages), driving real `task:*` SSE events by creating tasks through `POST /api/tasks` while scrolled down the list: the rows and header update while the selection and visible window stay put, and the list never collapses.

`npm run typecheck` clean; full suite 839 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
