### PR TITLE
Mount symlinked skill dirs (data-context Skill entrypoint)

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -11,7 +11,7 @@
  */
 
 import { join } from 'path';
-import { mkdir, symlink, readdir, writeFile } from 'fs/promises';
+import { mkdir, symlink, readdir, writeFile, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { Agent } from './agent.js';
@@ -117,11 +117,20 @@ async function setupAgentWorkspace(taskId: string, agent: Agent): Promise<string
 
     for (const skillsPath of skillSources) {
       for (const skillEntry of await readdir(skillsPath, { withFileTypes: true })) {
-        if (!skillEntry.isDirectory()) continue;
+        const entryPath = join(skillsPath, skillEntry.name);
+        // Mount real skill dirs AND symlinks that resolve to a dir. A skill can
+        // be vendored as a git submodule and exposed via a symlink (e.g. the
+        // data-analytics data-context); readdir's Dirent.isDirectory() is false
+        // for a symlink, so stat-follow to classify it. A dangling link is skipped.
+        let isDir = skillEntry.isDirectory();
+        if (!isDir && skillEntry.isSymbolicLink()) {
+          isDir = await stat(entryPath).then((s) => s.isDirectory()).catch(() => false);
+        }
+        if (!isDir) continue;
         const target = join(agentSkillsDir, skillEntry.name);
         if (!existsSync(target)) {
           await mkdir(agentSkillsDir, { recursive: true });
-          await symlink(join(skillsPath, skillEntry.name), target);
+          await symlink(entryPath, target);
         }
       }
     }


### PR DESCRIPTION
## Problem

`setupAgentWorkspace` mounts plugin skills into the agent's `.claude/skills/` by symlinking each entry, but gated on:

```ts
if (!skillEntry.isDirectory()) continue;
```

`readdir(…, {withFileTypes:true})` returns a `Dirent`, and for a **symlink** `isDirectory()` is `false` (it reports `isSymbolicLink()`). So the `data-analytics/sweatcoin-data-context` skill — vendored as a git submodule and exposed via a symlink — was **skipped**: never mounted, so Claude Code's `settingSources` scan never registered it as an invokable Skill. The analyst could still `Read` the files through the symlink (full context), but had no `Skill()` entrypoint. (Reported by the data-analyst self-check.)

## Fix

Classify each entry as a real directory **or** a symlink that `stat`-resolves to a directory, then mount it:

```ts
let isDir = skillEntry.isDirectory();
if (!isDir && skillEntry.isSymbolicLink()) {
  isDir = await stat(entryPath).then((s) => s.isDirectory()).catch(() => false);
}
if (!isDir) continue;
```

- Real dirs: unchanged.
- Symlink → dir (vendored submodule skill): now mounted → discoverable as a Skill.
- Dangling symlink (`stat` throws): skipped, safe.

Verified the classification against a real-layout fixture (real dir + relative symlink into a sibling `_vendor/` + dangling link) — mounts the first two, skips the dangling one. typecheck + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)