### PR TITLE
ci: automate the daily changelog from PR context

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -1,0 +1,175 @@
+# Daily changelog — summarize the previous day's commits into CHANGELOG.md.
+#
+# How it works:
+#   1. Gather the day's changes as PR context (scripts/changelog-gather.sh):
+#      each PR merged yesterday with its description, linked issues, commit
+#      subjects, and diffstat — so the model understands intent without reading
+#      code — plus a raw-commit backstop for direct-to-main pushes.
+#   2. If nothing landed — or that day already has an entry — stop (no empty commit).
+#   3. Have the Claude Code Action write ONLY the dated entry to new-entry.md
+#      (it never edits CHANGELOG.md itself).
+#   4. scripts/changelog-insert.mjs splices that entry into CHANGELOG.md in the
+#      right place (below [Unreleased], above the newest dated entry).
+#   5. Commit straight to `main` with [skip ci] so it doesn't trigger a rebuild.
+#
+# Setup prerequisites:
+#   - Repo secret ANTHROPIC_API_KEY.
+#   - main must allow this workflow to push. If branch protection requires PRs
+#     or status checks, add the github-actions bot to the bypass list (Settings
+#     -> Branches), or switch this job to open a PR instead of pushing.
+#
+# Actions are SHA-pinned per org policy (full commit SHA + version comment).
+name: Daily changelog
+
+on:
+  schedule:
+    # 02:00 UTC daily — late enough to capture the full previous UTC day.
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Day to summarize (YYYY-MM-DD, UTC). Defaults to yesterday."
+        required: false
+        type: string
+
+# Never let two runs edit the changelog at once.
+concurrency:
+  group: daily-changelog
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    name: Summarize yesterday into CHANGELOG.md
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main (full history)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Gather the day's changes (PR context)
+        id: gather
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TARGET_DATE="${{ inputs.date }}"
+          if [ -z "$TARGET_DATE" ]; then
+            TARGET_DATE="$(date -u -d 'yesterday' +%F)"
+          fi
+          echo "date=$TARGET_DATE" >> "$GITHUB_OUTPUT"
+          echo "Target day: $TARGET_DATE (UTC)"
+
+          # Already documented? Then there's nothing to do.
+          if grep -qE "^## ${TARGET_DATE}\b" CHANGELOG.md; then
+            echo "Entry for $TARGET_DATE already exists — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          set +e
+          bash scripts/changelog-gather.sh "$TARGET_DATE" "${{ github.repository }}" context.md
+          code=$?
+          set -e
+          if [ "$code" = "10" ]; then
+            echo "Nothing landed on $TARGET_DATE — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          [ "$code" = "0" ] || exit "$code"
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "::group::Context for the model"
+          cat context.md
+          echo "::endgroup::"
+
+      - name: Write the entry with Claude
+        if: steps.gather.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@4633baf5267540f3f8cb58b684f79901d564c280 # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --allowedTools Read,Write
+            --max-turns 8
+            --model claude-sonnet-4-6
+          prompt: |
+            You are updating Archie HQ's CHANGELOG.md. Write the entry for ${{ steps.gather.outputs.date }}.
+
+            First read two files in the repo:
+            - `context.md` — the changes that landed that day. Merged pull requests are the
+              primary source: each PR's description explains *what and why*, with its linked
+              issues, commit subjects, and diffstat. A raw-commit list at the end is a backstop
+              for anything pushed straight to main. Use the PR descriptions to understand the
+              VALUE and intent of each change — you do not need to read the code.
+            - `CHANGELOG.md` — copy the exact voice, formatting, and density of the existing
+              dated entries near the top.
+
+            Rules (follow exactly):
+            - The output is ONE section. The first line is the heading `## ${{ steps.gather.outputs.date }}` and nothing comes before it.
+            - One logical change = one bullet. A PR is normally one bullet, even when it spans
+              several commits. Do not write one bullet per commit, and do not list every commit.
+            - Lead each bullet with the VALUE the change delivers for business users — a bold
+              lead-in sentence drawn from the PR's "what & why" — then add engineer detail in a
+              trailing `_Technical: …_` clause.
+            - A change that is pure plumbing with no user-facing value stays purely technical:
+              write it as an italic `_Technical: …_` bullet with no bold business lead.
+            - Be concise and faithful. Never invent a change that is not in `context.md`.
+
+            Then self-review your draft before saving: does every bullet either lead with real
+            user value or stand as an explicit `_Technical:_` note? Is anything invented or
+            mis-summarized versus `context.md`? Are related changes grouped? Revise, then save.
+
+            Write ONLY the finished entry to a new file named `new-entry.md`.
+            Do NOT modify CHANGELOG.md or any other file.
+
+      - name: Insert the entry and commit
+        if: steps.gather.outputs.skip == 'false'
+        env:
+          TARGET_DATE: ${{ steps.gather.outputs.date }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -s new-entry.md ]; then
+            echo "Claude produced no new-entry.md — aborting." >&2
+            exit 1
+          fi
+
+          # Discard any stray edits Claude may have made; we only trust new-entry.md.
+          git checkout -- CHANGELOG.md
+
+          set +e
+          node scripts/changelog-insert.mjs CHANGELOG.md new-entry.md
+          code=$?
+          set -e
+          # 3 == entry already present (race / re-run): treat as a clean no-op.
+          if [ "$code" = "3" ]; then
+            echo "Already present — nothing to commit."
+            exit 0
+          fi
+          [ "$code" = "0" ] || exit "$code"
+
+          rm -f new-entry.md context.md
+
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "No changelog change — nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "archie-changelog[bot]"
+          git config user.email "archie-changelog@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): add entry for ${TARGET_DATE} [skip ci]"
+
+          # Retry the push a few times to ride out transient failures.
+          n=0
+          until git push origin HEAD:main; do
+            n=$((n + 1))
+            [ "$n" -ge 4 ] && { echo "push failed after retries" >&2; exit 1; }
+            sleep $((2 ** n))
+            git pull --rebase origin main
+          done

