### PR TITLE
chore(deps): bump claude-agent-sdk to 0.3.197 to adopt Sonnet 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.195",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.197",
         "@anthropic-ai/sdk": "^0.107.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1076.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -59,22 +59,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.195.tgz",
-      "integrity": "sha512-FVmXu9pvOMbuBKWrF8YsYQdQ/upOpv5rS8lFAnFO5jbyXT/2hN7kEPd2vd2GJpaMvNcO/KptyQUK5AxjjTz3+w==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.197.tgz",
+      "integrity": "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.195"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.195.tgz",
-      "integrity": "sha512-WIMM/8HRCLsTDHFTIwQvvE8WCA/oaMJtdQxsP7iNyfzIGwXbuOyU95V8vYIhZfaO2yaSpbBRncunq4CtR5H4ng==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.197.tgz",
+      "integrity": "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==",
       "cpu": [
         "arm64"
       ],
@@ -96,9 +96,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.195.tgz",
-      "integrity": "sha512-RY7DB+4LXosE0MJ+XELmakfPrDN1YX4lkk9CTDm28jGCVcESRz9kAEqbyaiC48dZcmN9V1NCLutzINGdcr1TBg==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.197.tgz",
+      "integrity": "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==",
       "cpu": [
         "x64"
       ],
@@ -109,14 +109,11 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.195.tgz",
-      "integrity": "sha512-JuIq5Fnz/F1snl0aqi1gcuRZqPWoPNrL9dJ0DuievCxKkO8hnEz/Mmn5Zos7x1X8HE//ZnEvmQXoEQEZXonJew==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.197.tgz",
+      "integrity": "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -125,14 +122,11 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.195.tgz",
-      "integrity": "sha512-ZmyBA/AFzhgutcxb7dbhCm6GTjJytwNYXTxJoKE2B3A409WCYccjMqeji6vCMNxyyfylglGo5D8dVMIxW9aoug==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.197.tgz",
+      "integrity": "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -141,14 +135,11 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.195.tgz",
-      "integrity": "sha512-s1lNi1cL93luoqsItH+fNO4KpIhdkvnVhWGGQUQ/8ftwa2gfmcIQnOg1hG8Ks+KzeD3UUQ8L9YEVHVADnFI/9A==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.197.tgz",
+      "integrity": "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -157,14 +148,11 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.195.tgz",
-      "integrity": "sha512-nf8Q/LauB+ZOC6QDjxNhbsvwUtYjKYnaWJLTYFwhkmsLujePnety1AtT/1ubaUoq5AM1j297DhMlYTasa79OUA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.197.tgz",
+      "integrity": "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -173,9 +161,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.195.tgz",
-      "integrity": "sha512-hbkDE+xPIZzRWm+D+BKrH9uJH6USIZdDIlsyrIlGi3JFHoieYoA1vdUNyldSS9+F3ZqQtfPjr2Qy08IVB6akYA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.197.tgz",
+      "integrity": "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==",
       "cpu": [
         "arm64"
       ],
@@ -186,9 +174,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.195.tgz",
-      "integrity": "sha512-av0piEB3X1Dzhpr8A+DqHVZ9y8s1jpn8enzwX0TKKUPBn5IqLTWC7wD6v66aoUgu4f+g4ThZirmDZA6shyPEZQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.197.tgz",
+      "integrity": "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "npm": ">=11.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.195",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
     "@anthropic-ai/sdk": "^0.107.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1076.0",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/agents/__tests__/model-label.test.ts
+++ b/src/agents/__tests__/model-label.test.ts
@@ -11,12 +11,12 @@ import { modelDisplayLabel, resolveAgentModel } from '../model-label.js';
 describe('modelDisplayLabel', () => {
   it('beautifies the short aliases', () => {
     expect(modelDisplayLabel('opus')).toBe('Opus 4.8');
-    expect(modelDisplayLabel('sonnet')).toBe('Sonnet 4.6');
+    expect(modelDisplayLabel('sonnet')).toBe('Sonnet 5');
     expect(modelDisplayLabel('haiku')).toBe('Haiku 4.5');
   });
 
   it('renders the [1m] marker as (1M)', () => {
-    expect(modelDisplayLabel('sonnet[1m]')).toBe('Sonnet 4.6 (1M)');
+    expect(modelDisplayLabel('sonnet[1m]')).toBe('Sonnet 5 (1M)');
     expect(modelDisplayLabel('opus[1m]')).toBe('Opus 4.8 (1M)');
   });
 
@@ -32,7 +32,7 @@ describe('modelDisplayLabel', () => {
   });
 
   it('is case-insensitive on the [1m] marker and tolerates whitespace', () => {
-    expect(modelDisplayLabel('sonnet[1M]')).toBe('Sonnet 4.6 (1M)');
+    expect(modelDisplayLabel('sonnet[1M]')).toBe('Sonnet 5 (1M)');
     expect(modelDisplayLabel('  opus  ')).toBe('Opus 4.8');
   });
 });

