### PR TITLE
Make agent background-task waits work: re-engage, no spurious recovery, CLI visibility

### DIFF
--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -35,6 +35,16 @@ export class Agent {
   sandbox?: SandboxOptions;
 
   /**
+   * In-flight background task ids (SDK `task_started` → `task_notification`): a
+   * backgrounded Bash wait, a subagent, etc. The agent's turn can END while one
+   * is still running, so the idle-check treats an agent with non-empty
+   * backgroundTasks as *busy* (not stalled) — otherwise recovery fires under a
+   * legitimate wait. Drained on settle (the spawn loop re-engages the agent) and
+   * on subprocess exit (a dead process can't settle them).
+   */
+  readonly backgroundTasks: Set<string> = new Set();
+
+  /**
    * A task teardown (complete/stop) deferred until this agent's current turn
    * ends. The spawn loop runs it when it sees the SDK `result` event, so the
    * triggering tool's response and the Stop hook's control round-trip both

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -653,8 +653,10 @@ Shared folder: ${sharedPath} [READ-ONLY]
             // not stalled — no spurious recovery) and re-engage the agent on settle.
             if (event.type === 'system' && event.subtype === 'task_started') {
               agent.backgroundTasks.add(event.task_id);
+              logger.agent(def.id, `background task started — ${event.description}`);
             } else if (event.type === 'system' && event.subtype === 'task_notification') {
               agent.backgroundTasks.delete(event.task_id);
+              logger.agent(def.id, `background task ${event.status} — ${event.summary}`);
               if (!agent.queue.isStopped()) {
                 agent.queue.addMessage(
                   `Background task ${event.status}: ${event.summary}. ` +

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -41,6 +41,7 @@ import { setupSharedClone, cloneExists, type CloneCheckout } from '../connectors
 import { configureGitIdentity } from '../connectors/github/client.js';
 import { loadPrompt } from '../utils/prompt-loader.js';
 import { processAgentEventForLogging, logger } from '../system/logger.js';
+import { emitEvent } from '../system/event-bus.js';
 import { getProbeBaseUrl } from '../system/context-probe.js';
 import { buildSandboxConfig, createFilesystemGuardHooks, type SandboxOptions } from './sandbox.js';
 import { applyOAuthBindings } from '../system/oauth/inject.js';
@@ -654,9 +655,17 @@ Shared folder: ${sharedPath} [READ-ONLY]
             if (event.type === 'system' && event.subtype === 'task_started') {
               agent.backgroundTasks.add(event.task_id);
               logger.agent(def.id, `background task started — ${event.description}`);
+              // Chat/CLI: one transcript entry per task, keyed by task_id — rendered
+              // as ⏳ running, then folded to ✅/❌ when the matching 'end' arrives.
+              emitEvent('agent:bg_task', taskId, {
+                action: 'start', key: event.task_id, description: event.description,
+              }, def.id);
             } else if (event.type === 'system' && event.subtype === 'task_notification') {
               agent.backgroundTasks.delete(event.task_id);
               logger.agent(def.id, `background task ${event.status} — ${event.summary}`);
+              emitEvent('agent:bg_task', taskId, {
+                action: 'end', key: event.task_id, status: event.status, summary: event.summary,
+              }, def.id);
               if (!agent.queue.isStopped()) {
                 agent.queue.addMessage(
                   `Background task ${event.status}: ${event.summary}. ` +

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -645,6 +645,27 @@ Shared folder: ${sharedPath} [READ-ONLY]
                 }
               }
             }
+
+            // Background tasks: the SDK runs a backgrounded Bash wait / subagent
+            // out-of-band and emits task_started → task_notification. archie drives
+            // agents only through its own queue, so a settle wakes nothing on its
+            // own. Track in-flight tasks (so the idle-check treats the agent as busy,
+            // not stalled — no spurious recovery) and re-engage the agent on settle.
+            if (event.type === 'system' && event.subtype === 'task_started') {
+              agent.backgroundTasks.add(event.task_id);
+            } else if (event.type === 'system' && event.subtype === 'task_notification') {
+              agent.backgroundTasks.delete(event.task_id);
+              if (!agent.queue.isStopped()) {
+                agent.queue.addMessage(
+                  `Background task ${event.status}: ${event.summary}. ` +
+                  `Re-check what you were waiting on and continue — then report or end your turn.`,
+                );
+                // Enqueue-marks-active: keep the agent busy with no gap before the
+                // SDK starts the resumed turn, so the idle-check can't park it.
+                task.updateAgentState(def.id, true);
+              }
+            }
+
             processAgentEventForLogging(
               event,
               def.id,
@@ -704,6 +725,9 @@ Shared folder: ${sharedPath} [READ-ONLY]
       }
     } finally {
       handle.isRunning = false;
+      // A dead subprocess can't settle these — drain so they don't keep the agent
+      // "busy" forever and wedge the idle-check.
+      agent.backgroundTasks.clear();
       // Backstop for a deferred teardown that the `result` path above never got
       // to run — e.g. the agent crashed after report_completion/request_edit_mode
       // deferred it. Without this the flag stays set, and the idle-check's

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -16,7 +16,7 @@ export function App() {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
-  const [lastEvent, setLastEvent] = useState<any>(null);
+  const [liveEvents, setLiveEvents] = useState<any[]>([]);
   const disconnectRef = useRef<(() => void) | null>(null);
 
   const refresh = useCallback(() => {
@@ -30,9 +30,12 @@ export function App() {
       onEvent: (event) => {
         if (event.type === 'connected') return;
 
-        // For detail view: pass event directly to TaskDetail
+        // For detail view: queue the event for TaskDetail. Accumulate via a
+        // functional update — plain replace (setLastEvent(event)) collapses bursts
+        // under React batching, dropping events that arrive in the same tick (e.g.
+        // an inter-agent message immediately followed by agent:active).
         if (view === 'detail') {
-          setLastEvent(event);
+          setLiveEvents((prev) => [...prev, event]);
         }
 
         // For list view: refresh on task-level events
@@ -66,14 +69,14 @@ export function App() {
   });
 
   const handleSelectTask = (taskId: string) => {
-    setLastEvent(null);
+    setLiveEvents([]);
     setSelectedTaskId(taskId);
     setView('detail');
   };
 
   const handleBack = () => {
     setSelectedTaskId(null);
-    setLastEvent(null);
+    setLiveEvents([]);
     setView('list');
     refresh();
   };
@@ -85,7 +88,7 @@ export function App() {
   const handleCreateTask = async (message: string) => {
     try {
       const taskId = await createTask(message);
-      setLastEvent(null);
+      setLiveEvents([]);
       setSelectedTaskId(taskId);
       setView('detail');
     } catch {
@@ -118,7 +121,7 @@ export function App() {
           <TaskDetail
             taskId={selectedTaskId}
             onBack={handleBack}
-            onEvent={lastEvent}
+            liveEvents={liveEvents}
             onConnect={connected}
           />
         )}

--- a/src/cli/components/TaskDetail.tsx
+++ b/src/cli/components/TaskDetail.tsx
@@ -45,7 +45,9 @@ interface SystemEvent {
 interface TaskDetailProps {
   taskId: string;
   onBack: () => void;
-  onEvent?: SystemEvent | null;
+  /** Append-only queue of live SSE events from the parent (accumulated so bursts
+   *  aren't lost to React batching). TaskDetail processes the delta each render. */
+  liveEvents?: SystemEvent[];
   onConnect?: boolean;
 }
 