--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -118,6 +118,8 @@ jobs:
               trailing `_Technical: …_` clause.
             - A change that is pure plumbing with no user-facing value stays purely technical:
               write it as an italic `_Technical: …_` bullet with no bold business lead.
+            - Write each bullet on a SINGLE line — never hard-wrap prose across multiple lines.
+              Only fenced code may span lines.
             - Be concise and faithful. Never invent a change that is not in `context.md`.
 
             Then self-review your draft before saving: does every bullet either lead with real

--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -13,10 +13,12 @@
 #   5. Commit straight to `main` with [skip ci] so it doesn't trigger a rebuild.
 #
 # Setup prerequisites:
-#   - Repo secret ANTHROPIC_API_KEY.
-#   - main must allow this workflow to push. If branch protection requires PRs
-#     or status checks, add the github-actions bot to the bypass list (Settings
-#     -> Branches), or switch this job to open a PR instead of pushing.
+#   - Repo secret ANTHROPIC_API_KEY (the Claude Code Action authenticates with it).
+#   - Repo secret CHANGELOG_DEPLOY_KEY — the PRIVATE half of a write-enabled
+#     deploy key whose PUBLIC half is added to the repo (Settings -> Deploy keys,
+#     "Allow write access") AND to the branch ruleset's bypass list. The built-in
+#     github-actions bot cannot be a ruleset bypass actor, so the job pushes over
+#     SSH as this deploy key to land the entry directly on main.
 #
 # Actions are SHA-pinned per org policy (full commit SHA + version comment).
 name: Daily changelog
@@ -50,6 +52,10 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # Push as a write-enabled deploy key that's on the ruleset bypass list,
+          # so the entry can land directly on the protected main branch. Checkout
+          # configures the SSH remote and persists the key for the later push.
+          ssh-key: ${{ secrets.CHANGELOG_DEPLOY_KEY }}
 
       - name: Gather the day's changes (PR context)
         id: gather

--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -1,23 +1,40 @@
-# Daily changelog — summarize the previous day's commits into CHANGELOG.md.
+# Daily changelog — summarize the previous day's changes into CHANGELOG.md.
+#
+# Two jobs, split for security (see "Security" below):
+#   generate — gather the day's PR context, have Claude draft the dated entry,
+#              expose it as a job output. Has the Anthropic key; NO push access.
+#   publish  — on a fresh checkout, splice the entry into CHANGELOG.md with the
+#              trusted insert script and push to main. Has the deploy key; runs
+#              NO model.
 #
 # How it works:
