### PR TITLE
ci: add dry-run mode to the daily changelog

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -50,6 +50,11 @@ on:
         description: "Day to summarize (YYYY-MM-DD, UTC). Defaults to yesterday."
         required: false
         type: string
+      dry_run:
+        description: "Preview the drafted entry in the run summary without committing."
+        required: false
+        type: boolean
+        default: false
 
 # Never let two runs edit the changelog at once.
 concurrency:
@@ -173,10 +178,27 @@ jobs:
             echo 'CHANGELOG_ENTRY_EOF'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Preview the drafted entry (dry run)
+        if: steps.gather.outputs.skip == 'false' && github.event.inputs.dry_run == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "### Drafted changelog entry for ${{ steps.gather.outputs.date }} (dry run — not committed)"
+            echo
+            echo "This is exactly what would be spliced into CHANGELOG.md. Re-run with dry_run off to publish it."
+            echo
+            echo '```markdown'
+            cat new-entry.md
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "----- drafted entry (dry run) -----"
+          cat new-entry.md
+
   publish:
     name: Insert and push
     needs: generate
-    if: needs.generate.outputs.skip == 'false'
+    # Skip entirely on a dry run so nothing is committed.
+    if: needs.generate.outputs.skip == 'false' && github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out main (full history)


### PR DESCRIPTION
## What & why

Lets you preview the drafted entry before anything is written to `main` — useful for a first run, or any time you want to eyeball output before it commits.

## How it works

Adds a `dry_run` boolean input to the manual `workflow_dispatch` trigger (default `false`). When checked:

- `generate` runs as usual and drafts the entry, then a preview step renders it in the **run summary** (as a fenced markdown block) and prints it to the step log.
- `publish` is skipped entirely (`if: … && github.event.inputs.dry_run != 'true'`), so nothing is inserted or committed.

Scheduled runs and normal manual runs are unaffected — `dry_run` is absent/false, so `publish` runs as before.

## Verification

- Workflow YAML parses; the new input, the preview step, and the `publish` guard are all present and correctly wired.
- Logic check: on `schedule`, `github.event.inputs.dry_run` is empty → `!= 'true'` → `publish` runs; with the box checked → `== 'true'` → preview only, `publish` skipped.

## How to use

Actions → **Daily changelog** → **Run workflow** → leave `date` blank (defaults to yesterday) → tick **dry_run** → Run. Open the run's **Summary** to read the drafted entry. Happy with it? Run again with `dry_run` unticked to publish.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwAANnThcY6v4NXWKca65U)_