### PR TITLE
fix(agents): recover from error-result turns instead of orphaning

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -759,6 +759,28 @@ Shared folder: ${sharedPath} [READ-ONLY]
               await teardown().catch((err) =>
                 logger.error(def.id, 'Error during deferred teardown', err)
               );
+            } else if (
+              event.type === 'result' &&
+              event.subtype !== 'success' &&
+              agent.session.active
+            ) {
+              // The turn ended with an ERROR result (API "Overloaded" once the
+              // SDK's own retries are exhausted, max_turns, …). Unlike a clean stop
+              // this does NOT fire the SDK `Stop` hook, so nothing marks the agent
+              // inactive: the active flag stays set, the idle-check never arms, and
+              // the task hangs until the 60-min wall-clock cap (observed: a 44-min
+              // orphan after an Overloaded, broken only by an external poke). Mark
+              // the agent inactive so the normal quiescence/recovery path runs —
+              // recovery re-engages the agent, which retries the work. The
+              // `agent.session.active` guard makes this a safety-net: a success
+              // result is owned by the Stop hook, and if the Stop hook or
+              // crash-detection already cleared the flag this is a no-op, so it
+              // can't double-fire recovery.
+              logger.warn(
+                def.id,
+                `Turn ended with error result '${event.subtype}' — marking inactive so recovery can run`,
+              );
+              task.updateAgentState(def.id, false);
             }
           }
 


### PR DESCRIPTION
## Problem

When an agent's turn ends with an SDK **error** `result` — `error_during_execution` (API **"Overloaded"** once the SDK's own retries exhaust) or `error_max_turns` — the SDK **`Stop` hook does not fire**. The `Stop` hook is the *sole* signal that marks an agent inactive, so on an error turn nothing clears `session.active`: the idle-check never arms, recovery never runs, and the task **orphans until the 60-min wall-clock cap** — while the "Archie is …" heartbeat keeps claiming progress.

### Evidence (`task-20260629-1453-fv3r6g`)

A natural experiment in one session:

| time | event |
|---|---|
| 16:00:42 | user msg → `agent:active` |
| **16:02:35** | **`API Error: Overloaded`** result — turn dies |
| 16:02 → 16:46 | **31 heartbeats, no `agent:inactive`** — orphaned 44 min |
| 16:46:49 | external `[cli]` poke → re-engaged |
| 17:22 | a *normal* turn-end (malformed tool call) → `agent:inactive` fired → recovery → **healed in ~1 min** |

Same agent, same day — the only variable is *how the turn ended*. The error path bypasses the `Stop` hook; every clean end emits `agent:inactive` and self-heals.

## Fix

In the spawn loop, on a `result` event with a **non-success** subtype, mark the agent inactive — exactly what the `Stop` hook does on a clean end — so the existing quiescence/recovery path runs (recovery re-engages the agent, which retries; Overloaded is transient, so the retry succeeds):

```ts
} else if (
  event.type === 'result' &&
  event.subtype !== 'success' &&
  agent.session.active
) {
  logger.warn(def.id, `Turn ended with error result '${event.subtype}' — marking inactive so recovery can run`);
  task.updateAgentState(def.id, false);
}
```

- **Success path untouched** — handled by the `Stop` hook.
- **`agent.session.active` guard** makes it a *safety-net*: if the `Stop` hook or crash-detection already cleared the flag (on subtypes where they do fire), this is a no-op → **no double-fire** of recovery. Verified against fv3r6g that `session.active` is `true` across an Overloaded error, so the heal does fire when needed.
- **Background tasks unaffected** — those turns end `success` (not an error subtype), and the idle-check's `backgroundTasks.size > 0` guard already prevents premature recovery on any overlap.

## Scope / risk

- Reachable non-success subtypes here are `error_during_execution` and `error_max_turns` (archie sets `maxTurns` but not `max_budget`/structured-output caps).
- Transient errors (the bug): ~1-turn heal vs 44-min orphan. Persistent errors: recovery churns until the wall-clock cap instead of a quiet orphan — same endpoint, bounded by the existing recovery cap (3 → nuclear) + wall-clock. This is the recovery system's pre-existing behavior; the fix just routes error-turns into it.

## Test

The check is a self-evident two-term condition inlined at its single call site. The loop wiring needs a live SDK and isn't unit-isolable, so there's no unit test — coverage is the causal evidence above plus typecheck. Suite 512/512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)