### PR TITLE
Completion as quiescence: fix spurious recovery & completion races

### DIFF
--- a/docs/plans/20260627-completion-quiescence.md
+++ b/docs/plans/20260627-completion-quiescence.md
@@ -1,0 +1,187 @@
+# Completion as Quiescence
+
+**Status:** Proposed (design verified — 2 subagent rounds, implementation-ready; under review; not yet implemented)
+**Supersedes the coordination half of:** the `activePeers` completion guard in `report_completion`.
+
+---
+
+## 1. Background
+
+Multi-agent task. PM owns the user conversation; specialists (mobile, backend, ops…) do work and report back via `send_message_to_agent`. Agents are turn-based: a turn starts on an incoming queue message and ends after a turn-ending tool call; the SDK `Stop` hook then marks the agent inactive ([spawn.ts:560](../../src/agents/spawn.ts) Stop hook → `updateAgentState(false)` at 562). A task with all agents inactive but still `isActive` is either *done* or *stalled*; the idle-check ([recovery.ts:77](../../src/tasks/recovery.ts)) currently always treats it as a stall and triggers recovery.
+
+`report_completion` ([tools.ts:569](../../src/agents/tools.ts)) is PM's turn-ending tool. **Corrected semantics (load-bearing):** completion does *not* mean the overall job is finished. Per the PM prompt itself ([pm-agent.md:86](../../prompts/pm-agent.md)): *"it means 'I've responded to my requester and am now waiting for their next input.'"* The task parks; any later message (user follow-up, late peer message, webhook) reopens it via `activate()` ([task.ts:1080](../../src/tasks/task.ts)) — `task.complete()` ([task.ts:739](../../src/tasks/task.ts)) produces a reopenable state.
+
+### Agent lifecycle fact (verified, essential to this design)
+
+`session.active` is set **only** by `updateAgentState(true)`, called in exactly two places — [spawn.ts:184](../../src/agents/spawn.ts) (start of `spawnAgent`) and [spawn.ts:606](../../src/agents/spawn.ts) (on the SDK `system:init` event). Both are tied to a `query()` spawn/turn-start, **never to message enqueue.**
+
+Empirically (events for `task-20260627-1443-4vm4bv`): a fresh spawn after a park emits **two** `agent:active` (184 + 606); a peer reply to an already-running PM emits **one** (606 only). So **the subprocess persists between turns ("live-idle": `isRunning` true, `session.active` false), and the SDK re-emits `init` on each resumed turn**, which re-marks active — but only *after* the SDK starts the turn. There is a latency gap between "message enqueued to a live-idle agent" and "agent marked active." **This gap is the crux of the design (see §3 Invariant).**
+
+## 2. Problem
+
+To stop PM completing while a specialist was genuinely working (which orphaned the specialist's pending reply), a guard refuses completion if `activePeers()` is non-empty ([tools.ts:593](../../src/agents/tools.ts), [task.ts:824](../../src/tasks/task.ts)).
+
+It misfires because **`session.active` conflates two states**:
+
+- **Working** — mid-turn, may still message PM. Completing *would* orphan it.
+- **Winding down** — already made its turn-ending `send_message_to_agent(PM)` call; just hasn't hit its `Stop` hook yet. Completing destroys nothing.
+
+So every threshold is wrong somewhere:
+
+- No check → PM completes over a genuinely-working peer (the original bug).
+- Refuse-if-active → PM blocked by a *winding-down* peer; PM falls back to `post_to_user`, ends its turn "waiting for a report that already arrived," nothing reopens it → all idle, no teardown pending → idle-check fires → **spurious recovery** (observed: `task-20260627-1443-4vm4bv`, PM `report_completion` at `20:28:57.759` refused because mobile's `Stop` hook hadn't fired until `20:28:58.108`).
+
+A synchronous gate guarding an asynchronous lifecycle always races the `Stop`-hook boundary. Tuning the gate cannot fix it.
+
+## 3. The model
+
+**Decide at quiescence, not at the racy moment.** `report_completion` stops being a gate and becomes an intent. Teardown is gated on the system actually going quiet.
+
+- **intent** — PM called `report_completion` and has not reopened since. Means "I wait for no one but the user."
+- **quiescent** — all agents idle.
+
+`report_completion`:
+1. Posts PM's message to the user **immediately** (it is PM's user-facing response, not a "done" banner — **do not defer it**).
+2. Sets `task.completionIntent = true`.
+3. Returns a short result that confirms completion and tells the agent to **end its turn now**. Since the call no longer tears the agent down, prompt turn-end is what lets the system reach quiescence.
+4. **Never refuses.**
+
+> **Hardened return text** (replaces the now-inaccurate `'Stopped task.'` / `'Posted message to Slack and stopped task.'`): *"Message posted. Nothing left to do — end your turn."* (with message) / *"Completion recorded. Nothing left to do — end your turn."* (no message). Kept minimal on purpose. It's a **soft** reinforcement of the prompt's "STOP immediately," not a correctness guarantee — the quiescence model self-protects (a lingering agent only delays the park; contradictory work makes a peer active → not quiescent), and the 30-min wall-clock `complete()` is the hard backstop.
+
+The idle-check (the single "system went quiet" handler) becomes:
+
+```
+on the 3s idle tick:
+  if (!task.isActive || getIsShuttingDown())            return;
+  if (any agent has a pending teardown)                  return;   // edit-mode / research-budget winding down
+  if (!allAgentsIdle())                                  return;   // not quiescent yet
+  // quiescent:
+  if (task.completionIntent) { await task.complete(); return; }    // PM's "wait for no one", verified → park
+  await triggerRecovery(task);                                     // quiet but nobody parked → dropped ball
+```
+
+### Invariant (resolves the live-idle gap — see §1 and §13/H1)
+
+> **An agent is marked `active` synchronously the moment a message is enqueued to it — not lazily when the SDK re-emits `init`.**
+
+Without this, a live-idle agent that just received a message (e.g. a peer's report reopening PM) is still `session.active === false` until the SDK starts its turn. In that gap the idle-check would see the system "quiescent" while PM is actually mid-turn, and with intent set it would **park PM and drop the very reply this design exists to protect.** Marking active at enqueue makes "all agents idle" a faithful proxy for "no work in flight," so the quiescence verdict is never wrong. (Implementation in §7.)
+
+### Why this is correct (and kills the misfire structurally)
+
+> `report_completion` is PM's **claim**: "I wait for no one." Quiescence is the system **verifying** it.
+
+- Claim true (no peer working, none queued) → quiescent → park. ✓
+- Claim false (misfire — a peer is genuinely working, or about to be messaged) → a message is or will be enqueued → target marked active → **not quiescent** → no park. The peer is protected *structurally*. Its report reopens PM (enqueue → PM active → intent cleared) → PM continues. **The false claim self-corrects.**
+
+Completion now runs from the idle-check **while PM is already idle** — not inside PM's turn — so it needs no deferred-teardown, and the prior idle-check-vs-deferred-teardown race cannot occur for completion at all.
+
+## 4. Recovery is kept — it is the answer to the dropped-ball case
+
+Recovery is the `no-intent` branch of quiescence: all idle, nobody parked = someone went silent without reporting → nudge ([recovery.ts:117](../../src/tasks/recovery.ts) `triggerRecovery`, unchanged). The bug was recovery firing when PM *had* parked (incident 2); fixed because parking now sets `completionIntent`, routing quiescence to `complete()` instead of recovery. Recovery gets **more** precise, not weaker.
+
+## 5. Scenario matrix
+
+`intent` = `completionIntent` set. `quiescent` = all agents idle (and, per the §3 invariant, no message enqueued-but-unprocessed). Message posts immediately wherever `report_completion` is called.
+
+| # | Situation | intent | at "all idle" | outcome |
+|---|---|---|---|---|
+| 1 | **Happy relay** — peer reports, PM relays + completes | yes | quiescent | park ✓ |
+| 2 | **Incident 2** — peer winding down when PM completes | yes | quiescent once peer `Stop`-hooks | park ✓ (no refuse, no recovery) |
+| 3 | **Dropped ball** — PM waiting, peer finishes silently | no | quiescent | recovery → nudge → continue ✓ |
+| 4 | **PM misfire** — peer genuinely working, PM completes early | yes | peer active / peer's report enqueued → PM marked active → **not** quiescent; PM reopens → intent cleared | message posted, PM continues; no premature park ✓ |
+| 5 | **Double fault** — PM misfires *and* peer then finishes silently (no report) | yes | quiescent | park ⚠️ (reopenable; see §10) |
+| 6 | **Parallel** — PM waits on 2 peers | no | quiescent only when both idle | both report → reopen → park; any silent → recovery ✓ |
+| 7 | **User barges in** mid-completion | set, then cleared | user msg enqueued → PM marked active → intent cleared | PM handles new request ✓ |
+| 8 | **PM stall/crash** (no delegation) | no | quiescent | recovery → respawn PM ✓ |
+| 9 | **Peer crash** mid-work | no | quiescent | recovery → nudge/respawn peer ✓ |
+| 10 | **Silent completion** — `report_completion()` no message | yes | quiescent | park silently ✓ |
+| 11 | **Message in flight** at the idle moment | — | enqueue marked target active → not quiescent | wait → processed → re-evaluate ✓ |
+| 12 | **Late peer message** after park | — | — | reopens task (`activate`) — self-heals ✓ |
+
+Rows currently broken: **2** (spurious recovery), **4** (flaky refuse). Both become correct. Rows 3/8/9 (recovery's real job) unchanged. Rows 4/7/11 are correct **only with the §3 invariant** — without it they regress to H1.
+
+## 6. Intent lifecycle
+
+- **Set:** in `report_completion`, after the message posts.
+- **Cleared:** on PM's `inactive→active` transition in `updateAgentState` ([task.ts:1030](../../src/tasks/task.ts)). With the §7 enqueue-marks-active change, this edge fires the moment a peer report or user message is delivered to a parked-intent PM — exactly when the intent should be reconsidered.
+  - **Implementation guardrail (edge-exact):** capture the *pre-update* `session.active` and clear intent only on a genuine `false→true` PM edge. The idempotency early-return at [task.ts:1037](../../src/tasks/task.ts) (`active === active && !sessionId`) covers the no-sessionId case, **but the SDK `init` re-fire calls `updateAgentState(pm, true, sessionId)` *with* a sessionId, which bypasses that early-return** — so a naive "clear whenever the body runs with active=true" would mis-fire on every resumed turn's init. Gate strictly on the edge. (In practice the synchronous enqueue-mark sets PM active ~30ms before the init re-fire, so intent is already cleared by then; the edge-gate just keeps it exact.)
+- **Not cleared by** a specialist going active (it has no bearing on PM's "waiting on user" claim unless it messages PM, which routes through PM going active). A more conservative variant — clear on *any* agent reactivation — trades rare premature parks (row 5) for slightly more recovery churn; default **pm-only**, noted as a tunable.
+- **Recovery nudge:** [recovery.ts:159](../../src/tasks/recovery.ts) currently marks active via `updateSession(true)` (no event, no intent-clear). Switch it to `updateAgentState(true)` so a nudged PM also clears intent and re-decides (otherwise stale intent could park instead of re-recovering).
+- **Persistence:** in-memory on `Task` (like `recoveryAttempts`, [task.ts:83](../../src/tasks/task.ts)). Lost on restart → a task about to park instead takes the recovery path on resume (nudge → PM re-completes). Acceptable; no new persistence.
+
+## 7. Code changes
+
+| File | Change |
+|---|---|
+| `src/tasks/task.ts` | Add `completionIntent: boolean`. In `updateAgentState`, clear it on pm-agent `inactive→active`. **Enqueue-marks-active:** in `toolSendMessage` ([task.ts:869](../../src/tasks/task.ts), after `addMessage` at ~908) call `updateAgentState(target, true)` so the recipient is active synchronously (the §3 invariant). |
+| `src/agents/tools.ts` | `report_completion`: **remove** the `activePeers` refuse ([tools.ts:593](../../src/agents/tools.ts)). Keep idempotency (`!task.isActive`) + no-channel guard + the immediate message post. Replace `deferTeardown(() => task.complete())` ([tools.ts:629](../../src/agents/tools.ts)) with `task.setCompletionIntent()`. **No teardown deferred for completion.** Replace both return strings ([tools.ts:630](../../src/agents/tools.ts)) with the hardened directive result (§3) — the old `'Stopped task.'` wording is now inaccurate (nothing stops synchronously). |
+| `src/tasks/recovery.ts` | `scheduleIdleCheck`: restructure to the §3 loop (quiescence gate, then `completionIntent → complete()` else `triggerRecovery()`). Nudge path ([recovery.ts:159](../../src/tasks/recovery.ts)): `updateSession(true)` → `updateAgentState(true)`. |
+| `src/tasks/task.ts` | **Choke set (verified complete — round 2):** mark the target active right after `addMessage` in **both** `sendMessage` (~[task.ts:223](../../src/tasks/task.ts) — every external/system enqueue funnels here: slack/events, github webhooks, api routes, launch, reminders, edit-mode/research/denial resumes, startup recovery) and `toolSendMessage` (~908), plus the recovery-nudge switch above. `Agent.sendMessage` ([agent.ts:84](../../src/agents/agent.ts)) has **zero callers**, and `prependMessage` only replays already-consumed messages into a mid-retry (already-active) generator — neither needs marking. So two call sites + the nudge switch cover everything. |
+| `src/tasks/task.ts` | `activePeers()` ([task.ts:824](../../src/tasks/task.ts)) becomes unused (sole caller is the deleted refuse — verified). Remove it. |
+
+**Second completion site (benign, no change):** the 60-min wall-clock cap calls `await this.complete()` ([task.ts:1112](../../src/tasks/task.ts)). Idempotent with the idle-check's `complete()` and ignores intent — parks unconditionally on timeout, which is correct. Noted so the reader knows completion isn't solely `report_completion`'s concern.
+
+**Unchanged / still needed** — the three teardown-race fixes already landed (pending-teardown guard, mid-turn abort, `finally` backstop) remain valid for the **forced-stop** paths that still defer from inside a turn: `request_edit_mode` ([tools.ts:563](../../src/agents/tools.ts) → `task.stop()`) and research-budget ([task.ts:981](../../src/tasks/task.ts) → `task.stop()`):
+- pending-teardown guard in the idle-check (still guards those defers),
+- abort mid-turn agents in `complete()`/`stop()`,
+- the `finally` backstop ([spawn.ts](../../src/agents/spawn.ts)) that runs a stranded deferred teardown on agent exit.
+
+Completion stops using the defer machinery; the forced stops keep it.
+
+## 8. Prompt updates
+
+The PM prompt hard-codes the deleted behavior and must be rewritten, not just "located":
+
+- [pm-agent.md:88](../../prompts/pm-agent.md): *"The tool enforces this: if a peer is still active, `report_completion` refuses and names who."* — **false under the new model** (never refuses). Rewrite: the guidance "only complete when no agent work is outstanding" stays as a *PM responsibility*; drop the "tool enforces / refuses" claim. Optionally note the system won't tear down a task while a peer is genuinely active (quiescence), but PM should still not call it while awaiting a peer.
+- [pm-agent.md:39](../../prompts/pm-agent.md): "It would pause the task and tear down the agent you're waiting on, dropping its reply." — soften: with quiescence the reply isn't dropped, but the correct behavior is still `post_to_user` + end turn (not `report_completion`) while awaiting a peer.
+- [pm-agent.md:33](../../prompts/pm-agent.md), [:86](../../prompts/pm-agent.md): already align with the corrected semantics ("waiting for their next input") — leave.
+
+Note (round-2 corrected): the active PM prompt is `prompts/pm-agent.md`, loaded via `loadPrompt('pm-agent')` ([spawn.ts:53](../../src/agents/spawn.ts)) — the pm-agent.md:88/:39 edits above are correctly targeted and mandatory. The active **skills** dir is `<repo>/skills/` (registry `CORE_SKILLS_DIR`, mounted at [spawn.ts:110](../../src/agents/spawn.ts)), **not** `prompts/_original/.claude/skills/` (a preserved, unloaded copy). **No active skill describes the refuse** (only `skills/self-awareness/SKILL.md` names `report_completion` as an internal tool) — so **no skill edit is needed**; only the two PM-prompt lines.
+
+## 9. Quiescence precision
+
+`allAgentsIdle()` = `checkAllAgentsInactive` ([recovery.ts:100](../../src/tasks/recovery.ts)) — all `session.active === false`. With the §3 invariant (enqueue marks active), an agent with an unprocessed message is `active`, so all-idle faithfully means no work in flight. **Do not** rely on `queue.pendingCount()` for this: `addMessage` hands a message directly to a waiting consumer without pushing to `messages[]`, so `pendingCount()` is 0 throughout processing ([message-queue.ts:39](../../src/agents/message-queue.ts)) — it cannot detect in-flight work. The enqueue-marks-active invariant is the correct mechanism; `pendingCount` is not a substitute.
+
+## 10. Residual risk
+
+**Row 5 (double fault):** PM *wrongly* parks (misfire) **and** the working peer then finishes **silently** (never reports what it should have). Result: premature park. Mitigations: (a) two simultaneous faults; (b) "parked awaiting user" is reopenable — any later message resurrects the task; (c) no worse than today, where the `activePeers` refuse only catches this if the peer happens to still be `active` at that exact instant (the same flaky race). Every other scenario resolves correctly by construction.
+
+**Pre-existing spawn-failure wedge (not introduced here; worth fixing alongside).** `spawnAgent` marks the agent active at [spawn.ts:184](../../src/agents/spawn.ts) *before* heavy async setup (workspace, MCP, clone) that can throw, but only wires the crash-handler that marks it inactive once `handle` is set at [spawn.ts:725](../../src/agents/spawn.ts). If setup throws in between, the agent stays `active` forever → never quiescent → no park/recovery until the 30-min wall-clock. This pre-dates the design, but the quiescence model leans harder on agents reliably reaching `inactive`, so add a `try`/guard in `spawnAgent`/`ensureAgentSpawned` that marks inactive if spawn throws. Note the §7 enqueue-mark adds **no** new wedge: it runs *after* `ensureAgentSpawned`, so a spawn failure throws before the mark.
+
+## 11. Testing
+
+- **Unit (vitest):** model the idle-check decision as a pure function of `(isActive, anyPendingTeardown, allIdle, completionIntent)` → assert the four outcomes. Test intent set/clear edges: set on `report_completion`; cleared on pm `inactive→active` (including the enqueue-driven transition); *not* cleared by a specialist reactivation or intra-turn `init` re-fire on PM. Test `toolSendMessage` marks the target active synchronously.
+- **Integration / manual (Docker):** reproduce incident 2 (peer winding down at completion → parks, no recovery log); the misfire (peer working + early `report_completion` → message posts, no park until peer done); the dropped ball (peer silent finish → recovery nudge); the live-idle race (user replies in the ~3s window after `report_completion` → PM re-engages, no park).
+- Local vitest runner currently fails to load (`rolldown-binding.darwin-universal.node` missing) — run in Docker or fix the binding.
+
+## 12. Out of scope (future)
+
+- Unifying `request_edit_mode` parking onto the same intent+quiescence model (same shape: PM parks awaiting user approval). Deferred to limit blast radius.
+- Persisting `completionIntent` across restarts (intentionally in-memory).
+
+## 13. Design-review log
+
+**Round 1 (subagent verification) — blocker found and resolved:**
+
+- **H1 (critical):** removing completion's teardown leaves PM **live-idle** (subprocess alive, `session.active` false) between turns; a message arriving in the pre-park window would be processed before the SDK re-emits `init` and re-marks active, so the idle-check could read the system as quiescent and **park PM mid-turn**, dropping the reply. **Resolution:** §3 Invariant — mark an agent active synchronously at message **enqueue** (§7), not lazily at `init`. Closes the gap; `session.active` becomes "has work queued or processing."
+- **H2 (medium):** intent could never clear for a live-idle PM, because the clear keyed off `updateAgentState(true)` which (pre-fix) only fired at spawn/`init`. **Resolution:** same enqueue-marks-active change routes the resume through `updateAgentState(true)`, firing the `inactive→active` clear; plus the recovery-nudge switch to `updateAgentState(true)` (§6).
+- **Ref drift:** stale line numbers in the first draft corrected throughout (activePeers 824, updateAgentState 1030/guard 1037, checkAllAgentsInactive 100, triggerRecovery 117, complete() 739, report_completion 569, timeout complete() 1112).
+- **Confirmed sound:** `activePeers` has a single caller (safe to delete); `complete()`/`stop()` idempotent (no double-complete harm); forced-stop paths unaffected; recovery branch logic intact.
+
+**Round 2 (subagent verification of the revision) — implementation-ready, no blockers.**
+
+- **Enqueue-marks-active confirmed correct + choke set complete.** Three enqueue mechanisms (`sendMessage`, `toolSendMessage`, the recovery-nudge `addMessage`); all covered by two call-site marks + the nudge switch. `Agent.sendMessage` has no callers; `prependMessage` is internal retry-replay. No uncovered path.
+- **Live-idle gap measured.** Event trace shows enqueue→active latency of 18–44ms on live-idle resumes; a scan found **no** real instant where all-idle coincided with a queued-but-unprocessed message (H1 narrow in practice — the active *sender* normally bridges PM's re-activation). The invariant makes it airtight regardless.
+- **No premature intent-clear** — provided the clear is edge-exact (see §6 guardrail): the sessionId-bearing `init` re-fire bypasses the idempotency early-return, so gate on the true `false→true` PM edge, not "body ran with active=true."
+- **Restructured loop race-free** — runs synchronously to `complete()`'s first `await` (which sets `isActive=false` + stops/aborts queues), so no message interleaves the quiescence check.
+- **Recovery-nudge `agent:active` emission is safe** — no subscriber re-arms idle checks; no recovery↔complete oscillation (nudge runs only in the `!intent` branch).
+- **One pre-existing spawn-failure wedge** surfaced (see §10) — not introduced here.
+- Minor doc fixes applied from round 2: §8 skills path, §1 Stop-hook ref (560/562), choke-set wording (§7), this log.
+
+## 14. Rollout
+
+1. Build on the landed teardown-race fixes (pending-teardown guard, mid-turn abort, `finally` backstop).
+2. Implement §7 + §8 (and, ideally, the §10 spawn-failure guard).
+3. Post-implementation subagent review (regression check on forced-stop paths + the edge-exact intent-clear + the spawn-failure guard).
+4. Build/typecheck; Docker repro of incident 2 + misfire + dropped ball + live-idle race.
+5. Hand off.

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -36,7 +36,7 @@ The key to managing your turns is understanding who you're waiting for after you
 
 - **Neither**: You have more actions to take. Continue working, then re-evaluate.
 
-**Pinged by the user while still waiting on an agent**: You're still *waiting for AGENT*. Reassure with `post_to_user`, then end your turn — do NOT `report_completion`. It would pause the task and tear down the agent you're waiting on, dropping its reply. The agent's report reopens your turn.
+**Pinged by the user while still waiting on an agent**: You're still *waiting for AGENT*. Reassure with `post_to_user`, then end your turn — do NOT `report_completion` (that signals you're waiting on no one, which isn't true). The agent's report reopens your turn.
 
 ### 3. Communication Channel Philosophy
 
@@ -85,7 +85,7 @@ When assigning work to an agent via `send_message_to_agent`, ALWAYS start your m
 
 Calling `report_completion` doesn't abandon work - it means "I've responded to my requester and am now waiting for their next input." Tasks automatically reopen when users respond or new events arrive.
 
-**Only complete when no agent work is outstanding.** Completing stops every agent, so a teammate still mid-task (e.g. an awaited review or deliverable) loses their reply. The tool enforces this: if a peer is still active, `report_completion` refuses and names who. That's not an error — stop and wait, their report reopens your turn.
+**Only complete when no agent work is outstanding.** If a teammate is still mid-task (e.g. an awaited review or deliverable), do NOT `report_completion`: reply with `post_to_user` if the user needs an update, then end your turn — their report reopens your turn. Reserve `report_completion` for when you're waiting on no one but the user.
 
 **When to include a message with report_completion** (user-facing milestones):
 

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -138,8 +138,16 @@ export class Agent {
 
     const hadSession = !!this.session.session_id;
 
-    // Spawn the SDK process
-    await spawnAgent(this, task);
+    // Spawn the SDK process. spawnAgent marks the agent active up-front (before
+    // MCP/clone setup that can throw); if that setup fails, undo the optimistic
+    // active mark so the agent doesn't linger "active" forever — which would wedge
+    // quiescence/idle detection (the task would never park or recover).
+    try {
+      await spawnAgent(this, task);
+    } catch (err) {
+      task.updateAgentState(this.def.id, false);
+      throw err;
+    }
 
     // Wire crash detection: when the SDK iterator exits, mark inactive.
     if (this.handle) {

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -504,6 +504,13 @@ Shared folder: ${sharedPath} [READ-ONLY]
 
   // ---- Build query options (session ID may change on retry) ----
 
+  // One controller per spawn, shared across retry attempts. task.complete()/stop()
+  // calls handle.abort() to hard-kill a subprocess that is mid-turn when its queue
+  // is stopped — otherwise it loops on "Stream closed" control requests. The
+  // control channel (query.interrupt) is dead at that point, so abort is the only
+  // path that reaches the subprocess.
+  const abortController = new AbortController();
+
   const buildQueryOptions = (sessionId?: string) => ({
     model: model as any,
     systemPrompt,
@@ -533,6 +540,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       ...(def.pluginDataPath ? { CLAUDE_PLUGIN_DATA: def.pluginDataPath } : {}),
     },
     resume: sessionId,
+    abortController,
     maxTurns: def.maxTurns ?? 100,
     ...(def.effort ? { effort: def.effort } : {}),
     permissionMode: 'bypassPermissions' as const,
@@ -578,6 +586,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
   const handle = {
     running: Promise.resolve() as Promise<void>,
     isRunning: true,
+    abort: () => abortController.abort(),
   };
 
   handle.running = (async () => {

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -704,6 +704,21 @@ Shared folder: ${sharedPath} [READ-ONLY]
       }
     } finally {
       handle.isRunning = false;
+      // Backstop for a deferred teardown that the `result` path above never got
+      // to run — e.g. the agent crashed after report_completion/request_edit_mode
+      // deferred it. Without this the flag stays set, and the idle-check's
+      // pending-teardown guard would then suppress recovery forever, hanging the
+      // task until the wall-clock timeout. Safe here: the turn is over and the
+      // stream is closed (the only reason teardown was deferred), and complete()/
+      // stop() are idempotent. The result path clears the flag, so this is a
+      // no-op on every normal exit.
+      if (agent.pendingTeardown) {
+        const teardown = agent.pendingTeardown;
+        agent.clearPendingTeardown();
+        await teardown().catch((err) =>
+          logger.error(def.id, 'Error during deferred teardown (exit)', err)
+        );
+      }
     }
   })();
 

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -569,34 +569,24 @@ function createRequestEditModeTool(agent: Agent, task: Task) {
 function createReportCompletionTool(agent: Agent, task: Task) {
   return tool(
     'report_completion',
-    'Stop the task. If message is provided, post it to Slack first.',
+    'Finish your turn: signal you have responded and are now waiting only on the user (not on any agent). If a message is provided, it is posted first.',
     {
-      message: z.string().optional().describe('Optional message to post to Slack before stopping'),
+      message: z.string().optional().describe('Optional message to post to Slack before finishing'),
     },
     async (args) => {
       const agentName = agent.def.id as AgentName;
-      // Idempotency: if the task is already completing/completed, skip side-effects.
-      // Prevents duplicate Slack posts when the agent retries after a stream-closed error
-      // (the previous complete() tore down the agent mid-response, so the retry is spurious).
+      // Idempotency: task already parked/stopped — nothing to do.
       if (!task.isActive) {
-        return ok('Task already completed.');
+        return ok('Task already completed. End your turn.');
       }
-      // Already asked to complete this turn — the spawn loop tears the task down
-      // when the turn ends. Skip duplicate side-effects (e.g. a second Slack post).
+      // A forced stop (request_edit_mode / research-budget) is already deferred
+      // this turn — don't double up.
       if (agent.pendingTeardown) {
-        return ok('Task already completing.');
+        return ok('Task already stopping. End your turn.');
       }
-      // Refuse completion while a peer agent is still mid-turn — completing now
-      // would stop their queue and drop the reply they're about to send back,
-      // orphaning the relay. Non-destructive: nothing posted, task stays active,
-      // the peer's reply reopens this turn. (report_completion is PM-only.)
-      const activePeers = task.activePeers(agentName);
-      if (activePeers.length > 0) {
-        return ok(
-          `Completion refused: ${activePeers.join(', ')} still working. ` +
-          `Not an error, nothing to retry — stop and wait, their report reopens your turn. ` +
-          `Need to update the user meanwhile? Use post_to_user.`
-        );
+      // Already recorded completion this turn — don't re-post or re-signal.
+      if (task.completionIntent) {
+        return ok('Completion already recorded. End your turn.');
       }
       if (args.message) {
         if (Object.keys(task.metadata.channels).length === 0) {
@@ -610,24 +600,27 @@ function createReportCompletionTool(agent: Agent, task: Task) {
           await task.postToUser(args.message, agentName);
         } catch (err) {
           // Surface the error to the agent so it can retry (e.g. split the
-          // message). Do NOT complete the task — completion only proceeds
-          // after a successful post (or no message at all).
+          // message). Do NOT record completion — it only proceeds after a
+          // successful post (or no message at all).
           return ok(formatSlackSendError(err));
         }
       }
       logger.agentAction(agentName, 'Reporting completion', '');
       task.touch();
-      // Blank the live status now: the final message is sent and we're done, but
-      // the teardown below is deferred to turn-end, so without this the indicator
-      // would pop back for a couple seconds during the wind-down.
+      // Blank the live status now — the final message is sent and the turn is
+      // ending; without this the indicator would pop back during the wind-down.
       task.suspendStatus();
-      // Defer teardown to the spawn loop: it runs this once the agent's turn
-      // fully ends (the SDK `result` event), so this tool response and the Stop
-      // hook's control round-trip both finish over an open input stream. Stopping
-      // the queue here (mid-turn) closes the stream under an in-flight hook, which
-      // the SDK surfaces as a "stream closed" error.
-      agent.deferTeardown(() => task.complete());
-      return ok(args.message ? 'Posted message to Slack and stopped task.' : 'Stopped task.');
+      // Record intent instead of tearing down. The idle-check parks the task once
+      // every agent is idle (quiescent); if a peer is in fact still working, the
+      // task stays active until it's done — so completion can't orphan a peer, and
+      // no synchronous peer-gate races the Stop-hook boundary. The agent must end
+      // its turn now: that's what lets the system reach quiescence and park.
+      task.setCompletionIntent();
+      return ok(
+        args.message
+          ? 'Message posted. Nothing left to do — end your turn.'
+          : 'Completion recorded. Nothing left to do — end your turn.'
+      );
     },
   );
 }

--- a/src/tasks/__tests__/completion-quiescence.test.ts
+++ b/src/tasks/__tests__/completion-quiescence.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the completion-as-quiescence model (see
+ * docs/plans/20260627-completion-quiescence.md).
+ *
+ * Covers the two load-bearing pure decisions:
+ *  - `idleDecision` — at quiescence, park (completion intent) vs recover (dropped
+ *    ball) vs wait (not active / forced-stop pending / still working).
+ *  - `shouldClearCompletionIntent` — the edge-exact PM intent-clear that must NOT
+ *    mis-fire on the SDK `init` re-fire of an already-active turn.
+ *
+ * The wired behaviours (report_completion sets intent, enqueue marks the target
+ * active) are exercised by the pre-merge smoke tests, not here — they need a live
+ * Task + SDK and aren't unit-isolable.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { idleDecision } from '../recovery.js';
+import { shouldClearCompletionIntent } from '../task.js';
+import type { Task } from '../task.js';
+import type { Agent } from '../../agents/agent.js';
+
+/** Minimal agent stand-in — idleDecision only reads `pendingTeardown` + `session.active`. */
+function fakeAgent(opts: { active?: boolean; pendingTeardown?: boolean } = {}): Agent {
+  return {
+    pendingTeardown: opts.pendingTeardown ? () => Promise.resolve() : undefined,
+    session: { active: opts.active ?? false },
+  } as unknown as Agent;
+}
+
+function fakeTask(opts: {
+  isActive?: boolean;
+  completionIntent?: boolean;
+  agents?: Agent[];
+}): Pick<Task, 'isActive' | 'completionIntent' | 'agentProcesses'> {
+  const agentProcesses = new Map<string, Agent>();
+  (opts.agents ?? []).forEach((a, i) => agentProcesses.set(`agent-${i}`, a));
+  return {
+    isActive: opts.isActive ?? true,
+    completionIntent: opts.completionIntent ?? false,
+    agentProcesses,
+  } as unknown as Pick<Task, 'isActive' | 'completionIntent' | 'agentProcesses'>;
+}
+
+describe('idleDecision', () => {
+  it('waits when the task is not active', () => {
+    expect(idleDecision(fakeTask({ isActive: false, agents: [fakeAgent()] }))).toBe('wait');
+  });
+
+  it('waits when any agent has a pending (forced-stop) teardown', () => {
+    expect(
+      idleDecision(fakeTask({ agents: [fakeAgent(), fakeAgent({ pendingTeardown: true })] })),
+    ).toBe('wait');
+  });
+
+  it('waits when no agents are spawned (not quiescent)', () => {
+    expect(idleDecision(fakeTask({ agents: [] }))).toBe('wait');
+  });
+
+  it('waits when any agent is still active (work in flight)', () => {
+    expect(
+      idleDecision(fakeTask({ completionIntent: true, agents: [fakeAgent({ active: true }), fakeAgent()] })),
+    ).toBe('wait');
+  });
+
+  it('completes when quiescent and PM signalled completion intent', () => {
+    expect(
+      idleDecision(fakeTask({ completionIntent: true, agents: [fakeAgent(), fakeAgent()] })),
+    ).toBe('complete');
+  });
+
+  it('recovers when quiescent but nobody parked (dropped ball)', () => {
+    expect(
+      idleDecision(fakeTask({ completionIntent: false, agents: [fakeAgent()] })),
+    ).toBe('recover');
+  });
+
+  it('prioritises the forced-stop teardown guard over completion intent', () => {
+    expect(
+      idleDecision(
+        fakeTask({ completionIntent: true, agents: [fakeAgent({ pendingTeardown: true })] }),
+      ),
+    ).toBe('wait');
+  });
+});
+
+describe('shouldClearCompletionIntent', () => {
+  it('clears on a genuine PM inactive→active edge (re-engagement)', () => {
+    expect(shouldClearCompletionIntent('pm-agent', true, false)).toBe(true);
+  });
+
+  it('does NOT clear on the init re-fire of an already-active PM turn', () => {
+    // The SDK `init` re-fire arrives with the agent already active (the synchronous
+    // enqueue mark set it first), so wasActive=true — must not re-clear intent.
+    expect(shouldClearCompletionIntent('pm-agent', true, true)).toBe(false);
+  });
+
+  it('does NOT clear when a specialist re-engages', () => {
+    expect(shouldClearCompletionIntent('mobile-agent', true, false)).toBe(false);
+  });
+
+  it('does NOT clear on PM going inactive', () => {
+    expect(shouldClearCompletionIntent('pm-agent', false, true)).toBe(false);
+  });
+});

--- a/src/tasks/recovery.ts
+++ b/src/tasks/recovery.ts
@@ -78,19 +78,26 @@ export function scheduleIdleCheck(task: Task): void {
   setTimeout(async () => {
     if (!task.isActive || getIsShuttingDown()) return;
 
-    // A pending teardown means a tool (report_completion / request_edit_mode /
-    // research-budget) already called task.complete()/stop(), deferred to this
-    // turn's SDK `result` event. The Stop hook that arms this 3s check fires
-    // *before* that result event, and the gap can exceed 3s — so without this
-    // guard the check fires first, sees isActive still true with all agents
-    // parked, and "recovers" an agent that complete() then orphans mid-turn
-    // (→ "Stream closed" loop). The task is winding down, not stalled.
+    // A pending teardown means a forced stop (request_edit_mode / research-budget)
+    // already called task.stop(), deferred to this turn's SDK `result` event. The
+    // Stop hook that arms this 3s check fires *before* that result event, and the
+    // gap can exceed 3s — so without this guard the check fires first, sees
+    // isActive still true with all agents parked, and "recovers" an agent that
+    // stop() then orphans mid-turn (→ "Stream closed" loop). Winding down, not stalled.
     if ([...task.agentProcesses.values()].some((a) => a.pendingTeardown)) return;
 
-    const allInactive = checkAllAgentsInactive(task);
-    if (allInactive) {
-      await triggerRecovery(task);
+    // Act only once the system is quiescent — every agent idle. With agents marked
+    // active at message enqueue, all-idle faithfully means "no work in flight."
+    if (!checkAllAgentsInactive(task)) return;
+
+    // Quiescent. If PM signalled "waiting on no one" (report_completion), park the
+    // task. Otherwise an agent went idle without anyone parking — a dropped ball
+    // → recover. (This branch is the whole completion-vs-stall decision.)
+    if (task.completionIntent) {
+      await task.complete();
+      return;
     }
+    await triggerRecovery(task);
   }, 3000);
 }
 
@@ -155,9 +162,10 @@ async function triggerRecovery(task: Task): Promise<void> {
         : AGENT_PROMPTS.reinforceAgent;
       targetAgent.queue.addMessage(prompt);
 
-      // Mark agent as active after nudge
-      targetAgent.updateSession(true);
-      task.save();
+      // Mark active after nudge — via updateAgentState (not updateSession) so it
+      // emits agent:active and clears any stale completionIntent on a nudged PM
+      // (which would otherwise park on the next quiescence instead of re-deciding).
+      task.updateAgentState(targetAgent.def.id, true);
     } else {
       // No live agent to nudge — re-spawn rather than silently stalling.
       // recoverTaskAgents re-sends the recovery prompt to previously-active

--- a/src/tasks/recovery.ts
+++ b/src/tasks/recovery.ts
@@ -78,6 +78,15 @@ export function scheduleIdleCheck(task: Task): void {
   setTimeout(async () => {
     if (!task.isActive || getIsShuttingDown()) return;
 
+    // A pending teardown means a tool (report_completion / request_edit_mode /
+    // research-budget) already called task.complete()/stop(), deferred to this
+    // turn's SDK `result` event. The Stop hook that arms this 3s check fires
+    // *before* that result event, and the gap can exceed 3s — so without this
+    // guard the check fires first, sees isActive still true with all agents
+    // parked, and "recovers" an agent that complete() then orphans mid-turn
+    // (→ "Stream closed" loop). The task is winding down, not stalled.
+    if ([...task.agentProcesses.values()].some((a) => a.pendingTeardown)) return;
+
     const allInactive = checkAllAgentsInactive(task);
     if (allInactive) {
       await triggerRecovery(task);

--- a/src/tasks/recovery.ts
+++ b/src/tasks/recovery.ts
@@ -74,43 +74,46 @@ async function recoverTaskAgents(task: Task): Promise<void> {
  * Small delay to avoid racing with message delivery
  * (another agent may be about to send a message that wakes this one).
  */
-export function scheduleIdleCheck(task: Task): void {
-  setTimeout(async () => {
-    if (!task.isActive || getIsShuttingDown()) return;
-
-    // A pending teardown means a forced stop (request_edit_mode / research-budget)
-    // already called task.stop(), deferred to this turn's SDK `result` event. The
-    // Stop hook that arms this 3s check fires *before* that result event, and the
-    // gap can exceed 3s — so without this guard the check fires first, sees
-    // isActive still true with all agents parked, and "recovers" an agent that
-    // stop() then orphans mid-turn (→ "Stream closed" loop). Winding down, not stalled.
-    if ([...task.agentProcesses.values()].some((a) => a.pendingTeardown)) return;
-
-    // Act only once the system is quiescent — every agent idle. With agents marked
-    // active at message enqueue, all-idle faithfully means "no work in flight."
-    if (!checkAllAgentsInactive(task)) return;
-
-    // Quiescent. If PM signalled "waiting on no one" (report_completion), park the
-    // task. Otherwise an agent went idle without anyone parking — a dropped ball
-    // → recover. (This branch is the whole completion-vs-stall decision.)
-    if (task.completionIntent) {
-      await task.complete();
-      return;
-    }
-    await triggerRecovery(task);
-  }, 3000);
+/**
+ * What the idle-check should do for a task. Pure (no timers/IO) so the
+ * completion-vs-recover-vs-wait decision is unit-testable:
+ * - `'wait'`     — not active; a forced-stop teardown (request_edit_mode /
+ *                  research-budget) is pending and deferred to turn-end; or not
+ *                  yet quiescent (some agent still active, or none spawned).
+ * - `'complete'` — quiescent and PM signalled completion (report_completion).
+ * - `'recover'`  — quiescent but nobody parked: an agent went idle without
+ *                  reporting (a dropped ball).
+ *
+ * Quiescence relies on agents being marked active at message *enqueue* (see
+ * Task.sendMessage / toolSendMessage), so "all idle" faithfully means "no work
+ * in flight." Shutdown is handled by the caller (it owns the process-global flag).
+ */
+export function idleDecision(
+  task: Pick<Task, 'isActive' | 'completionIntent' | 'agentProcesses'>,
+): 'wait' | 'complete' | 'recover' {
+  if (!task.isActive) return 'wait';
+  const agents = [...task.agentProcesses.values()];
+  // A pending teardown means a forced stop already called task.stop(), deferred
+  // to this turn's SDK `result` event. The Stop hook that arms this check fires
+  // *before* that event (gap can exceed the 3s delay), so without this guard the
+  // check would "recover" an agent that stop() then orphans mid-turn.
+  if (agents.some((a) => a.pendingTeardown)) return 'wait';
+  // Quiescent = at least one agent spawned and none active.
+  if (agents.length === 0) return 'wait';
+  if (agents.some((a) => a.session.active)) return 'wait';
+  return task.completionIntent ? 'complete' : 'recover';
 }
 
-/**
- * Check if all spawned agents are inactive.
- */
-function checkAllAgentsInactive(task: Task): boolean {
-  if (task.agentProcesses.size === 0) return false;
-
-  for (const [, agent] of task.agentProcesses) {
-    if (agent.session.active) return false;
-  }
-  return true;
+export function scheduleIdleCheck(task: Task): void {
+  setTimeout(async () => {
+    if (getIsShuttingDown()) return;
+    const action = idleDecision(task);
+    if (action === 'complete') {
+      await task.complete();
+    } else if (action === 'recover') {
+      await triggerRecovery(task);
+    }
+  }, 3000);
 }
 
 /**

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -81,6 +81,13 @@ export class Task {
   isActive: boolean = false;
   lastActivity: Date = new Date();
   recoveryAttempts: number = 0;
+  /**
+   * Set by report_completion: PM has responded and is waiting on no one but the
+   * user. The idle-check parks the task (instead of recovering) once all agents
+   * are idle. Cleared when PM next goes active (see updateAgentState). In-memory
+   * only — lost on restart, where recovery re-arms the lifecycle instead.
+   */
+  completionIntent: boolean = false;
   taskTimeoutTimer?: ReturnType<typeof setInterval>;
   /** Drives the "Archie is …" Slack loading indicator from agent activity. */
   private readonly statusController: TaskStatusController;
@@ -221,6 +228,11 @@ export class Task {
       throw new Error(`No agent ${agentName} after spawn`);
     }
     agent.queue.addMessage(message);
+    // Mark active synchronously at enqueue (not lazily at the SDK `init` re-fire,
+    // which lags). Keeps "all agents idle" a faithful proxy for "no work in
+    // flight" so the idle-check can't park a recipient that's about to process,
+    // and fires PM's intent-clear edge the moment work is delivered.
+    this.updateAgentState(agentName, true);
   }
 
   /**
@@ -812,21 +824,13 @@ export class Task {
   }
 
   /**
-   * Names of spawned agents currently mid-turn (active), excluding `exclude`.
-   *
-   * An agent can only emit inter-agent messages while its turn is running, and a
-   * turn is exactly the window in which `session.active` is true (the `inactive`
-   * marker fires from the Stop hook *after* the turn ends). So "any peer active"
-   * is a reliable signal that a delegated round-trip is still in flight — used by
-   * report_completion to refuse premature completion that would tear down a peer
-   * mid-work and orphan its reply.
+   * Record that PM has finished and is waiting on no one but the user (called by
+   * report_completion). The idle-check parks the task — instead of recovering —
+   * once all agents are idle (quiescent). Completion is thus decided at
+   * quiescence, not by a synchronous peer-active gate that races the Stop hook.
    */
-  activePeers(exclude: AgentName): AgentName[] {
-    const peers: AgentName[] = [];
-    for (const [name, agent] of this.agentProcesses) {
-      if (name !== exclude && agent.session.active) peers.push(name);
-    }
-    return peers;
+  setCompletionIntent(): void {
+    this.completionIntent = true;
   }
 
   /**
@@ -906,6 +910,10 @@ export class Task {
       throw new Error(`No agent ${target} after spawn`);
     }
     targetAgent.queue.addMessage(message, fromAgent);
+    // Mark active synchronously at enqueue (see sendMessage). A peer reporting to
+    // PM marks PM active here — so a parked-intent PM is never read as idle while
+    // its relay is in flight, and its intent-clear edge fires immediately.
+    this.updateAgentState(target, true);
 
     return `Message sent to ${target}. They will process it and log findings.`;
   }
@@ -1036,6 +1044,16 @@ export class Task {
     // Idempotency: skip if agent is already in the requested state (no sessionId update needed)
     if (agent && agent.session.active === active && !sessionId) return;
 
+    // Clear a pending completion intent when PM genuinely re-engages: its prior
+    // "waiting on no one" is stale, so the next quiescence should re-decide.
+    // Edge-exact: gate on the real inactive→active transition (agent.session.active
+    // is still the pre-update value here), NOT merely active===true — the SDK
+    // `init` re-fire passes a sessionId and bypasses the idempotency guard above,
+    // so a looser check would clear intent on every resumed turn.
+    if (active && name === 'pm-agent' && agent && !agent.session.active) {
+      this.completionIntent = false;
+    }
+
     if (agent) {
       agent.updateSession(active, sessionId);
       if (active) {
@@ -1079,6 +1097,11 @@ export class Task {
    */
   private activate(): void {
     this.isActive = true;
+    // A fresh activation (new task or reopen of a parked one) starts a new cycle —
+    // any completion intent from a prior cycle is stale. Clearing here covers
+    // reopens routed to a specialist (which don't pass through PM's active edge);
+    // the updateAgentState edge-clear covers mid-cycle PM re-engagement.
+    this.completionIntent = false;
     this.metadata.status = 'in_progress';
     activeTasks.set(this.taskId, this);
     this.startTaskTimeout();

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -705,9 +705,17 @@ export class Task {
     activeTasks.delete(this.taskId);
     this.clearTaskTimeout();
 
-    // Stop all queues — agent:inactive emitted by Stop hook / crash handler
+    // Stop all queues. A parked or just-finished agent (session inactive) exits
+    // gracefully on its next queue pull — the resume-safe path the deferred
+    // teardown relies on (see spawn.ts: never .return() the generator), so do
+    // NOT abort it. But an agent still mid-turn keeps generating and hits
+    // "Stream closed" on every tool/hook control request, looping until maxTurns
+    // — stopping its queue can't end it, so hard-abort those. agent:inactive is
+    // emitted by the Stop hook / crash handler (or the aborted loop exiting).
     for (const a of this.agentProcesses.values()) {
+      const midTurn = a.session.active;
       a.queue.stop();
+      if (midTurn) a.handle?.abort();
     }
 
     // Clean up clones to free disk space (only when not in edit mode)
@@ -738,9 +746,17 @@ export class Task {
     activeTasks.delete(this.taskId);
     this.clearTaskTimeout();
 
-    // Stop all queues — agent:inactive emitted by Stop hook / crash handler
+    // Stop all queues. A parked or just-finished agent (session inactive) exits
+    // gracefully on its next queue pull — the resume-safe path the deferred
+    // teardown relies on (see spawn.ts: never .return() the generator), so do
+    // NOT abort it. But an agent still mid-turn keeps generating and hits
+    // "Stream closed" on every tool/hook control request, looping until maxTurns
+    // — stopping its queue can't end it, so hard-abort those. agent:inactive is
+    // emitted by the Stop hook / crash handler (or the aborted loop exiting).
     for (const a of this.agentProcesses.values()) {
+      const midTurn = a.session.active;
       a.queue.stop();
+      if (midTurn) a.handle?.abort();
     }
 
     // Clean up clones to free disk space (only when not in edit mode).

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -72,6 +72,21 @@ export const activeTasks = new Map<string, Task>();
 
 // ---- Task class ----
 
+/**
+ * Whether an `updateAgentState` transition should clear a pending completion
+ * intent: PM genuinely re-engaging on a real inactive→active edge. Gating on the
+ * pre-update `wasActive` keeps it edge-exact — the SDK `init` re-fire arrives with
+ * the agent already active (the synchronous enqueue mark won the race), so it must
+ * not re-clear intent on every resumed turn. Pure, for unit testing.
+ */
+export function shouldClearCompletionIntent(
+  agentName: string,
+  active: boolean,
+  wasActive: boolean,
+): boolean {
+  return active && !wasActive && agentName === 'pm-agent';
+}
+
 export class Task {
   readonly taskId: string;
   metadata: TaskMetadata;
@@ -1046,11 +1061,9 @@ export class Task {
 
     // Clear a pending completion intent when PM genuinely re-engages: its prior
     // "waiting on no one" is stale, so the next quiescence should re-decide.
-    // Edge-exact: gate on the real inactive→active transition (agent.session.active
-    // is still the pre-update value here), NOT merely active===true — the SDK
-    // `init` re-fire passes a sessionId and bypasses the idempotency guard above,
-    // so a looser check would clear intent on every resumed turn.
-    if (active && name === 'pm-agent' && agent && !agent.session.active) {
+    // agent.session.active is still the pre-update value here (updateSession runs
+    // below), so this is edge-exact — see shouldClearCompletionIntent.
+    if (agent && shouldClearCompletionIntent(name, active, agent.session.active)) {
       this.completionIntent = false;
     }
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -67,6 +67,13 @@ export interface AgentHandle {
   running: Promise<void>;
   /** Whether the agent is still processing messages */
   isRunning: boolean;
+  /**
+   * Hard-abort the SDK subprocess (via its AbortController). Task teardown
+   * calls this after stopping the queue, to kill an agent that is mid-turn when
+   * its stream is closed — otherwise it loops on "Stream closed" control
+   * requests until maxTurns.
+   */
+  abort(): void;
 }
 
 /**


### PR DESCRIPTION
## Problem

Two production incidents on `task-20260627-1443-4vm4bv`, both rooted in `report_completion` being a **synchronous gate racing the agent lifecycle**:

- **Spurious recovery loop** — after the PM finished correctly, the idle-check fired recovery, which resurrected an agent that `task.complete()` then orphaned mid-turn → infinite `Error in hook callback hook_0` / `Stream closed` spam.
- **Flaky completion refusal** — `report_completion` refused because a peer's `session.active` was still `true` during its post-message wind-down (Stop hook lagged by ~0.4s); the PM dead-ended waiting for a report that had already arrived → recovery fired on a finished task.

Root cause: `session.active` conflates "genuinely working" with "winding down after its last message," so any synchronous peer-active gate is wrong somewhere.

## The model

**Completion is a quiescence condition, not an instantaneous gate.** `report_completion` stops being a gate:

- It posts the message, sets `task.completionIntent`, and ends the turn — **never refuses**.
- The idle-check, once every agent is idle (quiescent), **parks** the task if intent is set, else **recovers** (dropped ball). Completion and stall are the two outcomes of one "all agents idle" event.
- Agents are marked active **synchronously at message enqueue** (not lazily at the SDK `init` re-fire), so "all idle" faithfully means "no work in flight" — closes the live-idle gap that would otherwise let a park orphan an in-flight reply.
- Intent clears on PM's genuine re-engage edge and on `activate()`.

This deletes the racy `activePeers` refuse entirely; the protection is now structural (never tear down until actually quiet). Full rationale, scenario matrix, and 2-round design review: [docs/plans/20260627-completion-quiescence.md](../blob/fix/completion-quiescence/docs/plans/20260627-completion-quiescence.md).

## Stacking note

This branch builds on [#124](https://github.com/sweatco/archie-hq/pull/124) (recovery-teardown fixes), so this PR's diff currently includes those 2 commits (`231620b`, `3c7eaa4`). Once #124 merges, this collapses to its own 3 commits (design doc, implementation, tests). Review #124 first.

## Changes (this work)

- `tools.ts` — `report_completion`: no refuse, no deferred teardown → post + `setCompletionIntent()` + "end your turn" return.
- `recovery.ts` — idle-check restructured to `quiescent ? (intent ? complete : recover)`; extracted pure `idleDecision`; nudge routes through `updateAgentState`.
- `task.ts` — `completionIntent` field; enqueue-marks-active in both message paths; edge-exact intent-clear (`shouldClearCompletionIntent`); `activate()` clears intent; `activePeers` removed.
- `agent.ts` — spawn-failure guard (a failed spawn can't linger active and wedge quiescence).
- `pm-agent.md` — dropped the false "tool refuses" claim.

## Testing

- **Unit:** new [completion-quiescence.test.ts](../blob/fix/completion-quiescence/src/tasks/__tests__/completion-quiescence.test.ts) (idle decision × 4 outcomes + teardown-guard precedence + init-re-fire non-clear). Suite **475/475** green. (Local vitest also un-broken — stale `node_modules` reinstall; no lockfile change.)
- **Smoke (run, passing):** direct completion parks with no recovery; relay completion (incident-2 repro) no spurious recovery; Danger PR flow (incident-1 repro) no stream-closed loop; dropped-ball still recovers; edit-mode forced-stop still parks/resumes; reopen clears intent; no premature park while a peer works.
- Independent subagent review: ship-ready, no bugs/regressions; forced-stop teardown paths confirmed untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)