### PR TITLE
Discoverability & first-impression polish: README, community-health files, changelog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report something that isn't working as expected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill out the sections below so we can reproduce and fix the issue quickly.
+
+        > **Security issues:** do not file them here. Follow the private process in [SECURITY.md](https://github.com/sweatco/archie-hq/blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug, including what you expected to happen instead.
+      placeholder: When I run `npm run cli` and ask the PM to…, it…
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Clone and `npm install`
+        2. `npm run example:setup`
+        3. `npm run dev` then `npm run cli`
+        4. Send "…"
+        5. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste any relevant log output. This will be rendered as code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: How are you running Archie?
+      placeholder: |
+        - OS: macOS 15.3 / Ubuntu 24.04
+        - Node.js: 20.x
+        - Run mode: npm run dev / docker:dev
+        - Commit or version: e.g. v0.1.0 or git SHA
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go through SECURITY.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/sweatco/archie-hq/security/advisories/new
+    about: Please report security issues privately through GitHub Security Advisories, not as a public issue. See SECURITY.md.
+  - name: Question or idea
+    url: https://github.com/sweatco/archie-hq/blob/main/CONTRIBUTING.md
+    about: For setup help and how to contribute, start with the contributing guide.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest an idea or enhancement for Archie HQ
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! For new domain behavior (agents, skills, workflows), note that this usually belongs in a **plugin** rather than the engine — see [CONTRIBUTING.md](https://github.com/sweatco/archie-hq/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point. What are you trying to do that's hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen? Describe the behavior or API you have in mind.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or other approaches you've thought about.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the system does this touch?
+      options:
+        - Engine (orchestration / agent runtime / integrations)
+        - Plugin system
+        - CLI
+        - Slack integration
+        - GitHub integration
+        - Security / sandbox
+        - Docs
+        - Other / not sure
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
-Nothing here is mandatory — it's a starting point. Delete any section that
-doesn't apply. Keep PRs focused: one logical change per PR (see CONTRIBUTING.md).
-Tick only what you actually ran; note anything you couldn't (e.g. no API key).
+Keep PRs focused — one logical change per PR. Nothing below is mandatory:
+delete what doesn't apply, and tick only what you actually verified.
+Setup and commands live in README.md / CONTRIBUTING.md.
 -->
 
 ## What & why
@@ -10,8 +10,7 @@ Tick only what you actually ran; note anything you couldn't (e.g. no API key).
 
 ## Checklist
 
-- [ ] `npm run typecheck`, `npm run build`, and `npm test` pass
-- [ ] **Smoke test:** app boots (`npm run example:setup` then `npm run dev`) and a CLI request round-trips through the PM to an agent and back
-- [ ] Exercised the path this change touches (Slack / edit mode / sandbox / plugins / memory), or noted why not
-- [ ] New source files carry the SPDX header (`// SPDX-License-Identifier: AGPL-3.0-or-later`)
-- [ ] Docs updated if behavior or setup changed
+- [ ] Static checks pass locally — typecheck, build, and tests
+- [ ] Smoke-tested the running app: it boots cleanly and a real request flows end to end (request → PM → agent → response)
+- [ ] Verified the behavior this change actually affects, or noted what you couldn't check and why
+- [ ] Followed project conventions (SPDX header on new files; docs updated when behavior or setup changes)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+Thanks for contributing to Archie HQ! Please fill out the sections below.
+Keep PRs focused — one logical change per PR makes review faster (see CONTRIBUTING.md).
+-->
+
+## What does this PR do?
+
+<!-- A clear description of the change and the motivation behind it. -->
+
+## Related issues
+
+<!-- e.g. "Closes #123" or "Part of #456". Delete if none. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / internal change
+- [ ] Documentation
+- [ ] Build / CI / tooling
+
+## Checklist
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm run build` passes
+- [ ] `npm test` passes
+- [ ] New source files include the SPDX header (`// SPDX-License-Identifier: AGPL-3.0-or-later`)
+- [ ] All output goes through the unified logger (`src/system/logger.ts`), not `console.*`
+- [ ] Docs updated if behavior or setup changed
+- [ ] No secrets, tokens, or `.env` values committed
+
+## Notes for reviewers
+
+<!-- Anything specific you'd like reviewers to focus on, or context that helps the review. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,14 @@
 <!--
-Thanks for contributing to Archie HQ! Please fill out the sections below.
-Keep PRs focused — one logical change per PR makes review faster (see CONTRIBUTING.md).
+Nothing here is mandatory — it's a starting point. Delete any section that
+doesn't apply. Keep PRs focused: one logical change per PR (see CONTRIBUTING.md).
 -->
 
-## What does this PR do?
+## What & why
 
-<!-- A clear description of the change and the motivation behind it. -->
-
-## Related issues
-
-<!-- e.g. "Closes #123" or "Part of #456". Delete if none. -->
-
-## Type of change
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Refactor / internal change
-- [ ] Documentation
-- [ ] Build / CI / tooling
+<!-- What changed and the motivation. Link issues with "Closes #123" if relevant. -->
 
 ## Checklist
 
-- [ ] `npm run typecheck` passes
-- [ ] `npm run build` passes
-- [ ] `npm test` passes
-- [ ] New source files include the SPDX header (`// SPDX-License-Identifier: AGPL-3.0-or-later`)
-- [ ] All output goes through the unified logger (`src/system/logger.ts`), not `console.*`
+- [ ] `npm run typecheck`, `npm run build`, and `npm test` pass
+- [ ] New source files carry the SPDX header (`// SPDX-License-Identifier: AGPL-3.0-or-later`)
 - [ ] Docs updated if behavior or setup changed
-- [ ] No secrets, tokens, or `.env` values committed
-
-## Notes for reviewers
-
-<!-- Anything specific you'd like reviewers to focus on, or context that helps the review. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,29 @@
 <!--
-Keep PRs focused — one logical change per PR. Nothing below is mandatory:
-delete what doesn't apply, and tick only what you actually verified.
-Setup and commands live in README.md / CONTRIBUTING.md.
+Keep PRs focused — one logical change per PR (see CONTRIBUTING.md).
+Write for a reviewer who hasn't seen the work: explain the problem before the
+change. These headings are prompts, not a form — fill what applies, delete the
+rest. Setup and commands live in README.md / CONTRIBUTING.md.
 -->
 
 ## What & why
 
-<!-- What changed and the motivation. Link issues with "Closes #123" if relevant. -->
+<!-- Lead with the problem or motivation, then what this change does about it.
+     Link related work inline if relevant ("Closes #123", "Builds on #120"). -->
 
-## Checklist
+## How it works
 
-- [ ] Static checks pass locally — typecheck, build, and tests
-- [ ] Smoke-tested the running app: it boots cleanly and a real request flows end to end (request → PM → agent → response)
-- [ ] Verified the behavior this change actually affects, or noted what you couldn't check and why
-- [ ] Followed project conventions (SPDX header on new files; docs updated when behavior or setup changes)
+<!-- The approach and the key decisions a reviewer needs to follow the diff —
+     and anything subtle or surprising. No file-by-file list; the diff shows
+     that. Note what you deliberately left out of scope. -->
+
+## Verification
+
+<!-- What you actually checked, honestly. The static checks (typecheck, build,
+     tests) and — the part CI can't see — that the running app still works end
+     to end for the path you touched. If you couldn't run something (no API key,
+     no integration access), say so plainly rather than implying it passed. -->
+
+<!-- ## Deployment & follow-ups (optional)
+     Anything an operator must do before/after merge (redeploy, re-import the
+     Slack manifest, grant a scope, run a migration), plus known non-blocking
+     follow-ups. Delete this section if there's nothing to flag. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!--
 Nothing here is mandatory — it's a starting point. Delete any section that
 doesn't apply. Keep PRs focused: one logical change per PR (see CONTRIBUTING.md).
+Tick only what you actually ran; note anything you couldn't (e.g. no API key).
 -->
 
 ## What & why
@@ -10,5 +11,7 @@ doesn't apply. Keep PRs focused: one logical change per PR (see CONTRIBUTING.md)
 ## Checklist
 
 - [ ] `npm run typecheck`, `npm run build`, and `npm test` pass
+- [ ] **Smoke test:** app boots (`npm run example:setup` then `npm run dev`) and a CLI request round-trips through the PM to an agent and back
+- [ ] Exercised the path this change touches (Slack / edit mode / sandbox / plugins / memory), or noted why not
 - [ ] New source files carry the SPDX header (`// SPDX-License-Identifier: AGPL-3.0-or-later`)
 - [ ] Docs updated if behavior or setup changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,92 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to Archie HQ are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Archie ships **continuously** — every merge to `main` builds a fresh Docker
+image, and `SECURITY.md` asks operators to track `main`. We therefore keep a
+**date-based** changelog rather than cutting formal versioned releases: notable
+changes are grouped under the date they landed. (If we later tag versions, a
+dated heading like `## 2026-06-29` simply becomes `## [0.1.0] - 2026-06-29`.)
 
 ## [Unreleased]
 
-These changes are staged for the first tagged release (`v0.1.0`). When cutting
-the release, rename this section to `## [0.1.0] - YYYY-MM-DD` and start a fresh
-`[Unreleased]` section above it.
+_Changes on `main` that haven't been summarized into a dated entry yet._
+
+## 2026-06-29 — Initial public baseline
+
+The capabilities Archie HQ ships with as of going public. Subsequent entries
+record what changes from here.
 
 ### Added
 
-- Archie as an **AI employee** you delegate work to in Slack: a PM agent takes
-  the request, brings in the right specialist agents, has them collaborate, and
-  reports back.
-- Plugin architecture — add a new domain by dropping in a plugin directory, with
-  no core code changes. Supports repo agents (git/GitHub/PRs) and plugin agents
-  (workspace + MCP tools).
-- Slack integration (Bolt) and an interactive CLI for driving the engine without
-  Slack or GitHub.
-- GitHub App integration for repo agents: branches, commits, and automated PR
-  creation, gated behind human-approved edit mode.
-- OS-level sandbox (bubblewrap on Linux, sandbox-exec on macOS) with per-agent
-  filesystem isolation, network deny-all from agent Bash, and tool denylists.
-- Web research pipeline with structured output and prompt-injection defense.
-- Agent-to-agent messaging and a shared knowledge log for findings and audit
-  trail.
-- File-based session persistence and recovery under `ARCHIE_WORKDIR`.
-- Bundled example plugin set so a fresh clone is runnable with only an Anthropic
-  API key.
-- Community health and project docs: README, CONTRIBUTING, SECURITY,
-  CODE_OF_CONDUCT, issue/PR templates, and architecture docs under `docs/`.
-- CI workflow (typecheck, build, test, gitleaks secret scan) and CodeQL
-  analysis.
+- **An AI employee you work with in Slack.** Delegate a task in a Slack thread
+  (or the local CLI) and Archie gets it done, then reports back. To users it
+  presents as a single assistant that writes as "I" — the multi-agent machinery
+  underneath is never exposed. It is **non-proactive** (only acts in response to
+  a Slack message or GitHub webhook, never on its own) and **interruptible**
+  (tasks can be stopped, resumed, and recovered).
+
+- **A team of agents, not one chatbot.** A **PM agent** (Opus) reads the
+  request, loads the relevant skill, and delegates to specialist agents
+  (Sonnet). A designated **task owner** coordinates the work — sequentially or
+  in parallel — and synthesizes the result. Agents talk to each other
+  peer-to-peer and write discoveries, decisions, and blockers to a shared
+  **knowledge log** that every agent reads for context.
+
+- **Plugin architecture — add a department, not a fork.** New domains and
+  abilities are added by dropping a plugin directory into the plugins repo; the
+  engine discovers and loads them at startup with no core code changes. A plugin
+  can contribute repo agents, plugin agents, a PM overlay, agent skills, hooks,
+  and MCP server bindings.
+
+- **Repo agents for engineering work.** Agents bound to a GitHub repository work
+  in isolated shared git clones. They are **read-only by default**; once a human
+  approves **edit mode**, the agent gets a feature branch, commits (authored as
+  the person who approved), and opens and manages its own pull requests.
+
+- **Plugin agents for every other domain.** Marketing, analytics, ops, support,
+  research, and more — lightweight agents that get a workspace, skills, and any
+  MCP tools you wire up, with no git infrastructure.
+
+- **GitHub integration with a merge orchestrator.** A webhook-driven PR workflow
+  routes reviews, comments, CI results, and pushes to the right task, and merges
+  pull requests automatically once they're ready. Force pushes are disallowed
+  and pushing is blocked from agent Bash.
+
+- **Human approval gate for any change.** Agents cannot modify code until a
+  human approves edit mode via Slack buttons — the read-only-to-edit transition
+  is an explicit, auditable step.
+
+- **OS-level sandbox with defense-in-depth.** Each agent runs under per-agent
+  filesystem isolation (bubblewrap on Linux, sandbox-exec on macOS), a
+  network deny-all from agent Bash, and tool denylists — so a misbehaving or
+  prompt-injected agent stays contained.
+
+- **Web research pipeline.** Multi-agent web research with structured output and
+  prompt-injection defenses, bounded by per-task budgets.
+
+- **Per-task isolation and recovery.** Every task is its own runtime with
+  isolated message queues, task-scoped budgets (research requests, inter-agent
+  messages, wall-clock timeout), and metadata plus the knowledge log persisted
+  to disk. Tasks recover automatically after a restart.
+
+- **Persistent memory (optional, behind `ARCHIE_MEMORY`).** A cross-task memory
+  layer so agents "arrive informed" instead of starting cold each time — user
+  preferences, a rolling activity index, per-task summaries, and a graph of
+  entity pages for the systems and concepts the work keeps touching. Plain
+  Markdown, no database, removable as a single unit.
+
+- **Encrypted secrets and OAuth.** External integrations connect via an OAuth
+  flow, with tokens stored in an encrypted vault validated by a master key at
+  startup.
+
+- **Runs without Slack or GitHub.** A bundled example plugin set and an
+  interactive CLI make a fresh clone runnable with only an Anthropic API key;
+  Slack and GitHub are optional integrations.
+
+- **Deployment and CI.** Docker Compose for dev and prod, an image published to
+  GitHub Container Registry on every `main` build, and CI that runs typecheck,
+  build, tests, a gitleaks secret scan, and CodeQL analysis.
 
 [Unreleased]: https://github.com/sweatco/archie-hq/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ the release, rename this section to `## [0.1.0] - YYYY-MM-DD` and start a fresh
 
 ### Added
 
-- Multi-agent orchestration: a PM agent that delegates to specialist agents and
-  synthesizes their results.
+- Archie as an **AI employee** you delegate work to in Slack: a PM agent takes
+  the request, brings in the right specialist agents, has them collaborate, and
+  reports back.
 - Plugin architecture — add a new domain by dropping in a plugin directory, with
   no core code changes. Supports repo agents (git/GitHub/PRs) and plugin agents
   (workspace + MCP tools).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+These changes are staged for the first tagged release (`v0.1.0`). When cutting
+the release, rename this section to `## [0.1.0] - YYYY-MM-DD` and start a fresh
+`[Unreleased]` section above it.
+
+### Added
+
+- Multi-agent orchestration: a PM agent that delegates to specialist agents and
+  synthesizes their results.
+- Plugin architecture — add a new domain by dropping in a plugin directory, with
+  no core code changes. Supports repo agents (git/GitHub/PRs) and plugin agents
+  (workspace + MCP tools).
+- Slack integration (Bolt) and an interactive CLI for driving the engine without
+  Slack or GitHub.
+- GitHub App integration for repo agents: branches, commits, and automated PR
+  creation, gated behind human-approved edit mode.
+- OS-level sandbox (bubblewrap on Linux, sandbox-exec on macOS) with per-agent
+  filesystem isolation, network deny-all from agent Bash, and tool denylists.
+- Web research pipeline with structured output and prompt-injection defense.
+- Agent-to-agent messaging and a shared knowledge log for findings and audit
+  trail.
+- File-based session persistence and recovery under `ARCHIE_WORKDIR`.
+- Bundled example plugin set so a fresh clone is runnable with only an Anthropic
+  API key.
+- Community health and project docs: README, CONTRIBUTING, SECURITY,
+  CODE_OF_CONDUCT, issue/PR templates, and architecture docs under `docs/`.
+- CI workflow (typecheck, build, test, gitleaks secret scan) and CodeQL
+  analysis.
+
+[Unreleased]: https://github.com/sweatco/archie-hq/commits/main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,3 +58,7 @@ When creating commits (only when asked):
 - **Group related changes**: If multiple files change for the same feature, commit them together
 - **Clear commit messages**: Use descriptive messages that explain what changed and why
 - **Exclude drafts**: Don't commit draft documentation or proposals unless specifically requested
+
+### Pull Requests
+
+When opening a PR against this repo (only when asked), populate the description from `.github/PULL_REQUEST_TEMPLATE.md`: fill in **What & why** and tick the checklist items that apply. Delete any section that doesn't. This keeps PR descriptions consistent without manual effort from maintainers — the author (usually an agent) fills it, not the reviewer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,5 +58,3 @@ When creating commits (only when asked):
 - **Group related changes**: If multiple files change for the same feature, commit them together
 - **Clear commit messages**: Use descriptive messages that explain what changed and why
 - **Exclude drafts**: Don't commit draft documentation or proposals unless specifically requested
-
-> Note: `.github/PULL_REQUEST_TEMPLATE.md` (including its smoke-test checklist) exists for **external open-source contributors** opening PRs against this public repo. It is not a workflow gate for internal work or Archie's own agents.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,4 @@ When creating commits (only when asked):
 - **Clear commit messages**: Use descriptive messages that explain what changed and why
 - **Exclude drafts**: Don't commit draft documentation or proposals unless specifically requested
 
-### Pull Requests
-
-When opening a PR against this repo (only when asked), populate the description from `.github/PULL_REQUEST_TEMPLATE.md`: fill in **What & why** and tick the checklist items that apply. Delete any section that doesn't. This keeps PR descriptions consistent without manual effort from maintainers — the author (usually an agent) fills it, not the reviewer.
+> Note: `.github/PULL_REQUEST_TEMPLATE.md` (including its smoke-test checklist) exists for **external open-source contributors** opening PRs against this public repo. It is not a workflow gate for internal work or Archie's own agents.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**egor@sweatco.in**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Slack and GitHub are optional integrations — you do **not** need them to build
 ## Getting set up
 
 ```bash
-git clone https://github.com/<your-org>/archie-hq.git
+git clone https://github.com/sweatco/archie-hq.git
 cd archie-hq
 npm install
 cp .env.example .env        # then set ANTHROPIC_API_KEY in .env

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 [![Built with Claude Agent SDK](https://img.shields.io/badge/built%20with-Claude%20Agent%20SDK-d97757.svg)](https://docs.anthropic.com/en/docs/claude-code/sdk)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-A multi-agent AI system that handles work across any domain — engineering, marketing, analytics, ops, or anything you plug in. Agents collaborate on tasks via Slack, using whatever tools each domain needs. Built on the [Claude Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk) with a plugin architecture: add a new domain by dropping in a plugin directory, no core code changes.
+**Archie is an AI employee** — you delegate real work to it in Slack, the same way you would to a colleague, and it gets the job done across any domain: engineering, marketing, analytics, ops, or anything you plug in.
 
-**What makes it different:** unlike single-purpose agent frameworks, Archie is a *team* — a PM agent orchestrates specialist agents that talk to each other, share findings, and operate under an OS-level sandbox with a human approval gate before any code is written. New domains are plugins, not forks.
+Under the hood it's not one chatbot but a whole team: a PM agent takes your request, brings in the right specialist agents, has them collaborate, and reports back. It's built on the [Claude Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk) with a plugin architecture — add a new skill or department by dropping in a plugin directory, no core code changes.
+
+**Why "employee" and not just "agent":** unlike single-purpose agent frameworks, Archie has coworkers, a manager, a workplace (Slack), and rules of conduct — specialist agents talk to each other, share findings, and operate under an OS-level sandbox with a human approval gate before any code ships. You onboard new abilities as plugins, not forks.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 **A**utonomous **R**esponsive and **C**ollaborative **H**yper **I**ntelligent **E**mployee
 
+[![CI](https://github.com/sweatco/archie-hq/actions/workflows/ci.yml/badge.svg)](https://github.com/sweatco/archie-hq/actions/workflows/ci.yml)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0--or--later-blue.svg)](LICENSE)
+[![Built with Claude Agent SDK](https://img.shields.io/badge/built%20with-Claude%20Agent%20SDK-d97757.svg)](https://docs.anthropic.com/en/docs/claude-code/sdk)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
 A multi-agent AI system that handles work across any domain — engineering, marketing, analytics, ops, or anything you plug in. Agents collaborate on tasks via Slack, using whatever tools each domain needs. Built on the [Claude Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk) with a plugin architecture: add a new domain by dropping in a plugin directory, no core code changes.
+
+**What makes it different:** unlike single-purpose agent frameworks, Archie is a *team* — a PM agent orchestrates specialist agents that talk to each other, share findings, and operate under an OS-level sandbox with a human approval gate before any code is written. New domains are plugins, not forks.
+
+## Contents
+
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start-no-slack-no-github--just-an-api-key)
+- [Plugins](#plugins)
+- [Architecture](#architecture)
+- [Security](#security)
+- [Documentation](#documentation)
+- [Technology Stack](#technology-stack)
+- [Contributing](CONTRIBUTING.md)
+- [License](#license)
 
 ## How It Works
 
@@ -26,7 +45,7 @@ Archie ships with a small **example plugin set** (a PM plus a general assistant 
 
 ```bash
 # 1. Clone and install
-git clone https://github.com/<your-org>/archie-hq.git && cd archie-hq
+git clone https://github.com/sweatco/archie-hq.git && cd archie-hq
 npm install
 
 # 2. Configure — the only required value is your Anthropic API key
@@ -173,6 +192,8 @@ See [Security Architecture](docs/architecture/security.md) for the full threat m
 
 - [Contributing](CONTRIBUTING.md) — how to set up, the dev loop, and PR expectations
 - [Security Policy](SECURITY.md) — how to report a vulnerability
+- [Code of Conduct](CODE_OF_CONDUCT.md) — community standards
+- [Changelog](CHANGELOG.md) — notable changes by version
 
 ## Technology Stack
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Under the hood it's not one chatbot but a whole team: a PM agent takes your requ
 ## Contents
 
 - [Why a team, not a single agent?](#why-a-team-not-a-single-agent)
+- [Runs your whole team on one server](#runs-your-whole-team-on-one-server)
 - [How It Works](#how-it-works)
 - [Quick Start](#quick-start-no-slack-no-github--just-an-api-key)
 - [Plugins](#plugins)
@@ -33,6 +34,13 @@ A single agent can call sub-agents, so why model a whole team? Three reasons:
 - **A coordinator delegates; a lead hoards.** Give one "lead" agent some sub-agents and it tends to do the whole job itself — it sees itself as the one in charge of the *work*. Archie's PM is a coordinator by design: its job is to delegate and synthesize, never to do the work. That structural choice is what actually distributes the work to the right specialists instead of one model trying to be everything.
 
 This is also why Archie reads as an **employee**, not a tool: it has coworkers, a manager, a workplace (Slack), and a human approval gate before anything ships. You onboard new abilities as plugins, not forks.
+
+## Runs your whole team on one server
+
+Archie is a production system, not a demo — and it's deliberately cheap to operate:
+
+- **Massively parallel, single box.** Every task is its own lightweight, isolated runtime, so many run concurrently on one server. In production, a single instance serves an entire ~100-person company running tasks in parallel, with no resource strain.
+- **Near-zero infrastructure.** No database, no message broker, no external state store — just files on disk and git. All runtime state lives under one working directory, which makes deploying, backing up, and recovering trivial. Crash recovery is built in: tasks check-point to disk and resume after a restart.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@
 
 Under the hood it's not one chatbot but a whole team: a PM agent takes your request, brings in the right specialist agents, has them collaborate, and reports back. It's built on the [Claude Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk) with a plugin architecture — add a new skill or department by dropping in a plugin directory, no core code changes.
 
-**Why "employee" and not just "agent":** unlike single-purpose agent frameworks, Archie has coworkers, a manager, a workplace (Slack), and rules of conduct — specialist agents talk to each other, share findings, and operate under an OS-level sandbox with a human approval gate before any code ships. You onboard new abilities as plugins, not forks.
-
 ## Contents
 
+- [Why a team, not a single agent?](#why-a-team-not-a-single-agent)
 - [How It Works](#how-it-works)
 - [Quick Start](#quick-start-no-slack-no-github--just-an-api-key)
 - [Plugins](#plugins)
@@ -24,6 +23,16 @@ Under the hood it's not one chatbot but a whole team: a PM agent takes your requ
 - [Technology Stack](#technology-stack)
 - [Contributing](CONTRIBUTING.md)
 - [License](#license)
+
+## Why a team, not a single agent?
+
+A single agent can call sub-agents, so why model a whole team? Three reasons:
+
+- **Context stays focused.** One agent grinding through a long task fills its context window fast and starts losing the thread. Splitting the work across agents keeps each one's context small, relevant, and sharp.
+- **Specialists beat a generalist.** An agent with a well-defined role — backed by peers it can question and reach agreement with — produces better work than a single generic agent reasoning alone. Collaboration and disagreement are features, not overhead.
+- **A coordinator delegates; a lead hoards.** Give one "lead" agent some sub-agents and it tends to do the whole job itself — it sees itself as the one in charge of the *work*. Archie's PM is a coordinator by design: its job is to delegate and synthesize, never to do the work. That structural choice is what actually distributes the work to the right specialists instead of one model trying to be everything.
+
+This is also why Archie reads as an **employee**, not a tool: it has coworkers, a manager, a workplace (Slack), and a human approval gate before anything ships. You onboard new abilities as plugins, not forks.
 
 ## How It Works
 


### PR DESCRIPTION
## What & why

Archie HQ is going public, and the repo was missing most of the cheap, high-leverage signals that make an open-source project legible to a first-time visitor: the README buried its positioning, the quick-start clone URL was a broken `<your-org>` placeholder, and several GitHub Community Standards files (Code of Conduct, issue/PR templates) didn't exist. This PR closes those gaps with documentation and `.github/` config only — no engine code is touched.

It implements the file-based items from a discoverability punch-list; the settings-only items (About description, topics, social-preview image) are applied separately in repo settings.

## How it works

- **README, repositioned.** Leads with "Archie is an **AI employee**" and adds two value-prop sections grounded in the architecture docs: *Why a team, not a single agent?* (focused per-agent context, specialists with peer review, a PM that coordinates rather than hoards) and *Runs your whole team on one server* (massively parallel, near-zero infrastructure — verified against the file-based persistence model and the absence of any DB/broker dependency). Adds a TOC and a small badge set (CI, license, SDK, PRs-welcome).
- **Fixed the broken quick start.** `<your-org>` → `sweatco` in the README and CONTRIBUTING clone commands, so the first command a new user runs actually works.
- **Community-health files.** `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), issue templates (bug report, feature request, config that routes security reports to private advisories), and a PR template.
- **CHANGELOG.md.** Capability-focused, date-based (not per-commit), matching how Archie ships — continuously, with operators tracking `main`. Versioned releases stay optional.
- **PR template matches the house style.** Rewritten after reading the last ~11 closed PRs: problem-first narrative sections (What & why → How it works → Verification) with an optional deployment/follow-ups callout, rather than a checkbox form — because that's what the repo's PRs actually do, including being candid about what couldn't be verified.

The deliberately-out-of-scope items: the GitHub settings that have no file representation (About description, topics, social-preview image) and any tagged release — handled outside the repo.

## Verification

Docs and `.github/` config only — no source changed, so there's nothing to typecheck or build. Checks run:

- Issue-template YAML parses cleanly (validated with a YAML parser).
- README TOC anchors match their heading slugs.
- Confirmed against the codebase that the "no database / near-zero infrastructure" and "file-based persistence with crash recovery" claims are accurate (`package.json` has no DB/queue/broker deps; `docs/architecture/persistence.md`).
- I did not render the GitHub issue/PR template forms or the social-preview unfurl live; those are best eyeballed once merged.

## Deployment & follow-ups

- After merge, complete the settings-only items in repo settings: About **description** and **topics**, and upload a **social-preview image** (1280×640).
- Verify **Insights → Community Standards** shows green for Code of Conduct, issue templates, and PR template.
- Enable **private vulnerability reporting** so the link in `SECURITY.md` / issue-template config resolves.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WiCKRRRpvgVBc9mjXQ7TNx)_