### PR TITLE
Force plugin submodule init on every startup (self-heal on redeploy)

### DIFF
--- a/src/system/workdir.ts
+++ b/src/system/workdir.ts
@@ -102,6 +102,13 @@ export async function bootstrapWorkdir(): Promise<void> {
       `Set ARCHIE_PLUGINS to a git URL, or manually place plugins in ${PLUGINS_DIR}.`
     );
   }
+
+  // Materialise plugin submodules on every startup, independent of whether the
+  // plugins branch moved. refreshPlugins() only touches submodules when the
+  // branch tip changes, so a clone already at HEAD with an un-initialised
+  // submodule (e.g. one added while an earlier init failed under the old SSH
+  // URL) would never self-heal. This makes a redeploy/restart always force it.
+  if (managedPlugins) await ensureSubmodules();
 }
 
 /**
@@ -136,6 +143,28 @@ export function getBaseCachePath(github: string): string {
 
 let managedPlugins = false;
 let pluginsRefreshPromise: Promise<boolean> | null = null;
+
+/**
+ * Materialise the plugins repo's git submodules. Idempotent: a no-op when they
+ * are already checked out, a self-heal when they aren't.
+ *
+ * `submodule sync` first copies the current .gitmodules URLs into .git/config —
+ * without it an existing clone keeps a stale cached URL (e.g. an SSH URL that
+ * fails under the HTTPS/GIT_ASKPASS auth used in prod) and the submodule never
+ * materialises. Then `update --init --recursive` checks out each submodule at
+ * its recorded commit (and initialises any newly added one).
+ *
+ * Best-effort: logs and returns on failure so a submodule problem never blocks
+ * startup — the rest of the plugin tree still loads.
+ */
+async function ensureSubmodules(): Promise<void> {
+  try {
+    await execAsync('git submodule sync --recursive', { cwd: PLUGINS_DIR });
+    await execAsync('git submodule update --init --recursive', { cwd: PLUGINS_DIR });
+  } catch (err) {
+    logger.error('workdir', 'Plugin submodule init failed', err);
+  }
+}
 
 /**
  * Check the plugins remote for new commits and, if the branch tip moved,
@@ -178,14 +207,9 @@ export async function refreshPlugins(): Promise<boolean> {
         await execAsync('git fetch --all --prune', { cwd: PLUGINS_DIR });
         await execAsync(`git checkout "${branch}"`, { cwd: PLUGINS_DIR });
         await execAsync(`git reset --hard "origin/${branch}"`, { cwd: PLUGINS_DIR });
-        // `reset --hard` moves the gitlink but not submodule working trees, so sync
-        // submodules onto their recorded commits (and init any newly added ones).
-        // `submodule sync` first propagates any .gitmodules URL change into this
-        // clone's .git/config — without it an existing clone keeps a stale cached
-        // URL (e.g. an SSH URL that fails under HTTPS/GIT_ASKPASS auth) and the
-        // submodule never materialises.
-        await execAsync('git submodule sync --recursive', { cwd: PLUGINS_DIR });
-        await execAsync('git submodule update --init --recursive', { cwd: PLUGINS_DIR });
+        // `reset --hard` moves the gitlink but not submodule working trees, so
+        // sync+update them onto their recorded commits (and init newly added ones).
+        await ensureSubmodules();
         logger.system('Plugins refreshed from remote');
         // Re-scan plugin definitions (picks up new/changed agents, prompts, etc.)
         initPlugins();


### PR DESCRIPTION
## Why the previous fix didn't take

#120 added `git submodule sync` + `update --init` — but only inside `refreshPlugins()`'s **branch-moved** path. In prod, the plugins clone is already at HEAD (the HTTPS `.gitmodules` from archie-plugins#62 is present), so on restart the app logs:

```
[workdir] Plugins up to date (main @ 713eeb37)
```

…and returns early — **never running the submodule step**. The data-context submodule (added in PR 48 while the old SSH URL was failing) stayed un-initialised, `_vendor/` empty, and the skill symlink dangling. A redeploy couldn't heal it because there was no branch movement to trigger the path, and the initial `clone --recurse-submodules` doesn't re-run on an existing dir.

Verified on the server: `.gitmodules` is HTTPS ✅, but `.git/config` has no submodule entry and `git submodule status` (as the `archie` container user) shows it uninitialised.

## Fix

Extract the sync+update into an idempotent **`ensureSubmodules()`** and call it **unconditionally** from `bootstrapWorkdir` for managed plugin clones — independent of branch movement:

```ts
if (managedPlugins) await ensureSubmodules();
```

- **No-op** when submodules are already checked out; **self-heal** when they aren't.
- So **every redeploy/restart now guarantees** submodules are materialised — which is what unblocks prod here, with no manual intervention.
- `refreshPlugins()` still calls it on branch moves (a mid-run plugins push adding a submodule is still picked up).
- Best-effort (logged, non-fatal) — a submodule problem never blocks startup.

## Validation
Deploying this **is** the fix: on container start, `ensureSubmodules()` runs → the data-context submodule checks out over HTTPS (`GIT_ASKPASS` token) → the `skills/sweatcoin-data-context` symlink resolves → data analyst regains its context. The deploy itself proves the self-heal.

typecheck + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)