### PR TITLE
Raise task wall-clock cap from 30 to 60 minutes

### DIFF
--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -32,7 +32,7 @@ export interface TaskBudgets {
   interAgentMessageCount: number;   // send_message_to_agent calls
   interAgentMessageLimit: number;   // default: 100
   taskStartTime: Date;              // for wall-clock timeout
-  taskTimeoutMs: number;            // default: 1_800_000 (30 minutes)
+  taskTimeoutMs: number;            // default: 3_600_000 (60 minutes)
 }
 import { Agent } from '../agents/agent.js';
 
@@ -95,7 +95,7 @@ export class Task {
       interAgentMessageCount: 0,
       interAgentMessageLimit: 100,
       taskStartTime: new Date(),
-      taskTimeoutMs: 1_800_000, // 30 minutes
+      taskTimeoutMs: 3_600_000, // 60 minutes
     };
 
     // Migrate legacy slack_threads → channels


### PR DESCRIPTION
Tasks increasingly hit the 30-minute auto-pause mid-work and need a manual resume. Bumps the wall-clock backstop to **60 minutes** ([task.ts:98](../blob/main/src/tasks/task.ts#L98)).

```ts
taskTimeoutMs: 3_600_000, // 60 minutes  (was 1_800_000)
```

- The cap is checked once a minute, so it fires at ~60 min (±1).
- The pause message computes its minute count from actual elapsed time, so it reports the real duration with no other change.
- Still a *park* (`complete()`), not a `stop()` — the task reopens cleanly on the next reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)