### PR TITLE
Diagnose bot-authored commits + swap Claude trailer for Archie

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -40,7 +40,7 @@ import {
   createRecoverableInputGenerator,
 } from './message-queue.js';
 import { setupSharedClone, cloneExists, type CloneCheckout } from '../connectors/github/repo-clone.js';
-import { configureGitIdentity } from '../connectors/github/client.js';
+import { configureGitIdentity, getGitHubAppIdentity } from '../connectors/github/client.js';
 import { buildChannelCanvasPromptSection } from '../connectors/slack/channel-canvas.js';
 import { loadPrompt } from '../utils/prompt-loader.js';
 import { processAgentEventForLogging, logger } from '../system/logger.js';
@@ -140,13 +140,27 @@ async function setupAgentWorkspace(taskId: string, agent: Agent): Promise<string
     }
   }
 
-  // Write .claude/settings.json with plugin hooks (picked up by SDK via settingSources)
-  if (agent.def.pluginHooks) {
-    const settingsPath = join(claudeDir, 'settings.json');
-    const settings = { hooks: agent.def.pluginHooks };
-    await writeFile(settingsPath, JSON.stringify(settings, null, 2));
-    logger.agent(agent.def.id, `Mounted plugin hooks to ${settingsPath}`);
-  }
+  // Write .claude/settings.json (picked up by the SDK via settingSources: ['project']).
+  //
+  // attribution.commit replaces Claude Code's default commit trailer: we swap the
+  // harness-default "Co-Authored-By: Claude <model>" line for Archie (the GitHub
+  // App bot) so commits credit Archie as co-author, not the model. sessionUrl:false
+  // drops the Claude-Session trailer too. When the bot identity isn't configured
+  // the empty string simply hides the trailer. Plugin hooks are merged in when set.
+  const settingsPath = join(claudeDir, 'settings.json');
+  const archie = getGitHubAppIdentity();
+  const settings: Record<string, unknown> = {
+    attribution: {
+      commit: archie ? `Co-Authored-By: ${archie.name} <${archie.email}>` : '',
+      sessionUrl: false,
+    },
+  };
+  if (agent.def.pluginHooks) settings.hooks = agent.def.pluginHooks;
+  await writeFile(settingsPath, JSON.stringify(settings, null, 2));
+  logger.agent(
+    agent.def.id,
+    `Wrote agent settings.json (attribution${agent.def.pluginHooks ? ' + plugin hooks' : ''})`,
+  );
 
   return agentWorkspace;
 }
@@ -535,6 +549,19 @@ Shared folder: ${sharedPath} [READ-ONLY]
   // GIT_AUTHOR_* so repo-agent commits are authored by the human who approved
   // edit mode (the committer stays the GitHub App bot). See buildCommitAuthorEnv.
   const commitAuthorEnv = buildCommitAuthorEnv(def, metadata);
+
+  // Diagnostic: surface whether the human author is actually being applied. If a
+  // repo agent commits as the bot, this line distinguishes "approver was never
+  // captured" (edit_approved_by=NONE) from "captured but env didn't take effect".
+  if (isRepoAgent(def)) {
+    const ea = metadata.edit_approved_by;
+    logger.agent(
+      def.id,
+      `Commit author: edit_approved_by=${ea ? `${ea.name} <${ea.email ?? 'no-email'}>` : 'NONE'}; ` +
+        `GIT_AUTHOR ${'GIT_AUTHOR_NAME' in commitAuthorEnv ? 'injected' : 'absent → bot authors'}`,
+      { editMode: metadata.edit_allowed === true },
+    );
+  }
 
   const buildQueryOptions = (sessionId?: string) => ({
     model: model as any,

--- a/src/connectors/github/client.ts
+++ b/src/connectors/github/client.ts
@@ -1205,7 +1205,7 @@ export function createGitHubClient(): GitHubClient | null {
 /**
  * Get GitHub App bot identity for git commits
  */
-function getGitHubAppIdentity(): { name: string; email: string } | null {
+export function getGitHubAppIdentity(): { name: string; email: string } | null {
   const appId = process.env.GITHUB_APP_ID;
   const appSlug = process.env.GITHUB_APP_SLUG;
 


### PR DESCRIPTION
Follow-up to #129 (commit authorship). After deploy, edit-mode commits showed `archie-hq[bot]` as the **author** (not the human approver), with a `Co-Authored-By: Claude` trailer. This branch fixes the trailer and adds a diagnostic to pin down the author issue.

## Changes

- **Swap the Claude trailer for Archie** (`src/agents/spawn.ts`): each agent's `.claude/settings.json` now sets `attribution.commit` to Archie's (the GitHub App bot) co-author line and `sessionUrl: false`. This replaces Claude Code's default `Co-Authored-By: Claude <model>` trailer — deterministically, with no reliance on the agent. `getGitHubAppIdentity()` is exported (`src/connectors/github/client.ts`) to build the line.
- **Author diagnostic** (`src/agents/spawn.ts`): logs one line per repo-agent spawn —
  `Commit author: edit_approved_by=<name|NONE>; GIT_AUTHOR injected|absent` — so we can tell whether the approver was captured (`NONE` = capture failed) vs captured-but-not-applied, without guessing.

## Why

After #129 merged, a production edit-mode commit was authored by the bot instead of the approver. Static review of the post-merge code doesn't reveal a logic regression on the happy path (internal user + Slack approval + single approval), which points at either a subtle capture failure or a deploy/build mismatch. Running this branch and approving an edit-mode task surfaces the diagnostic line, which says definitively which it is.

## Verification
- `npm run typecheck` — clean
- `npx vitest run` — 512 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GknyFMfRSGrfGAW9R1yBVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GknyFMfRSGrfGAW9R1yBVh)_