### PR TITLE
Fix archie-debug MCP port resolution

### DIFF
--- a/tools/debug-mcp/server.ts
+++ b/tools/debug-mcp/server.ts
@@ -4,15 +4,50 @@
  * Standalone stdio MCP server. No imports from src/.
  * Ejectable: copy tools/debug-mcp/ anywhere, install deps, run.
  *
- * Config: ARCHIE_URL env var (default: http://localhost:3000)
+ * Target Archie URL resolution:
+ *   1. ARCHIE_URL      — explicit override (e.g. a remote host)
+ *   2. PORT env var    — http://localhost:$PORT
+ *   3. PORT from .env  — the same file the server reads its PORT from
+ *   4. http://localhost:3000
  */
 
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { ArchieClient } from './archie-client.js';
 
-const client = new ArchieClient(process.env.ARCHIE_URL || 'http://localhost:3000');
+/** Read PORT from a .env file without pulling in a dotenv dependency. */
+function portFromEnvFile(): string | undefined {
+  const candidates = [
+    join(process.cwd(), '.env'),
+    join(dirname(fileURLToPath(import.meta.url)), '..', '..', '.env'), // repo root from tools/debug-mcp/
+  ];
+  for (const path of candidates) {
+    try {
+      // Capture the value only — stop at whitespace, a quote, or an inline `#`
+      const m = readFileSync(path, 'utf-8').match(/^\s*PORT\s*=\s*["']?([^\s"'#]+)/m);
+      if (m) return m[1];
+    } catch {
+      // file absent — try the next candidate
+    }
+  }
+  return undefined;
+}
+
+/** Resolve the Archie base URL (see precedence in the file header). */
+function resolveArchieUrl(): string {
+  if (process.env.ARCHIE_URL) return process.env.ARCHIE_URL;
+  const port = process.env.PORT || portFromEnvFile() || '3000';
+  return `http://localhost:${port}`;
+}
+
+const archieUrl = resolveArchieUrl();
+// stderr only — stdout carries the MCP protocol and must not be polluted.
+console.error(`[archie-debug] targeting ${archieUrl}`);
+const client = new ArchieClient(archieUrl);
 const server = new McpServer({
   name: 'archie-debug',
   version: '1.0.0',


### PR DESCRIPTION
## Problem

The `archie-debug` MCP (`tools/debug-mcp/server.ts`) hardcoded `http://localhost:3000`. It's launched from `.mcp.json` with no `ARCHIE_URL`/`PORT` in its environment, so whenever Archie runs on a non-default port — `PORT` from `.env`, or `npm run docker:dev` mapping a different host port — every debug call fails with `fetch failed`.

## Fix

Resolve the target URL instead of hardcoding it:

1. `ARCHIE_URL` — explicit override (e.g. a remote host)
2. `PORT` env var → `http://localhost:$PORT`
3. `PORT` read from the repo `.env` — the same file the server reads its port from
4. `http://localhost:3000`

Self-contained — node builtins only, no `dotenv` dependency, so the tool stays ejectable. The resolved URL is logged to **stderr** (stdout carries the MCP protocol and must not be polluted).

## Test

- `esbuild` transpile of the edited file: OK.
- Resolver verified against a real `.env` with `PORT=3457` → resolves `http://localhost:3457`; the `ARCHIE_URL` and `PORT` env overrides are both honored.

> Note: MCP servers load at session start, so a running `archie-debug` instance must be reconnected for this to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkeEzyzYj3MmX2veh7WxCB
