### PR TITLE
docs: add no-hard-wrap prose convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ See `docs/guides/local-development.md` for full setup instructions.
 
 Use the unified logger (`src/system/logger.ts`) for all console output. Never use `console.log/error/warn` directly. The logger provides color-coded, semantic logging methods for agents, system events, and errors.
 
+## Writing Conventions
+
+**Never hard-wrap prose.** In Markdown and other prose (docs, `CHANGELOG.md`, PR descriptions, comments), write each paragraph or bullet as a single line and let it soft-wrap. Do not insert manual line breaks to hit a column width — they make edits and diffs noisy. Only code (fenced blocks, indented samples) may span fixed-width lines.
+
 ## Git Workflow
 
 **IMPORTANT**: Only create commits when explicitly requested by the user. Never commit code automatically.


### PR DESCRIPTION
## What & why

Records a writing convention so it's followed consistently across sessions and contributors: prose is never hard-wrapped. Manual line breaks at a column width make edits and diffs noisy (the changelog rewrite in #154 had to undo exactly that).

## How it works

Adds a short **Writing Conventions** section to `CLAUDE.md`: write each paragraph/bullet as a single line and let it soft-wrap in Markdown and other prose (docs, `CHANGELOG.md`, PR descriptions, comments); only code may span fixed-width lines. The daily-changelog automation (#155) already carries the same rule in its generation prompt, so generated entries stay consistent with this.

## Verification

- Docs-only, single section added; the rest of `CLAUDE.md` is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwAANnThcY6v4NXWKca65U)_