### PR TITLE
fix(docker): use curl for dev container healthcheck (wget not in image)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,10 +7,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Install git, ssh (for git fetch over ssh), git-lfs, bash (required by Claude CLI),
 # bubblewrap + socat (sandbox runtime), gosu (entrypoint privilege drop),
-# python3 + pip (for agent scripts)
+# curl (container healthcheck), python3 + pip (for agent scripts)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git openssh-client git-lfs bash bubblewrap socat gosu ca-certificates \
+      git openssh-client git-lfs bash bubblewrap socat gosu ca-certificates curl \
       python3 python3-pip python3-venv && \
     git lfs install && \
     mkdir -p ~/.ssh && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - /app/node_modules
 
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:${PORT:-3000}/health || exit 1"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:${PORT:-3000}/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Problem

The dev `docker-compose` healthcheck runs `wget --no-verbose --tries=1 --spider …`, but the dev image (`node:24-trixie-slim`) ships **neither `wget` nor `curl`**. Every probe failed with `wget: not found`, so the container was permanently reported **`unhealthy`** even though the app serves `200` on `/health`.

## Fix

- Install `curl` in `Dockerfile.dev`.
- Switch the healthcheck to the standard `curl -fsS http://localhost:${PORT}/health`. `-f` makes curl exit non-zero on any HTTP ≥ 400, and a refused connection exits 7 — so anything but a `200` correctly marks the container unhealthy.

## Verification

Rebuilt the dev image and recreated the container:

- `curl 8.14.1` present in the image
- healthcheck command returns `{"status":"ok","activeTasks":0}` (exit 0)
- `docker inspect` → `healthy` (failing streak 0)
- `docker compose ps` → `Up … (healthy)`

Scope: dev only. `Dockerfile.prod` defines no `HEALTHCHECK` (prod relies on external probes), so it's left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbFPBmuTcZkQxZ6pYVDAdj