### PR TITLE
ci: group changelog technical bullets by theme (cap at three)

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -149,19 +149,25 @@ jobs:
               trailing `_Technical: …_` clause.
             - A change that is pure plumbing with no user-facing value stays purely technical:
               write it as an italic `_Technical: …_` bullet with no bold business lead.
-            - Consolidate the long tail: fold minor plumbing — chores, dependency bumps,
-              CI / tooling / dev-environment fixes — into one or two combined `_Technical: …_`
-              bullets rather than giving each its own. Reserve a standalone bullet for a change
-              with real user value or notable engineering significance.
+            - Consolidate the long tail of minor plumbing (chores, dependency bumps,
+              CI / tooling / dev-environment fixes) into `_Technical: …_` bullets, grouped by
+              theme. Prefer a single combined bullet; split into a separate `_Technical:_`
+              bullet only when the changes are genuinely unrelated (e.g. a docs/process change
+              vs. a runtime fix vs. dependency bumps). Never exceed three technical-only bullets:
+              don't give every chore its own, and don't cram unrelated changes into one
+              run-on line either.
+            - Reserve a standalone bullet for a change with real user value or notable
+              engineering significance.
             - Aim for the most important 3–6 bullets on a typical day; group the rest.
             - Write each bullet on a SINGLE line — never hard-wrap prose across multiple lines.
               Only fenced code may span lines.
             - Be concise and faithful. Never invent a change that is not in `context.md`.
 
             Then self-review your draft before saving: does every bullet either lead with real
-            user value or stand as an explicit `_Technical:_` note? Is the minor plumbing
-            consolidated rather than one bullet per chore? Is anything invented or mis-summarized
-            versus `context.md`? Are related changes grouped? Revise, then save.
+            user value or stand as an explicit `_Technical:_` note? Is the minor plumbing grouped
+            by theme into at most three technical bullets — neither one-per-chore nor a single
+            run-on dump? Is anything invented or mis-summarized versus `context.md`? Are related
+            changes grouped? Revise, then save.
 
             Write ONLY the finished entry to a new file named `new-entry.md`.
             Do NOT modify CHANGELOG.md or any other file.


### PR DESCRIPTION
## What & why

The earlier "one or two combined bullets" rule over-corrected: a run folded *everything* — a 30-day changelog rewrite, issue-template cleanup, a port-resolution fix, a healthcheck, and dependency bumps — into a single run-on `_Technical:_` bullet, even though those aren't related. That reads as badly as the original one-bullet-per-chore version.

## How it works

Reframes the consolidation rule around **cohesion, not count**:

- Group minor plumbing into `_Technical:_` bullets **by theme** — prefer a single combined bullet, but split into a separate one when changes are genuinely unrelated (e.g. a docs/process change vs. a runtime fix vs. dependency bumps).
- **Never exceed three** technical-only bullets — so neither one-per-chore fragmentation nor a single dumping-ground line.

The self-review step is updated to check for exactly this.

## Verification

- Workflow YAML parses.
- Prompt-only change; best confirmed with a `dry_run` re-run after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwAANnThcY6v4NXWKca65U)_