### PR TITLE
Spawn dynamic agents with opus by default

### DIFF
--- a/src/agents/__tests__/dynamic-agent.test.ts
+++ b/src/agents/__tests__/dynamic-agent.test.ts
@@ -51,6 +51,7 @@ describe('synthesizeDynamicAgentDef', () => {
     ]);
     expect(def.visibility).toBe('global');
     expect(def.pluginName).toBe('<dynamic>');
+    expect(def.model).toBe('opus'); // defaults to opus, like configured repo agents
   });
 
   it('throws on an empty repos list', () => {

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -200,6 +200,12 @@ export function synthesizeDynamicAgentDef(spec: DynamicAgentSpec): AgentDef {
     role: spec.role,
     expertise: spec.expertise,
     pluginName: '<dynamic>',
+    // Dynamic agents are repo agents, so default them to opus like the
+    // configured repo agents (which all set `model: opus` in frontmatter).
+    // Without this they fell through spawn.ts's non-PM default to sonnet,
+    // whose smaller context window overflowed on the large injected system
+    // prompt — the failure mode seen in task-20260625-2243-dj79r4.
+    model: 'opus',
     // PM-spawned agents are globally addressable across the task — they only
     // exist because PM created them on demand, so peers should be able to
     // reach them without a same-plugin relationship.


### PR DESCRIPTION
## Problem

PM-spawned **dynamic agents** are repo agents but `synthesizeDynamicAgentDef` set no `model`, so they fell through `spawn.ts`'s non-PM default to **sonnet**. Every configured repo agent (archie, backend, mobile, infrastructure, data-analyst) declares `model: opus` in frontmatter — dynamic agents should match.

This mattered: agents carry a large injected system prompt (~424K tokens of org memory). Sonnet's smaller context window overflows on it; opus's 1M window absorbs it. In `task-20260625-2243-dj79r4` the sonnet `data-context` dynamic agent hit "Prompt is too long" + autocompact thrash — it fetched the answer in ~1s but couldn't emit it, turning a 1-minute task into an 8-hour overnight stall. The opus repo agents in the same task handled the identical context fine.

## Change

`synthesizeDynamicAgentDef` now defaults `model: 'opus'`, mirroring configured repo agents. One line + a test assertion.

> Note: immediate mitigation. The root cause — ~424K of `scope:org` memory injected uncapped into every agent's system prompt — is tracked separately; capping that cuts cost across all agents regardless of model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)