### PR TITLE
Add temporary [cache] per-turn token-usage logging to verify prompt caching

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -741,6 +741,27 @@ Shared folder: ${sharedPath} [READ-ONLY]
             // tool calls. Best-effort and debounced inside the task.
             task.noteActivityFromEvent(def.id, event);
 
+            // [cache] TEMPORARY debug: log per-turn token usage to verify prompt caching is landing.
+            // Cache reads bill at ~0.1x, cache writes at ~1.25x, uncached input at full price.
+            // Healthy caching shows a large `read` share from turn 2 of a session onward; if `read` stays 0, caching isn't engaging.
+            // `uncached` (input_tokens) is the uncached remainder only — the whole prompt is uncached + read + write.
+            if (event.type === 'result') {
+              const u = (event as any).usage ?? {};
+              const read = u.cache_read_input_tokens ?? 0;
+              const write = u.cache_creation_input_tokens ?? 0;
+              const uncached = u.input_tokens ?? 0;
+              const output = u.output_tokens ?? 0;
+              const prompt = read + write + uncached;
+              const cachedPct = prompt > 0 ? Math.round((read / prompt) * 100) : 0;
+              const cost = (event as any).total_cost_usd;
+              logger.agent(
+                def.id,
+                `[cache] prompt=${prompt} tok (read=${read} write=${write} uncached=${uncached}) ` +
+                  `output=${output} cached=${cachedPct}%` +
+                  (cost != null ? ` cost=$${Number(cost).toFixed(4)}` : ''),
+              );
+            }
+
             // Deferred teardown (report_completion / request_edit_mode / research
             // budget): now that the turn has fully ended (the SDK `result` event),
             // run it. The teardown stops this agent's queue, which closes the input


### PR DESCRIPTION
## What & why

We don't actually know whether prompt caching is landing in the requests the Claude Agent SDK builds. Archie sets no `cache_control` and no cache betas anywhere in `src`, so any caching is entirely the SDK's default behavior — which we neither control nor observe today. This adds a temporary per-turn log so we can measure it on a real workload before deciding whether to take explicit control of caching.

## How it works

On each SDK `result` event in the agent loop (`src/agents/spawn.ts`) it logs one line per turn, per agent, via the existing `logger.agent`:

```
[cache] prompt=<n> tok (read=<n> write=<n> uncached=<n>) output=<n> cached=<pct>% cost=$<n>
```

`read` = `cache_read_input_tokens` (billed ~0.1×), `write` = `cache_creation_input_tokens` (~1.25×), `uncached` = `input_tokens` (full price — the uncached remainder only), and `cached%` = read ÷ whole prompt. `total_cost_usd` is appended when the SDK reports it. All field reads are nullish-guarded, so a missing `usage` just logs zeros. No behavior change beyond the log line.

## How to read it

Run a normal multi-turn task and watch one agent's lines: healthy caching shows `read` becoming a large share of the prompt from turn 2 of a session onward, with `uncached` small. If `read` stays 0 across turns, caching isn't engaging — and the volatile "Current Context" block we append to the end of the system prompt is the prime suspect (we'd then want to take explicit control of the cache breakpoint).

## Verification

`npm run typecheck` passes with 0 errors (deps installed via `npm ci`). The change is log-only, gated on the existing `event.type === 'result'` branch. I could not exercise it against a live task from this environment (no Slack/Anthropic runtime here) — that's the point of the PR: run it locally and report the numbers back.

## Scope / follow-up

Temporary measurement aid, intentionally always-on (no env flag) so it's zero-setup to run locally. Safe to remove once caching is confirmed, or to gate behind a flag / fold into `context-probe.ts` if we decide to keep it. Feeds the "verify prompt caching" issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bynYAZrrZsBACBPobeRkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015bynYAZrrZsBACBPobeRkQ)_