### PR TITLE
Fix recovery loop when task completes during deferred teardown

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -504,6 +504,13 @@ Shared folder: ${sharedPath} [READ-ONLY]
 
   // ---- Build query options (session ID may change on retry) ----
 
+  // One controller per spawn, shared across retry attempts. task.complete()/stop()
+  // calls handle.abort() to hard-kill a subprocess that is mid-turn when its queue
+  // is stopped — otherwise it loops on "Stream closed" control requests. The
+  // control channel (query.interrupt) is dead at that point, so abort is the only
+  // path that reaches the subprocess.
+  const abortController = new AbortController();
+
   const buildQueryOptions = (sessionId?: string) => ({
     model: model as any,
     systemPrompt,
@@ -533,6 +540,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       ...(def.pluginDataPath ? { CLAUDE_PLUGIN_DATA: def.pluginDataPath } : {}),
     },
     resume: sessionId,
+    abortController,
     maxTurns: def.maxTurns ?? 100,
     ...(def.effort ? { effort: def.effort } : {}),
     permissionMode: 'bypassPermissions' as const,
@@ -578,6 +586,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
   const handle = {
     running: Promise.resolve() as Promise<void>,
     isRunning: true,
+    abort: () => abortController.abort(),
   };
 
   handle.running = (async () => {

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -704,6 +704,21 @@ Shared folder: ${sharedPath} [READ-ONLY]
       }
     } finally {
       handle.isRunning = false;
+      // Backstop for a deferred teardown that the `result` path above never got
+      // to run — e.g. the agent crashed after report_completion/request_edit_mode
+      // deferred it. Without this the flag stays set, and the idle-check's
+      // pending-teardown guard would then suppress recovery forever, hanging the
+      // task until the wall-clock timeout. Safe here: the turn is over and the
+      // stream is closed (the only reason teardown was deferred), and complete()/
+      // stop() are idempotent. The result path clears the flag, so this is a
+      // no-op on every normal exit.
+      if (agent.pendingTeardown) {
+        const teardown = agent.pendingTeardown;
+        agent.clearPendingTeardown();
+        await teardown().catch((err) =>
+          logger.error(def.id, 'Error during deferred teardown (exit)', err)
+        );
+      }
     }
   })();
 

