### PR TITLE
Sync submodule URLs before update on plugin refresh

### DIFF
--- a/src/system/workdir.ts
+++ b/src/system/workdir.ts
@@ -180,6 +180,11 @@ export async function refreshPlugins(): Promise<boolean> {
         await execAsync(`git reset --hard "origin/${branch}"`, { cwd: PLUGINS_DIR });
         // `reset --hard` moves the gitlink but not submodule working trees, so sync
         // submodules onto their recorded commits (and init any newly added ones).
+        // `submodule sync` first propagates any .gitmodules URL change into this
+        // clone's .git/config — without it an existing clone keeps a stale cached
+        // URL (e.g. an SSH URL that fails under HTTPS/GIT_ASKPASS auth) and the
+        // submodule never materialises.
+        await execAsync('git submodule sync --recursive', { cwd: PLUGINS_DIR });
         await execAsync('git submodule update --init --recursive', { cwd: PLUGINS_DIR });
         logger.system('Plugins refreshed from remote');
         // Re-scan plugin definitions (picks up new/changed agents, prompts, etc.)


### PR DESCRIPTION
## Why

When `.gitmodules` changes a submodule's URL, that change does **not** reach an already-cloned repo's `.git/config` on its own — `git submodule update` keeps using the stale cached URL. So when prod's plugins clone first saw the data-context submodule pinned over **SSH** (which fails under Archie's HTTPS/`GIT_ASKPASS` auth), the submodule never materialised, leaving its skill symlink dangling and the data analyst without its context docs.

Fixing the URL in `archie-plugins` (sweatco/archie-plugins#62) isn't enough on its own — the existing prod clone would keep the cached SSH URL.

## Fix

Run `git submodule sync --recursive` before `git submodule update --init --recursive` on every plugin refresh ([workdir.ts](../blob/main/src/system/workdir.ts)). `sync` copies the current `.gitmodules` URLs into `.git/config`, so a URL change propagates to existing clones and the data-context submodule self-heals on the next plugin pull — no manual reclone needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)