### PR TITLE
Pull plugin-declared repos in parallel on startup

### DIFF
--- a/src/system/workdir.ts
+++ b/src/system/workdir.ts
@@ -116,11 +116,21 @@ export async function bootstrapWorkdir(): Promise<void> {
 export async function cloneRepos(
   repos: Array<{ github: string; baseBranch?: string }>
 ): Promise<void> {
-  for (const { github, baseBranch } of repos) {
-    const repoPath = getBaseCachePath(github);
-    const repoUrl = githubRepoToUrl(github);
-    await cloneOrFetch(repoUrl, repoPath, github, baseBranch);
-  }
+  // Pull every repo in parallel. Each one targets its own directory, so there's
+  // no shared working tree or cross-repo git lock to contend over — total time
+  // becomes the slowest single repo instead of the sum of all of them.
+  // `allSettled` keeps one repo's failure from aborting startup (matching the
+  // "log and carry on" behaviour cloneOrFetch already has on the fetch path).
+  const results = await Promise.allSettled(
+    repos.map(({ github, baseBranch }) =>
+      cloneOrFetch(githubRepoToUrl(github), getBaseCachePath(github), github, baseBranch)
+    )
+  );
+  results.forEach((result, i) => {
+    if (result.status === 'rejected') {
+      logger.warn('workdir', `Failed to clone/fetch ${repos[i].github}: ${result.reason}`);
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
## What

`cloneRepos` (`src/system/workdir.ts`) previously awaited each plugin-declared repo's clone/fetch **one at a time**, so startup cost was the *sum* of every repo's git + network time. This pulls them all concurrently instead, so boot time now tracks the **slowest single repo** rather than the total.

```js
const results = await Promise.allSettled(
  repos.map(({ github, baseBranch }) =>
    cloneOrFetch(githubRepoToUrl(github), getBaseCachePath(github), github, baseBranch)
  )
);
results.forEach((result, i) => {
  if (result.status === 'rejected') {
    logger.warn('workdir', `Failed to clone/fetch ${repos[i].github}: ${result.reason}`);
  }
});
```

## Why it's safe to parallelize

- **Distinct target dirs.** Each repo clones to `getBaseCachePath(github)` (`workdir/repos/<org>/<repo>`), and the caller already dedupes by `github` — no two clones touch the same working tree or `.git`.
- **No cross-repo git lock.** Git's locks are per-repository; nothing operates on the same repo twice concurrently.
- **Shared-parent `mkdir` is safe.** Repos under the same org both call `mkdir(dirname, { recursive: true })` on the shared parent, which is idempotent and won't throw on `EEXIST`.

## Error handling

Switched to `Promise.allSettled` so one repo's failure logs a warning and boot continues, instead of aborting startup. This is a small improvement over the previous behaviour, where a failing fresh `git clone` would throw and crash boot (the fetch path already logged-and-continued).

## Why there's no race with task recovery

The call site stays `await`ed (`index.ts:123`), so the parallelism is internal to `cloneRepos`. Task recovery (`index.ts:250`) and webhook-driven agent spawns (`index.ts:253+`) still run only **after** every base cache is fully pulled — so `setupSharedClone`'s `git clone --shared` never reads a base cache mid-fetch. (Making the pull fire-and-forget *would* open that race; deliberately not doing that.)

## Not included

No concurrency cap — unnecessary for the current handful of repos. Worth revisiting only if the plugin-declared repo list grows into the dozens.

## Testing

- `npm run typecheck` ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017rbc21ojtSKZUYmsq7Wm1d)_