--- a/src/agents/model-label.ts
+++ b/src/agents/model-label.ts
@@ -4,7 +4,7 @@
  * The app passes short aliases (`opus`, `sonnet`, `haiku`) to the Claude Agent
  * SDK, optionally suffixed with `[1m]` to enable the 1M context window (the SDK
  * strips the suffix and adds the `context-1m` beta — see `spawn.ts`). For the
- * footer we beautify these into names like `Opus 4.8` / `Sonnet 4.6 (1M)`:
+ * footer we beautify these into names like `Opus 4.8` / `Sonnet 5 (1M)`:
  * the `claude-` provider prefix is dropped, the family is capitalised, the
  * version is dotted, and the 1M marker is shown as `(1M)`.
  */
@@ -15,7 +15,7 @@ import { isPmAgent } from '../types/agent.js';
 /** Beautified display names for the short aliases the app uses. */
 const MODEL_DISPLAY_NAMES: Record<string, string> = {
   opus: 'Opus 4.8',
-  sonnet: 'Sonnet 4.6',
+  sonnet: 'Sonnet 5',
   haiku: 'Haiku 4.5',
 };
 
@@ -45,7 +45,7 @@ function beautify(model: string): string {
 
 /**
  * Beautified label for a single model string, preserving the 1M-context marker
- * as `(1M)`. Examples: `opus → Opus 4.8`, `sonnet[1m] → Sonnet 4.6 (1M)`,
+ * as `(1M)`. Examples: `opus → Opus 4.8`, `sonnet[1m] → Sonnet 5 (1M)`,
  * `claude-opus-4-8 → Opus 4.8`. Unknown non-Claude ids pass through unchanged.
  */
 export function modelDisplayLabel(model: string): string {


### PR DESCRIPTION
## What & why

We want the specialist/plugin fleet on **Sonnet 5** (native 1M context, frontier-class). Because this codebase selects models by *alias* (`sonnet[1m]` for specialists, `opus` for PM — see `resolveAgentModel` in `src/agents/model-label.ts`), the alias→concrete-model mapping is not ours to set: it lives inside the Claude Code CLI binary that `@anthropic-ai/claude-agent-sdk` bundles. So picking up a new model means bumping the SDK.

`claude-agent-sdk` **0.3.197** tracks Claude Code **v2.1.197**, which is the release that points the `sonnet` alias at Sonnet 5. The current Dependabot group PR (#137) only bumps the SDK to 0.3.195 (Claude Code v2.1.195) — two versions short of Sonnet 5 — so this change carries it the rest of the way.

Scoped to the SDK only. The other three bumps in the `npm-minor-and-patch` group (`@anthropic-ai/sdk`, `@aws-sdk/client-bedrock-runtime`, `@types/node`) are left to #137.

## How it works

- `@anthropic-ai/claude-agent-sdk` `^0.3.187` → `^0.3.197` in `package.json` + lockfile. The lockfile delta is confined to the `claude-agent-sdk` entries and its platform binaries — no other dependency subtree moves.
- **Behavior change to be aware of:** with 0.3.197 the `sonnet` alias resolves to Sonnet 5, so every agent currently on `sonnet[1m]` (all specialists + plugin agents) moves from Sonnet 4.6 to Sonnet 5 on deploy. PM stays on `opus` → Opus 4.8, unchanged.
- Updated the Slack-footer display label for the `sonnet` alias from `Sonnet 4.6` to `Sonnet 5` (and the matching tests) so the model shown to users matches what actually runs. The full-ID beautify cases (`claude-sonnet-4-6-…`) are intentionally left alone — they test the generic formatter, not the alias.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `npx vitest run` — **515/515 tests pass** (incl. updated `model-label` label assertions)
- The 0.3.196/0.3.197 deltas over 0.3.195 are additive/parity only (a new `prompt_id` hook-input field + a control-protocol dedup fix); the new hook field is additive and doesn't affect this repo's hook usage.
- Not verified at runtime: I did not start the app against the live API/Slack, so the actual Sonnet 5 routing is confirmed only by the SDK/CLI version mapping, not an end-to-end run.

## Deployment & follow-ups

- On deploy, specialist/plugin agents begin running Sonnet 5 immediately (no config change needed). Sonnet 5 ships with promotional pricing through Aug 31 per the Claude Code v2.1.197 notes.
- Open question raised separately: whether to also move **PM** off Opus 4.8 onto Sonnet 5 — deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fz4evYnubVQ4f6MMz2bpQR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fz4evYnubVQ4f6MMz2bpQR)_