@@ -61,7 +63,7 @@ function isApprovalResolved(req: SystemEvent, allEvents: SystemEvent[]): boolean
   );
 }
 
-export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailProps) {
+export function TaskDetail({ taskId, onBack, liveEvents, onConnect }: TaskDetailProps) {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const termHeight = stdout?.rows ?? 24;
@@ -78,7 +80,7 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
   const [liveStatus, setLiveStatus] = useState<string>('');
   const [reminder, setReminder] = useState<{ trigger_at: string; reason: string } | null>(null);
   const [title, setTitle] = useState<string | null>(null);
-  const prevOnEvent = useRef<SystemEvent | null>(null);
+  const processedRef = useRef(0); // count of liveEvents already applied
   const prevOnConnect = useRef<boolean | undefined>(undefined);
   const scrollRef = useRef<ScrollViewRef>(null);
   const autoScroll = useRef(true); // stick to bottom unless user scrolls up
@@ -218,52 +220,58 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
     loadInitial();
   }, [loadInitial]);
 
-  // Handle SSE events from parent
+  // Handle live SSE events from parent. `liveEvents` is an append-only queue, so
+  // process only the delta since the last render and apply each event in order —
+  // nothing is dropped when several arrive in the same tick.
   useEffect(() => {
-    if (onEvent && onEvent !== prevOnEvent.current) {
-      prevOnEvent.current = onEvent;
+    const queue = liveEvents ?? [];
+    // Buffer was reset (task switch / fresh connect) — start from the top.
+    if (processedRef.current > queue.length) processedRef.current = 0;
+    const fresh = queue.slice(processedRef.current);
+    if (fresh.length === 0) return;
+    processedRef.current = queue.length;
 
-      // Live status is transient UI, not a log entry — update and stop here so
-      // it never lands in the scrollback.
-      if (onEvent.type === 'status') {
-        setLiveStatus((onEvent.data?.status as string) || '');
-        return;
+    for (const ev of fresh) {
+      // Live status is transient UI, not a log entry — never lands in scrollback.
+      if (ev.type === 'status') {
+        setLiveStatus((ev.data?.status as string) || '');
+        continue;
       }
 
-      setEvents((prev) => [...prev, onEvent]);
+      setEvents((prev) => [...prev, ev]);
       setEventCursor((c) => c + 1);
 
       // Update agents bar from agent events
-      if (onEvent.type === 'agent:active' || onEvent.type === 'agent:inactive') {
+      if (ev.type === 'agent:active' || ev.type === 'agent:inactive') {
         setAgents((prev) => {
-          const existing = prev.find((a) => a.agent === onEvent.agentName);
-          const active = onEvent.type === 'agent:active';
+          const existing = prev.find((a) => a.agent === ev.agentName);
+          const active = ev.type === 'agent:active';
           if (existing) {
-            return prev.map((a) => a.agent === onEvent.agentName ? { ...a, active } : a);
+            return prev.map((a) => a.agent === ev.agentName ? { ...a, active } : a);
           }
-          return [...prev, { agent: onEvent.agentName!, active }];
+          return [...prev, { agent: ev.agentName!, active }];
         });
       }
 
       // Update status from task events
-      if (onEvent.type === 'task:resumed') setStatus('in_progress');
-      if (onEvent.type === 'task:completed') { setStatus('completed'); setLiveStatus(''); }
-      if (onEvent.type === 'task:stopped') { setStatus('stopped'); setLiveStatus(''); }
+      if (ev.type === 'task:resumed') setStatus('in_progress');
+      if (ev.type === 'task:completed') { setStatus('completed'); setLiveStatus(''); }
+      if (ev.type === 'task:stopped') { setStatus('stopped'); setLiveStatus(''); }
 
       // Update reminder from reminder events
-      if (onEvent.type === 'reminder:set') {
-        setReminder({ trigger_at: onEvent.data.trigger_at as string, reason: onEvent.data.reason as string });
+      if (ev.type === 'reminder:set') {
+        setReminder({ trigger_at: ev.data.trigger_at as string, reason: ev.data.reason as string });
       }
-      if (onEvent.type === 'reminder:cancelled' || onEvent.type === 'reminder:fired') {
+      if (ev.type === 'reminder:cancelled' || ev.type === 'reminder:fired') {
         setReminder(null);
       }
-
-      // Auto-scroll to bottom when new events arrive (if user hasn't scrolled up)
-      if (autoScroll.current) {
-        setTimeout(() => scrollRef.current?.scrollToBottom(), 0);
-      }
     }
-  }, [onEvent]);
+
+    // Auto-scroll to bottom when new events arrive (if user hasn't scrolled up)
+    if (autoScroll.current) {
+      setTimeout(() => scrollRef.current?.scrollToBottom(), 0);
+    }
+  }, [liveEvents]);
 
   // Handle reconnect — fetch missed events
   useEffect(() => {

--- a/src/cli/components/TaskDetail.tsx
+++ b/src/cli/components/TaskDetail.tsx
@@ -105,6 +105,28 @@ export function TaskDetail({ taskId, onBack, onEvent, onConnect }: TaskDetailPro
             node: <Text dimColor>[{event.agentName}] {event.data.finding as string}</Text>,
           });
           break;
+        case 'agent:bg_task': {
+          // One entry per background task, keyed by task_id: render the 'start' as
+          // ⏳ running, and once the matching 'end' has arrived (events is rebuilt on
+          // every update) fold it into ✅/❌. Skip the 'end' itself.
+          if (event.data.action !== 'start') break;
+          const key = event.data.key as string;
+          const ended = events.find(
+            (e) => e.type === 'agent:bg_task' && e.data.action === 'end' && e.data.key === key,
+          );
+          const desc = (event.data.description as string) || 'background task';
+          if (ended) {
+            const status = ended.data.status as string;
+            logLines.push({
+              node: <Text dimColor>{status === 'completed' ? '✅' : '❌'} [{event.agentName}] background task {status} — {desc}</Text>,
+            });
+          } else {
+            logLines.push({
+              node: <Text color="yellow">⏳ [{event.agentName}] background task running — {desc}</Text>,
+            });
+          }
+          break;
+        }
         case 'approval:requested': {
           const resolved = isApprovalResolved(event, events);
           if (resolved) {

--- a/src/system/event-bus.ts
+++ b/src/system/event-bus.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from 'events';
 export type EventType =
   | 'task:created' | 'task:resumed' | 'task:stopped' | 'task:completed'
   | 'agent:active' | 'agent:inactive'
-  | 'message' | 'agent:log'
+  | 'message' | 'agent:log' | 'agent:bg_task'
   | 'status'
   | 'approval:requested' | 'approval:resolved'
   | 'reminder:set' | 'reminder:cancelled' | 'reminder:fired';

--- a/src/tasks/__tests__/completion-quiescence.test.ts
+++ b/src/tasks/__tests__/completion-quiescence.test.ts
@@ -19,11 +19,12 @@ import { shouldClearCompletionIntent } from '../task.js';
 import type { Task } from '../task.js';
 import type { Agent } from '../../agents/agent.js';
 
-/** Minimal agent stand-in — idleDecision only reads `pendingTeardown` + `session.active`. */
-function fakeAgent(opts: { active?: boolean; pendingTeardown?: boolean } = {}): Agent {
+/** Minimal agent stand-in — idleDecision reads `pendingTeardown`, `session.active`, `backgroundTasks`. */
+function fakeAgent(opts: { active?: boolean; pendingTeardown?: boolean; bgTasks?: string[] } = {}): Agent {
   return {
     pendingTeardown: opts.pendingTeardown ? () => Promise.resolve() : undefined,
     session: { active: opts.active ?? false },
+    backgroundTasks: new Set<string>(opts.bgTasks ?? []),
   } as unknown as Agent;
 }
 
@@ -59,6 +60,14 @@ describe('idleDecision', () => {
   it('waits when any agent is still active (work in flight)', () => {
     expect(
       idleDecision(fakeTask({ completionIntent: true, agents: [fakeAgent({ active: true }), fakeAgent()] })),
+    ).toBe('wait');
+  });
+
+  it('waits when an agent has an in-flight background task (busy, not stalled)', () => {
+    // Turn ended (session inactive) but a backgrounded wait is pending — must not
+    // park or recover under it, even with completion intent set.
+    expect(
+      idleDecision(fakeTask({ completionIntent: true, agents: [fakeAgent({ bgTasks: ['t1'] })] })),
     ).toBe('wait');
   });
 

--- a/src/tasks/recovery.ts
+++ b/src/tasks/recovery.ts
@@ -78,8 +78,8 @@ async function recoverTaskAgents(task: Task): Promise<void> {
  * What the idle-check should do for a task. Pure (no timers/IO) so the
  * completion-vs-recover-vs-wait decision is unit-testable:
  * - `'wait'`     — not active; a forced-stop teardown (request_edit_mode /
- *                  research-budget) is pending and deferred to turn-end; or not
- *                  yet quiescent (some agent still active, or none spawned).
+ *                  research-budget) is pending; or not yet quiescent (an agent is
+ *                  active, has an in-flight background task, or none are spawned).
  * - `'complete'` — quiescent and PM signalled completion (report_completion).
  * - `'recover'`  — quiescent but nobody parked: an agent went idle without
  *                  reporting (a dropped ball).
@@ -98,9 +98,12 @@ export function idleDecision(
   // *before* that event (gap can exceed the 3s delay), so without this guard the
   // check would "recover" an agent that stop() then orphans mid-turn.
   if (agents.some((a) => a.pendingTeardown)) return 'wait';
-  // Quiescent = at least one agent spawned and none active.
+  // Quiescent = at least one agent spawned and none busy. An agent is busy if its
+  // turn is active OR it has an in-flight background task (a backgrounded wait /
+  // subagent the SDK will settle later) — without the latter, recovery would fire
+  // under a legitimate wait, since the agent's turn ends while the task runs.
   if (agents.length === 0) return 'wait';
-  if (agents.some((a) => a.session.active)) return 'wait';
+  if (agents.some((a) => a.session.active || a.backgroundTasks.size > 0)) return 'wait';
   return task.completionIntent ? 'complete' : 'recover';
 }
 

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -1056,6 +1056,13 @@ export class Task {
     const name = agentName as AgentName;
     const agent = this.agentProcesses.get(name);
 
+    // An agent with in-flight background work is still "busy": keep it shown as
+    // active (status indicator + agent:active state) and don't arm the idle-check
+    // when its turn ends. It flips inactive once the task settles and the resumed
+    // turn finishes (backgroundTasks drained), or on subprocess exit (the spawn
+    // loop's finally drains them first, so the exit still marks it inactive).
+    if (!active && agent && agent.backgroundTasks.size > 0) return;
+
     // Idempotency: skip if agent is already in the requested state (no sessionId update needed)
     if (agent && agent.session.active === active && !sessionId) return;
 

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -1056,12 +1056,10 @@ export class Task {
     const name = agentName as AgentName;
     const agent = this.agentProcesses.get(name);
 
-    // An agent with in-flight background work is still "busy": keep it shown as
-    // active (status indicator + agent:active state) and don't arm the idle-check
-    // when its turn ends. It flips inactive once the task settles and the resumed
-    // turn finishes (backgroundTasks drained), or on subprocess exit (the spawn
-    // loop's finally drains them first, so the exit still marks it inactive).
-    if (!active && agent && agent.backgroundTasks.size > 0) return;
+    // Note: an agent parked on a background task is allowed to go idle here — it
+    // isn't actively working, so we don't fake it as active. Recovery is still
+    // held off while a task is pending via idleDecision's backgroundTasks check;
+    // the ⏳ background-task entry is the in-progress indication.
 
     // Idempotency: skip if agent is already in the requested state (no sessionId update needed)
     if (agent && agent.session.active === active && !sessionId) return;


### PR DESCRIPTION
## Problem

A repo agent backgrounds a wait (`Bash` with `run_in_background`, e.g. `sleep`/CI poll) and ends its turn expecting to be re-invoked when it settles. Interactive Claude Code's REPL does that on `task_notification`; **archie doesn't** — agents are driven solely by their MessageQueue and only reacted to `system:init`/`result`, discarding the task events. So the settled task woke nothing: the agent stalled, and recovery fired *during* the wait (all agents looked idle), escalating toward a nuclear restart.

## Fix

**Re-engagement + recovery**
- Track in-flight background tasks per agent (`Agent.backgroundTasks`): added on SDK `task_started`, drained on `task_notification` and on subprocess exit.
- On settle, enqueue a wake message so the agent resumes and re-checks — archie supplies the re-invocation the SDK expects the harness to provide.
- `idleDecision` treats an agent with in-flight background tasks as **busy**, so recovery/quiescence holds off during a legitimate wait.
- ✅ **Confirmed live**: the SDK *does* emit `task_started`/`task_notification` on the streaming output in archie's headless setup; auto-resume works with no recovery during the wait.

**Visibility**
- New `agent:bg_task` event → the CLI renders **one entry per task**, ⏳ running folded to ✅/❌ on settle (transcript re-derives on each event). Server logs gain per-agent start/settle lines.
- The agent is shown **idle** during the wait — it isn't actively working; the ⏳ entry is the accurate "in progress" signal (we briefly faked "active", then reverted it as misleading + redundant).

**CLI event-drop fix (general, surfaced here)**
- The CLI fed live SSE events to `TaskDetail` one at a time via a single prop (replace semantics), so a burst collapsed under React batching — an inter-agent message immediately followed by `agent:active` in the same millisecond was silently dropped from the transcript (a `mobile→pm` report vanished from the CLI while present in logs + events.jsonl). App now accumulates events in an **append-only queue**; `TaskDetail` processes the delta. Fixes any event burst, not just background tasks.

## Files
- `src/agents/agent.ts`, `src/agents/spawn.ts`, `src/tasks/recovery.ts` — tracking, re-engage on settle, busy-aware `idleDecision`, server log lines
- `src/system/event-bus.ts`, `src/cli/components/TaskDetail.tsx`, `src/cli/App.tsx` — `agent:bg_task` ⏳→✅ entry + event-queue fix

## Testing
- Unit: `idleDecision` busy-on-background-task case. **476/476** green, typecheck clean.
- Smoke (confirmed): background a `sleep` → no `[recovery]` during the wait, agent auto-resumes on completion, ⏳→✅ entry in the CLI, agent shows idle during the wait, and the inter-agent completion message renders (no longer dropped).

Builds on the completion-as-quiescence model (#125, merged) — same recovery/quiescence path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)