-#   1. Gather the day's changes as PR context (scripts/changelog-gather.sh):
-#      each PR merged yesterday with its description, linked issues, commit
-#      subjects, and diffstat — so the model understands intent without reading
-#      code — plus a raw-commit backstop for direct-to-main pushes.
+#   1. generate: scripts/changelog-gather.sh builds the model's context — each PR
+#      merged that day with its description, linked issues, commit subjects, and
+#      diffstat (so the model grasps intent without reading code), plus a
+#      raw-commit backstop for direct-to-main pushes.
 #   2. If nothing landed — or that day already has an entry — stop (no empty commit).
-#   3. Have the Claude Code Action write ONLY the dated entry to new-entry.md
-#      (it never edits CHANGELOG.md itself).
-#   4. scripts/changelog-insert.mjs splices that entry into CHANGELOG.md in the
-#      right place (below [Unreleased], above the newest dated entry).
-#   5. Commit straight to `main` with [skip ci] so it doesn't trigger a rebuild.
+#   3. generate: the Claude Code Action writes ONLY the dated entry to new-entry.md;
+#      a step captures it into the `entry` job output.
+#   4. publish: scripts/changelog-insert.mjs splices the entry below [Unreleased],
+#      above the newest dated entry, leaving structure and the bottom snapshot alone.
+#   5. publish: commit straight to main with [skip ci] so it doesn't trigger a rebuild.
+#
+# Security:
+#   The gather step feeds attacker-influenceable text (PR/issue/commit bodies) to
+#   the model, so the model step is treated as untrusted. It is isolated in the
+#   `generate` job, which never holds the deploy key — so a prompt-injected model
+#   cannot read/exfiltrate the push credential or tamper with a script that later
+#   runs alongside it. `publish` runs no model and checks out fresh, so the insert
+#   script it runs is the trusted repo version; the drafted entry crosses the job
+#   boundary as a job output consumed via an env var (never expression-interpolated
+#   into a shell), and the insert script only ever writes CHANGELOG.md.
 #
 # Setup prerequisites:
 #   - Repo secret ANTHROPIC_API_KEY (the Claude Code Action authenticates with it).
 #   - Repo secret CHANGELOG_DEPLOY_KEY — the PRIVATE half of a write-enabled
 #     deploy key whose PUBLIC half is added to the repo (Settings -> Deploy keys,
 #     "Allow write access") AND to the branch ruleset's bypass list. The built-in
-#     github-actions bot cannot be a ruleset bypass actor, so the job pushes over
+#     github-actions bot cannot be a ruleset bypass actor, so publish pushes over
 #     SSH as this deploy key to land the entry directly on main.
 #
 # Actions are SHA-pinned per org policy (full commit SHA + version comment).
@@ -40,22 +57,25 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  changelog:
-    name: Summarize yesterday into CHANGELOG.md
+  generate:
+    name: Draft the entry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      skip: ${{ steps.gather.outputs.skip }}
+      date: ${{ steps.gather.outputs.date }}
+      entry: ${{ steps.capture.outputs.entry }}
     steps:
       - name: Check out main (full history)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
           fetch-depth: 0
-          # Push as a write-enabled deploy key that's on the ruleset bypass list,
-          # so the entry can land directly on the protected main branch. Checkout
-          # configures the SSH remote and persists the key for the later push.
-          ssh-key: ${{ secrets.CHANGELOG_DEPLOY_KEY }}
 
       - name: Gather the day's changes (PR context)
         id: gather
@@ -135,20 +155,51 @@ jobs:
             Write ONLY the finished entry to a new file named `new-entry.md`.
             Do NOT modify CHANGELOG.md or any other file.
 
-      - name: Insert the entry and commit
+      - name: Capture the drafted entry
+        id: capture
         if: steps.gather.outputs.skip == 'false'
-        env:
-          TARGET_DATE: ${{ steps.gather.outputs.date }}
         run: |
           set -euo pipefail
-
           if [ ! -s new-entry.md ]; then
             echo "Claude produced no new-entry.md — aborting." >&2
             exit 1
           fi
+          # Pass the entry to the publish job as a job output. It is consumed there
+          # via an env var (never interpolated into a shell), so its content — which
+          # is attacker-influenceable — cannot inject commands downstream.
+          {
+            echo 'entry<<CHANGELOG_ENTRY_EOF'
+            cat new-entry.md
+            echo 'CHANGELOG_ENTRY_EOF'
+          } >> "$GITHUB_OUTPUT"
 
