### PR TITLE
Clean up issue templates: single Type badge, no redundant prefix/label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug report
 description: Report something that isn't working as expected
-title: "[Bug]: "
-labels: ["bug"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature request
 description: Suggest an idea or enhancement for Archie HQ
-title: "[Feature]: "
-labels: ["enhancement"]
+type: Feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## What & why

In the issues list the same category was stated three times — a `[Feature]:` / `[Bug]:` title prefix, the issue **Type** badge, *and* an `enhancement` / `bug` label. That's noisy and redundant. This change makes the category appear once.

## How it works

Both issue forms now set the org issue type directly via the top-level `type:` key (`Feature` / `Bug`) and drop the `title:` prefix and the `labels:` entry:

- Submitters write a clean, descriptive title (no `[Feature]:` / `[Bug]:` prefix).
- The **Type** badge becomes the single categorization signal.
- No label is auto-applied, leaving labels free for genuinely orthogonal use later (e.g. an area tag).

All body fields are unchanged (feature: *problem / proposed solution / alternatives / area / checks*; bug: *what happened / steps / logs / environment / checks*), and `config.yml` (blank issues disabled + contact links) is untouched.

Out of scope: a Task/Spike form (easy to add later if we want the `Task` type selectable from the picker), and any web-UI work.

## Verification

- Both `.yml` files parse cleanly with a YAML loader and keep all body fields; `type` is set, `title`/`labels` removed.
- `type:` is a supported top-level issue-form key per GitHub's issue-form syntax docs, and `Feature` / `Bug` match the org's existing issue types.
- Note: GitHub renders issue forms from the **default branch**, so the new behaviour is only observable once this merges to `main` — I could not render the form pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bynYAZrrZsBACBPobeRkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015bynYAZrrZsBACBPobeRkQ)_