### PR TITLE
ci: tune changelog prompt to consolidate minor plumbing

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -149,13 +149,19 @@ jobs:
               trailing `_Technical: …_` clause.
             - A change that is pure plumbing with no user-facing value stays purely technical:
               write it as an italic `_Technical: …_` bullet with no bold business lead.
+            - Consolidate the long tail: fold minor plumbing — chores, dependency bumps,
+              CI / tooling / dev-environment fixes — into one or two combined `_Technical: …_`
+              bullets rather than giving each its own. Reserve a standalone bullet for a change
+              with real user value or notable engineering significance.
+            - Aim for the most important 3–6 bullets on a typical day; group the rest.
             - Write each bullet on a SINGLE line — never hard-wrap prose across multiple lines.
               Only fenced code may span lines.
             - Be concise and faithful. Never invent a change that is not in `context.md`.
 
             Then self-review your draft before saving: does every bullet either lead with real
-            user value or stand as an explicit `_Technical:_` note? Is anything invented or
-            mis-summarized versus `context.md`? Are related changes grouped? Revise, then save.
+            user value or stand as an explicit `_Technical:_` note? Is the minor plumbing
+            consolidated rather than one bullet per chore? Is anything invented or mis-summarized
+            versus `context.md`? Are related changes grouped? Revise, then save.
 
             Write ONLY the finished entry to a new file named `new-entry.md`.
             Do NOT modify CHANGELOG.md or any other file.


### PR DESCRIPTION
## What & why

The first real run drafted a solid, accurate entry but with ~10 bullets — one per change, including every minor chore (healthcheck fix, issue-form cleanup, dep bumps, each as its own bullet). Correct, but denser than the house style, which folds the long tail of plumbing into a combined `_Technical:_` bullet (see the 06-25 entry).

## How it works

Adds two rules to the generation prompt (no pinned example — the model already reads the full `CHANGELOG.md` for style):

- Consolidate minor plumbing (chores, dependency bumps, CI / tooling / dev-environment fixes) into one or two combined `_Technical:_` bullets; reserve standalone bullets for changes with real user value or notable engineering significance.
- Soft target of 3–6 bullets on a typical day, grouping the rest.

Also extends the self-review step to check for that consolidation.

## Verification

- Workflow YAML parses.
- Behavioral change only (prompt text); best confirmed with a `dry_run` re-run after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwAANnThcY6v4NXWKca65U)_