### PR TITLE
Default non-PM agents to sonnet[1m] (1M context window)

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -197,7 +197,11 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
 
   const workspace = await setupAgentWorkspace(taskId, agent);
   const cwd = workspace;
-  const model = def.model || (isPmAgent(def) ? 'opus' : 'sonnet');
+  // Default non-PM agents to sonnet with the 1M context window. The `[1m]`
+  // suffix is how the SDK enables it (it strips the suffix and adds the
+  // `context-1m-2025-08-07` beta); plain `sonnet` caps at 200K and overflows
+  // on the large injected system prompt. Opus is 1M natively, no suffix needed.
+  const model = def.model || (isPmAgent(def) ? 'opus' : 'sonnet[1m]');
   const tools = def.tools;
 
   const pluginPaths = def.pluginPath ? [def.pluginPath] : [];


### PR DESCRIPTION
## Problem

Non-PM agents default to `sonnet` (`claude-sonnet-4-6`), which caps at a **200K** context window. Every agent carries ~424K tokens of injected org memory in its system prompt, so sonnet agents overflow — "Prompt is too long" + autocompact thrashing. This stranded the **ops-agent** in `task-20260626-0700-98n0o7` (context maxed at ~505K; hit the 30-minute auto-pause three times).

## Fix

Default non-PM agents to **`sonnet[1m]`**. The `[1m]` suffix is how the Agent SDK enables Sonnet's 1M window — it strips the suffix, sends `claude-sonnet-4-6`, and adds the `context-1m-2025-08-07` beta header (verified directly against the SDK request). Opus is 1M natively, so the PM default (`opus`) is unchanged.

```ts
const model = def.model || (isPmAgent(def) ? 'opus' : 'sonnet[1m]');
```

The model string is set **explicitly** rather than via a runtime transform, so the intent is visible at the definition site.

## Scope

- This PR: the code-level default in `spawn.ts`.
- **Companion PR in `archie-plugins`:** the `ops` agent pins `model: sonnet` in frontmatter → `model: sonnet[1m]`. (All other plugin agents are already `opus`.)
- Left unchanged: the memory extractor/housekeeping side-agents (`maxTurns: 1`, tiny inputs — never overflow) and the research classifier (different `anthropic/` model format).

**Cost:** the 1M window carries no per-token premium (Sonnet 4.6 is $3/$15 at 1M). It removes the *overflow*; the ~424K of injected memory per turn is a separate workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)