-          # Discard any stray edits Claude may have made; we only trust new-entry.md.
-          git checkout -- CHANGELOG.md
+  publish:
+    name: Insert and push
+    needs: generate
+    if: needs.generate.outputs.skip == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main (full history)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+          # Deploy key on the ruleset bypass list — lets this job push the entry
+          # directly to the protected main branch over SSH.
+          ssh-key: ${{ secrets.CHANGELOG_DEPLOY_KEY }}
+
+      - name: Insert the entry and push
+        env:
+          TARGET_DATE: ${{ needs.generate.outputs.date }}
+          ENTRY: ${{ needs.generate.outputs.entry }}
+        run: |
+          set -euo pipefail
+
+          # Materialize the drafted entry from the env var (safe: no shell
+          # interpolation of untrusted content). The insert script — the trusted
+          # repo version, since no model ran in this job — sanitizes it and only
+          # ever writes CHANGELOG.md.
+          printf '%s\n' "$ENTRY" > new-entry.md
 
           set +e
           node scripts/changelog-insert.mjs CHANGELOG.md new-entry.md
@@ -161,7 +212,7 @@ jobs:
           fi
           [ "$code" = "0" ] || exit "$code"
 
-          rm -f new-entry.md context.md
+          rm -f new-entry.md
 
           if git diff --quiet -- CHANGELOG.md; then
             echo "No changelog change — nothing to commit."

--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -122,7 +122,7 @@ jobs:
           claude_args: |
             --allowedTools Read,Write
             --max-turns 8
-            --model claude-sonnet-4-6
+            --model sonnet
           prompt: |
             You are updating Archie HQ's CHANGELOG.md. Write the entry for ${{ steps.gather.outputs.date }}.
 

