### PR TITLE
Disable context-probe (debugging complete)

### DIFF
--- a/src/system/context-probe.ts
+++ b/src/system/context-probe.ts
@@ -29,7 +29,7 @@ import { join } from 'node:path';
 import { logger } from './logger.js';
 
 // ░░ MASTER SWITCH — set to false + redeploy to fully disable. ░░
-export const CONTEXT_PROBE_ENABLED = true;
+export const CONTEXT_PROBE_ENABLED = false;
 
 const PROBE_PORT = 8788;
 const PROBE_HOST = '127.0.0.1';


### PR DESCRIPTION
Turns the context-probe off now that it's done its job.

## What we learned (the reason it existed)

The probe captured every agent's real request breakdown on the server. Result:

- The ~488K base context is the **system prompt (~424K tokens)**, not tools (26–73K).
- **~381K of that is 156 `scope:org` memory entity pages** (1.38MB) injected into *every* agent by `enrichPromptWithMemory`.
- `selectEntities` exempts `scope: org` pages from the inject cap ([entity-index.ts:184](../blob/main/src/memory/entity-index.ts#L184)), so org memory injection grows unbounded.
- This is what overflowed the trivial dynamic `data-context` agent on Sonnet (463K → "Prompt is too long" → the 8-hour stall in `task-20260625-2243-dj79r4`).

Follow-up fix (separate PR): cap/scope org-memory injection so trivial agents don't carry the whole org corpus.

## This PR

Flips `CONTEXT_PROBE_ENABLED` to `false` — the proxy is fully out of the request path again (agents talk to the API directly). The probe code stays in the tree; set the flag to `true` + redeploy to re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)