--- a/src/tasks/recovery.ts
+++ b/src/tasks/recovery.ts
@@ -78,6 +78,15 @@ export function scheduleIdleCheck(task: Task): void {
   setTimeout(async () => {
     if (!task.isActive || getIsShuttingDown()) return;
 
+    // A pending teardown means a tool (report_completion / request_edit_mode /
+    // research-budget) already called task.complete()/stop(), deferred to this
+    // turn's SDK `result` event. The Stop hook that arms this 3s check fires
+    // *before* that result event, and the gap can exceed 3s — so without this
+    // guard the check fires first, sees isActive still true with all agents
+    // parked, and "recovers" an agent that complete() then orphans mid-turn
+    // (→ "Stream closed" loop). The task is winding down, not stalled.
+    if ([...task.agentProcesses.values()].some((a) => a.pendingTeardown)) return;
+
     const allInactive = checkAllAgentsInactive(task);
     if (allInactive) {
       await triggerRecovery(task);

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -705,9 +705,17 @@ export class Task {
     activeTasks.delete(this.taskId);
     this.clearTaskTimeout();
 
-    // Stop all queues — agent:inactive emitted by Stop hook / crash handler
+    // Stop all queues. A parked or just-finished agent (session inactive) exits
+    // gracefully on its next queue pull — the resume-safe path the deferred
+    // teardown relies on (see spawn.ts: never .return() the generator), so do
+    // NOT abort it. But an agent still mid-turn keeps generating and hits
+    // "Stream closed" on every tool/hook control request, looping until maxTurns
+    // — stopping its queue can't end it, so hard-abort those. agent:inactive is
+    // emitted by the Stop hook / crash handler (or the aborted loop exiting).
     for (const a of this.agentProcesses.values()) {
+      const midTurn = a.session.active;
       a.queue.stop();
+      if (midTurn) a.handle?.abort();
     }
 
     // Clean up clones to free disk space (only when not in edit mode)
@@ -738,9 +746,17 @@ export class Task {
     activeTasks.delete(this.taskId);
     this.clearTaskTimeout();
 
-    // Stop all queues — agent:inactive emitted by Stop hook / crash handler
+    // Stop all queues. A parked or just-finished agent (session inactive) exits
+    // gracefully on its next queue pull — the resume-safe path the deferred
+    // teardown relies on (see spawn.ts: never .return() the generator), so do
+    // NOT abort it. But an agent still mid-turn keeps generating and hits
+    // "Stream closed" on every tool/hook control request, looping until maxTurns
+    // — stopping its queue can't end it, so hard-abort those. agent:inactive is
+    // emitted by the Stop hook / crash handler (or the aborted loop exiting).
     for (const a of this.agentProcesses.values()) {
+      const midTurn = a.session.active;
       a.queue.stop();
+      if (midTurn) a.handle?.abort();
     }
 
     // Clean up clones to free disk space (only when not in edit mode).

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -67,6 +67,13 @@ export interface AgentHandle {
   running: Promise<void>;
   /** Whether the agent is still processing messages */
   isRunning: boolean;
+  /**
+   * Hard-abort the SDK subprocess (via its AbortController). Task teardown
+   * calls this after stopping the queue, to kill an agent that is mid-turn when
+   * its stream is closed — otherwise it loops on "Stream closed" control
+   * requests until maxTurns.
+   */
+  abort(): void;
 }
 
 /**


### PR DESCRIPTION
## Problem

On `task-20260627-1443-4vm4bv`, the PM finished a task correctly — then the system triggered **recovery** (an error in this context), which resurrected `mobile-agent`. `task.complete()` immediately orphaned it, and the orphaned subprocess **looped indefinitely**, spamming:

```
[mobile-agent] stderr: Error in hook callback hook_0: ... error: Stream closed
```

## Root cause

Two chained defects.

**1 — Recovery races the deferred teardown.**
`report_completion` defers `task.complete()` to the SDK `result` event so the tool response and Stop hook finish over an open stream. But the **Stop hook** — which arms the 3s idle check — fires *before* the result event, and that gap can exceed 3s. The idle check's only guard was `if (!task.isActive) return`; at fire time `isActive` was still `true`, all agents were parked, so it triggered recovery and nudged the task owner back to life.

Timeline:

| time | event |
|---|---|
| `15:29:29.196` | pm-agent inactive (Stop hook) → arms idle check at **+3s = 15:29:32.196** |
| `15:29:32.196` | idle check fires — `isActive` still true, all idle → recovery |
| `15:29:32.236` | mobile-agent reactivated (`reinforceAgent` nudge) |
| `15:29:32.370` | deferred `task.complete()` runs → stops mobile's queue mid-turn |

**2 — An orphaned mid-turn subprocess loops on "Stream closed".**
`task.complete()` only called `queue.stop()`; there was no way to kill the subprocess. A subprocess mid-turn keeps generating and hits "Stream closed" on every tool/hook control request, retrying until `maxTurns`.

## Fix

**Primary — `recovery.ts`:** skip the idle check when any agent has a pending teardown. The task is winding down, not stalled. `report_completion` sets that flag at `15:29:26`, well before the timer fires, so recovery never runs.

**Defense-in-depth — `spawn.ts` / `task.ts` / `agent.ts`:** each spawn gets an `AbortController` exposed as `handle.abort()`. `task.complete()`/`stop()` hard-aborts agents still **mid-turn** (`session.active`), since stopping their queue can't end a generating subprocess. Parked/finished agents are left to exit gracefully via the queue-drain path, preserving resume safety (`spawn.ts` deliberately never `.return()`s the generator — abrupt teardown previously broke the next `resume`). The mid-turn guard is what keeps this from re-introducing that regression.

**Backstop — `spawn.ts` finally (commit 3):** the primary guard assumes a deferred teardown always eventually runs. It runs on the `result` event — but if the agent crashes *between* `report_completion` and that event, `pendingTeardown` stays set and the guard would suppress recovery forever → task hangs until the wall-clock timeout. So: if a teardown is still pending when the query loop exits, run it then. Safe (turn over, stream closed, `complete()`/`stop()` idempotent) and a no-op on every normal exit (the result path already cleared the flag).

## Files

- `src/tasks/recovery.ts` — pending-teardown guard on the idle check
- `src/agents/spawn.ts` — per-spawn `AbortController` → `handle.abort()`; deferred-teardown backstop in `finally`
- `src/tasks/task.ts` — `complete()`/`stop()` abort mid-turn agents after stopping queues
- `src/types/agent.ts` — `AgentHandle.abort()`

## Verification

- `npm run typecheck` — clean.
- Traced every path into the new `finally` backstop: no double-run (result path clears the flag first), no retry interference (`continue` stays in-loop), idempotent teardowns, no leak across runs (`clearPendingTeardown` at spawn start), no deadlock (teardowns don't await `handle.running`), shutdown-safe.
- vitest not run: the local runner fails to load (`rolldown-binding.darwin-universal.node` missing) — environmental, unrelated. No existing tests cover recovery / task lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)