--- a/scripts/changelog-gather.sh
+++ b/scripts/changelog-gather.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Build the LLM context for a day's changelog entry.
+#
+# The primary unit is the MERGED PULL REQUEST, not the commit: a PR's
+# description is where a human explained *what and why*, which is exactly the
+# intent a good changelog bullet needs — so the model never has to read code to
+# understand a change. For each PR merged that day we emit its title, body,
+# linked issues, commit subjects, and diffstat (files + ±lines as a scope
+# signal). A raw-commit list is appended as a backstop so anything pushed
+# straight to main without a PR is still covered.
+#
+# Usage: scripts/changelog-gather.sh <YYYY-MM-DD> <owner/repo> <out-file>
+# Requires: gh (authenticated via GH_TOKEN), jq, git.
+# Exit 0:  wrote <out-file>.
+# Exit 10: nothing landed that day — caller should skip.
+set -euo pipefail
+
+DATE="${1:?usage: changelog-gather.sh <YYYY-MM-DD> <owner/repo> <out-file>}"
+REPO="${2:?missing owner/repo}"
+OUT="${3:?missing out-file}"
+
+SINCE="$DATE 00:00:00 +0000"
+UNTIL="$DATE 23:59:59 +0000"
+SKIP_OWN='^docs(changelog): add entry for'
+
+# Bail early if nothing landed at all (no PRs, no direct commits).
+prs="$(gh pr list --repo "$REPO" --search "is:merged base:main merged:$DATE" \
+        --json number --jq '.[].number' --limit 100 || true)"
+commits="$(git log --no-merges --since="$SINCE" --until="$UNTIL" --pretty=format:'%h')"
+if [ -z "$prs" ] && [ -z "$commits" ]; then
+  exit 10
+fi
+
+tmp="$(mktemp)"
+{
+  echo "# Changes that landed on \`main\` on $DATE"
+  echo
+
+  if [ -n "$prs" ]; then
+    echo "## Pull requests merged this day (primary source)"
+    echo
+    echo "One logical change is usually one PR = one changelog bullet. Each PR's"
+    echo "description explains what and why — prefer it over the raw commits below."
+    echo
+    for n in $prs; do
+      gh pr view "$n" --repo "$REPO" \
+        --json number,title,url,body,labels,additions,deletions,changedFiles,files,commits,closingIssuesReferences \
+        --jq '
+          "### PR #\(.number) — \(.title)",
+          "\(.url)",
+          (if (.labels|length) > 0 then "Labels: " + ([.labels[].name] | join(", ")) else empty end),
+          "Scope: \(.changedFiles) files, +\(.additions)/-\(.deletions)",
+          (if (.files|length) > 0 then
+             "Files: " + ([.files[] | "\(.path) (+\(.additions)/-\(.deletions))"][0:15] | join("; "))
+           else empty end),
+          (if (.closingIssuesReferences|length) > 0 then
+             "Linked issues:",
+             (.closingIssuesReferences[] | "  - #\(.number) \(.title): \(((.body // "") | gsub("\\s+"; " "))[0:400])")
+           else empty end),
+          "Commits:",
+          (.commits[] | "  - \(.messageHeadline)"),
+          "Description:",
+          (.body // "(no description)"),
+          ""
+        '
+    done
+  fi
+
+  echo "## All commits this day (backstop — covers anything pushed straight to main)"
+  echo
+  git log --no-merges --since="$SINCE" --until="$UNTIL" \
+    --invert-grep --grep="$SKIP_OWN" \
+    --pretty=format:'- %h %s%n%b'
+} > "$tmp"
+
+mv "$tmp" "$OUT"
+echo "Wrote $OUT — $(echo "$prs" | grep -c . || true) PR(s), $(echo "$commits" | grep -c . || true) commit(s)."

--- a/scripts/changelog-insert.mjs
+++ b/scripts/changelog-insert.mjs
@@ -1,0 +1,66 @@
+// Insert a generated changelog entry into CHANGELOG.md in the right place.
+//
+// Used by .github/workflows/daily-changelog.yml: the workflow gathers a day's
+// commits, has Claude write the dated entry to a file, and this script splices
+// that entry into CHANGELOG.md deterministically — so the file structure (the
+// [Unreleased] section and the bottom "Before this log" snapshot) is never
+// touched by the model.
+//
+// Usage: node scripts/changelog-insert.mjs <CHANGELOG.md> <new-entry.md>
+//
+// Exit codes:
+//   0  inserted successfully
+//   1  the entry file has no "## YYYY-MM-DD" heading (refuse to insert)
+//   2  bad arguments
+//   3  an entry for that date is already present (no-op; safe to ignore)
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const DATE_HEADING = /^## (\d{4}-\d{2}-\d{2})\b/m;
+
+const [, , changelogPath, entryPath] = process.argv;
+if (!changelogPath || !entryPath) {
+  console.error('usage: node scripts/changelog-insert.mjs <CHANGELOG.md> <new-entry.md>');
+  process.exit(2);
+}
+
+const changelog = readFileSync(changelogPath, 'utf8');
+const raw = readFileSync(entryPath, 'utf8');
+
+// Tolerate minor model noise: strip any preamble/fences before the dated
+// heading, and keep only the first "## " section (one day per entry).
+const start = raw.search(DATE_HEADING);
+if (start === -1) {
+  console.error('Refusing to insert: entry has no "## YYYY-MM-DD" heading. Got:\n' + raw.slice(0, 160));
+  process.exit(1);
+}
+const fromHeading = raw.slice(start);
+const headingLineEnd = fromHeading.indexOf('\n');
+const afterHeading = fromHeading.slice(headingLineEnd);
+const nextSection = afterHeading.search(/^## /m);
+let entry = (nextSection === -1
+  ? fromHeading
+  : fromHeading.slice(0, headingLineEnd) + afterHeading.slice(0, nextSection)
+).replace(/```[a-z]*\s*$/i, '').trim();
+
+const date = entry.match(DATE_HEADING)[1];
+
+// Idempotency: never add a second section for the same date.
+if (new RegExp(`^## ${date}\\b`, 'm').test(changelog)) {
+  console.error(`Entry for ${date} already present in ${changelogPath}; nothing to do.`);
+  process.exit(3);
+}
+
+// Insert immediately before the newest existing dated entry (reverse
+// chronological). Fall back to the "Before this log" snapshot, then EOF.
+const lines = changelog.split('\n');
+let at = lines.findIndex((l) => /^## \d{4}-\d{2}-\d{2}\b/.test(l));
+if (at === -1) at = lines.findIndex((l) => /^## Before this log\b/.test(l));
+if (at === -1) at = lines.length;
+
+const head = lines.slice(0, at).join('\n').replace(/\s+$/, '');
+const tail = lines.slice(at).join('\n').replace(/^\s+/, '');
+const result = `${head}\n\n${entry}\n\n${tail}`.replace(/\n*$/, '\n');
+
+writeFileSync(changelogPath, result);
+console.log(`Inserted entry for ${date} (before line ${at + 1}).`);


### PR DESCRIPTION
## What & why

Keeping the changelog current by hand doesn't scale. This adds a scheduled job that writes the previous day's entry automatically, in the same value-first / technical-detail format as the manual log (companion PR #154, merged).

The key design decision: the model should understand **intent and business value without reading code**. A bare commit list only describes mechanics, so instead we feed it **merged-PR context** — the PR description is where a human already explained *what and why*. (Validated against real PRs: e.g. the PR-card work that spanned ~15 commits in one day is a single PR with a clear "what & why" body → one clean bullet, not fifteen.)

## How it works

`.github/workflows/daily-changelog.yml`, daily at 02:00 UTC (+ manual `workflow_dispatch` with an optional `date` to backfill), split into two jobs:

**`generate`** (has the Anthropic key; no push access)
1. **Gather** (`scripts/changelog-gather.sh`) — for each PR merged that day, emit its title, body, **linked issues**, commit subjects, and **diffstat** (files + ±lines, a cheap scope signal). A raw-commit list is appended as a backstop for anything pushed straight to `main` without a PR. Uses the runner's `gh` + `jq`.
2. **Skip cleanly** when nothing landed, or when that date already has a section (idempotent, safe to re-run / backfill).
3. **Draft** — the Claude Code Action reads that context plus the existing entries for style and writes **only** the dated entry to `new-entry.md`, self-reviewing against the rules first. A capture step exposes it as a job output.

**`publish`** (has the deploy key; runs no model)
4. **Insert** (`scripts/changelog-insert.mjs`, from a fresh checkout) — splices the entry below `## [Unreleased]` and above the newest dated entry, so the file structure and the bottom snapshot are never touched. Tolerates minor model noise; refuses a malformed entry; no-ops if the date is already present.
5. **Commit to `main`** over SSH using a write-enabled **deploy key** (the built-in github-actions bot can't be a ruleset bypass actor), with `[skip ci]` so it doesn't retrigger the image build, plus push retries.

Scope is deliberately drawn at PR text + diffstat (the "1–3" context tier we discussed); reading full diffs / the repo is intentionally left out. The prompt also instructs the model to keep entries unwrapped (one line per bullet).

## Security

The gather step feeds attacker-influenceable text (PR/issue/commit bodies) to the model, so the model step is treated as untrusted and isolated:

- The model runs only in `generate`, which **never holds the deploy key** — a prompt-injected model can't read/exfiltrate the push credential or tamper with a script that later runs beside it.
- `publish` runs **no model** and checks out **fresh**, so the insert script it runs is the trusted repo version.
- The drafted entry crosses the job boundary as a **job output consumed via an env var** — never expression-interpolated into a shell — so its content can't inject commands.
- The insert script only ever writes `CHANGELOG.md`; the model's tools are limited to `Read,Write` (no Bash/network); the deploy key is scoped to this one repo.

## Verification

- `scripts/changelog-insert.mjs` tested locally: clean insert above the newest entry; idempotent re-run (exit 3); rejects a headingless entry (exit 1); tolerant of leading model noise / code fences; structure preserved.
- `scripts/changelog-gather.sh`: `bash -n` clean; the `jq` projection validated against a real PR JSON shape.
- Workflow YAML parses; job wiring (outputs → `needs` → `if`) confirmed; actions SHA-pinned per org policy (`claude-code-action@v1` → `4633baf`).
- Not executed end-to-end in CI yet — see below.

## Deployment & follow-ups

- ✅ Secret `ANTHROPIC_API_KEY` added.
- ✅ Deploy key added: public half on the repo (write access) and on the ruleset bypass list; private half stored as secret `CHANGELOG_DEPLOY_KEY`.
- After merging, trigger once via **Actions → Daily changelog → Run workflow** (optionally with a past `date`) to confirm a commit lands on `main`, before relying on the 02:00 UTC schedule. Tip: to dry-run, run it before adding the deploy key — `generate` will produce the entry and `publish` will simply fail at the push, changing nothing.
- Easy knob: model is the `sonnet` alias (tracks the latest Sonnet automatically — no version to maintain; switch to `opus` for richer prose). The entry-writing rules live inline in the workflow prompt.