### PR TITLE
Forge: proposal + /forge skill skeleton (idea → verified PR loop)

### DIFF
--- a/.claude/commands/forge.md
+++ b/.claude/commands/forge.md
@@ -1,0 +1,21 @@
+---
+name: "Forge"
+description: Run the Forge loop — idea, issue, or PR in; verified, tested pull request out
+category: Workflow
+tags: [workflow, verification, forge]
+---
+
+Run the Forge development loop on one unit of work.
+
+**Usage**
+
+- `/forge <idea text>` — full run from inception
+- `/forge issue <n>` — seed inception from a GitHub issue
+- `/forge pr <n>` — finish, verify, and ship an existing PR
+- `/forge resume` — continue the active run from its recorded stage
+- `/forge abandon` — mark the active run abandoned (unblocks the one-run-at-a-time guard)
+
+**Steps**
+
+1. Load the `forge` skill and follow it as the orchestrator playbook.
+2. Pass the argument after `/forge` as the invocation input. If no argument was given, ask the user what to forge (an idea, an issue number, or a PR number).

--- a/.claude/skills/forge/SKILL.md
+++ b/.claude/skills/forge/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: forge
+description: Run the Forge loop — take an idea, GitHub issue, or existing PR and produce a verified, tested pull request through staged, adversarially-verified development. Use when the user invokes /forge or asks to run Forge on an idea, issue, or PR. Design rationale lives in docs/proposals/forge.md.
+---
+
+# Forge — orchestrator playbook
+
+You are the Forge orchestrator. You take one unit of work (an idea, an issue, or an existing PR) through staged development to a verified pull request. You coordinate; fresh-context subagents do the verification. Full design rationale: `docs/proposals/forge.md`.
+
+## Ground rules
+
+- **One run at a time.** Run state lives on the run's branch, so scan more than the working tree: check `openspec/changes/*/forge.yaml` here AND on every `forge/*` branch, local and remote (`git branch --list 'forge/*'`, `git ls-remote --heads origin 'forge/*'`, then `git show <branch>:openspec/changes/<change>/forge.yaml`). If an active run (stage not `done`/`abandoned`) exists anywhere, tell the user and offer to resume or abandon it. Never run two in parallel.
+- **Fresh context for every verifier.** Spawn verification roles as subagents (Task tool) whose prompt contains ONLY: the role instructions from the stage file, paths to the artifacts they may read, and the output contract. Never include your conversation history, your reasoning, or the authoring agent's rationale. The rings get progressively blinder — respect each stage's stated inputs exactly.
+- **Capped loops.** Each stage file states its revision cap (2–3 rounds). When a cap is hit with unresolved findings, stop and present the impasse to the user rather than looping.
+- **Structured verdicts.** Every verification pass must end in an explicit verdict written to the change dir (`verdicts/<role>-round<N>.md`) and reflected in `forge.yaml`. A pass with no written verdict did not happen.
+- **Two human gates.** Inception sign-off and the merge decision. Everything between runs autonomously; come back to the user only for an unverifiable AC, a genuine scope change, or a hit cap.
+- **Persist before proceeding.** Update `forge.yaml` and commit artifacts to the run's branch at every stage boundary, so `/forge resume` always works. Invoking `/forge` IS the user's explicit request to commit on the run's branch (this satisfies the repo CLAUDE.md commit rule); it is never license to commit outside that branch.
+- **Forge state is not scope creep.** Everything under `openspec/changes/<change>/` is run state, committed with `forge(<change>): …` messages. Reviewers exclude it from scope-creep judgment, and in `pr` mode these commits will appear in the PR's diff — that's intentional transparency, but if the PR's author isn't Archie or the operator, flag it to the user before committing state there.
+
+## Run state: `forge.yaml`
+
+Lives at `openspec/changes/<change>/forge.yaml`:
+
+```yaml
+run: <change-name>                # kebab-case, matches the change dir
+source: { type: idea|issue|pr, ref: "<text | issue number | PR number>" }
+repo: sweatco/archie-hq           # target repo. Run state ALWAYS lives in archie-hq's openspec/changes/, even when implementation targets archie-plugins (sibling checkout, its own branch)
+branch: <feature branch>
+stage: inception                  # inception | research | plan | implement | qa | ship | done | abandoned
+stage_rounds: {}                  # e.g. { plan: 2, implement: 1 } — revision rounds consumed
+acceptance_criteria:              # written at inception; statuses updated by QA/ship
+  - id: AC1
+    text: "<observable behavior>"
+    method: unit|integration|live-e2e|manual|deploy-only
+    status: pending               # pending | verified | waived | failed
+    evidence: null                # path or link once verified; named post-merge step if waived
+pr: null                          # PR number once opened
+```
+
+## Change directory
+
+The run's artifacts live in `openspec/changes/<change>/`: `proposal.md`, `design.md`, `tasks.md`, `specs/` (OpenSpec artifacts), plus Forge's additions — `brief.md` (inception), `research.md` (dossier), `verification-plan.md`, `verdicts/`, `qa-evidence/`, and `forge.yaml`.
+
+If the `openspec` CLI is on PATH, scaffold and validate the OpenSpec artifacts with it (as `/opsx:propose` does: `openspec new change`, `openspec status --json`, `openspec instructions <artifact> --json`). If not, create the same files by hand following the structure of `openspec/changes/archive/2026-07-01-debug-mcp-wait-for-task/` — do not block on the CLI.
+
+## Entry points
+
+Parse the invocation input:
+
+- **Idea text** → full run from Stage 0.
+- **`issue <n>`** → fetch the issue (GitHub MCP or `gh`); its body seeds the Stage 0 interview. Derive the change name from the issue title.
+- **`pr <n>`** → finish-this-PR mode. Check out the PR's branch. Stage 0 runs as **reverse inception**: reconstruct the brief and ACs from the PR description, linked issues, and diff; ask the user to confirm gaps ("what would make you comfortable merging this?"). Reverse inception also writes `verification-plan.md` (Stage 2 is skipped, and Stage 4 requires it). Then skip Stages 1–2 unless the reconstruction exposes an unresolved design question, and run Stages 3→5 (finish, verify, QA, ship). The change dir is named `pr-<n>-<slug>`.
+- **`resume`** → locate the active run (same cross-branch scan as the one-run rule), check out its branch, report where it stands, and continue from `stage`.
+- **`abandon`** → locate the active run, confirm with the user, set `stage: abandoned` and commit — this is the only way the one-run guard unblocks without finishing.
+
+## Stage sequence
+
+Work through the stage files in order, in this skill's `stages/` directory. Each file is self-contained: purpose, inputs, procedure, verification passes (with the exact subagent role prompts), exit criteria, and state updates.
+
+1. `stages/0-inception.md` — interactive interview → `brief.md` with numbered, testable ACs. **Human sign-off gate.**
+2. `stages/1-research.md` — parallel research lenses → `research.md`, adversarially fact-checked.
+3. `stages/2-plan.md` — OpenSpec artifacts + `verification-plan.md`; completeness critic + red team; published to the user, **not** a gate.
+4. `stages/3-implement.md` — execute `tasks.md`; spec-compliance reviewer + adversarial bug hunt with mutation-checked tests.
+5. `stages/4-qa.md` — black-box QA against a live instance via the archie-debug MCP; independent verdict reviewer. Degrades to explicit waivers when the E2E harness or docker isn't available.
+6. `stages/5-ship.md` — house-style PR with the verification manifest; CI watch; **human merge gate**; post-merge archive.
+
+Read a stage file when you reach that stage — do not preload all of them.
+
+## Git discipline
+
+- Create the run's feature branch off the base branch at Stage 0 (`forge/<change-name>`, or reuse the PR's branch in `pr` mode). Record it in `forge.yaml`.
+- Commit artifacts at stage boundaries with `forge(<change>): <stage> — <summary>` messages; implementation commits follow the repo's normal conventions.
+- Never force-push someone else's branch; in `pr` mode rebase only with the user's knowledge if the branch is shared.

--- a/.claude/skills/forge/stages/0-inception.md
+++ b/.claude/skills/forge/stages/0-inception.md
@@ -1,0 +1,31 @@
+# Stage 0 — Inception
+
+**Purpose:** turn a raw idea, issue, or PR into a signed-off brief whose acceptance criteria are the contract every later stage verifies against.
+
+**Inputs:** the invocation input (idea text / issue body / PR description + linked issues + diff summary).
+
+**Output:** `brief.md` in the change dir, plus the `acceptance_criteria` block in `forge.yaml`.
+
+## Procedure
+
+You are the interviewer. Interview the user until the brief is unambiguous. Ask in small batches (AskUserQuestion or plain chat), never a wall of questions. Do **web research** instead of asking when an external fact answers better than the user can (SDK capabilities, API limits, third-party behavior) — cite sources in the brief.
+
+The brief must contain:
+
+- **Problem** — what's wrong or missing, in the user's terms.
+- **Goals / Non-goals** — non-goals are load-bearing; scope creep at Stage 3 is judged against them.
+- **Constraints** — architectural, security, compatibility, deadline.
+- **Affected repos** and rough blast radius; risk class (docs-only / plugins-only / engine / engine+migration).
+- **Acceptance criteria** — numbered, each one *observable* ("WHEN X THEN Y", not "should work well"). For each AC, force the verification method now: `unit`, `integration`, `live-e2e` (dockerized instance driven via archie-debug MCP), `manual`, or `deploy-only` (name the post-merge step). If you can't state how an AC would be verified, it isn't an AC yet — rework it with the user.
+
+Ask explicitly: "how would we know this works end to end?" — the answer usually surfaces the ACs the user actually cares about.
+
+### Reverse inception (`pr` mode)
+
+Reconstruct the same brief from the PR: description (What & why / Verification sections), linked issues, the diff, and review comments. Mark every reconstructed item as **inferred** and have the user confirm or correct it. Always ask: "what would make you comfortable merging this?" — their answer becomes ACs. Pay special attention to the PR's own "couldn't verify" admissions: each becomes an AC with method `live-e2e` or an explicit `deploy-only` waiver.
+
+Because Stage 2 is normally skipped in `pr` mode, reverse inception also writes `verification-plan.md`: the AC table expanded with the concrete scenario/check that will produce each AC's evidence and where the evidence will live (Stage 4 requires this file).
+
+## Exit criteria (human gate)
+
+Present the brief compactly and get explicit user sign-off. Record ACs in `forge.yaml`, set `stage: research` (or `implement` in `pr` mode with no open design questions), create the branch, commit `brief.md`.

--- a/.claude/skills/forge/stages/1-research.md
+++ b/.claude/skills/forge/stages/1-research.md
@@ -1,0 +1,28 @@
+# Stage 1 — Research
+
+**Purpose:** ground the plan in verified facts about the codebase, prior art, constraints, and (when flagged) the outside world.
+
+**Inputs:** `brief.md`. **Output:** `research.md` (the dossier) — only claims that survived the refutation pass.
+
+## Procedure
+
+Spawn the applicable lenses **in parallel** as fresh-context subagents. Each gets: the brief, its lens instructions below, and the output contract "return findings as a list of factual claims, each with a `file:line` citation or source URL; flag uncertainty explicitly."
+
+- **Codebase mapper** — which subsystems the brief touches, the existing patterns to follow (with `file:line`), the tests that cover the area today, and the seams the change should use. Read `docs/architecture/` first.
+- **Prior-art scanner** — open PRs, recently closed PRs, open issues, `docs/plans/`, `docs/proposals/`, and `openspec/changes/archive/`. Goal: nothing in flight collides with or already solves this; name anything the plan should build on or supersede.
+- **Constraints scanner** — architecture docs, `docs/architecture/security.md`, sandbox rules, edit-mode gate, plugin spec compliance. Return the constraints the design must not violate.
+- **Web researcher** (only when the brief flags external unknowns) — upstream SDK/API docs and changelogs; every claim cited with a URL.
+
+Merge the findings into `research.md`, keeping citations.
+
+## Verification pass (1 round)
+
+Spawn a **research verifier** (fresh context) with this role:
+
+> You are an adversarial fact-checker. Input: `research.md` and read access to the repo. For each factual claim, try to REFUTE it against the actual code or the cited source. Verdict per claim: CONFIRMED (you saw it yourself) / WRONG (say what's actually there) / UNVERIFIABLE (no citation, or citation doesn't support it). Do not evaluate the design direction — facts only.
+
+Write the verdict to `verdicts/research-verifier-round1.md`. Delete WRONG claims, fix or delete UNVERIFIABLE ones (re-check yourself; keep only what you can now cite). Research that hallucinates poisons every later stage — be ruthless here.
+
+## Exit criteria
+
+Dossier contains only CONFIRMED claims. Commit `research.md` + verdict, set `stage: plan`.

--- a/.claude/skills/forge/stages/2-plan.md
+++ b/.claude/skills/forge/stages/2-plan.md
@@ -1,0 +1,29 @@
+# Stage 2 — Plan
+
+**Purpose:** produce the OpenSpec plan artifacts plus a verification plan, hardened by two different critics. The plan is **published, not gated** — the run proceeds after publishing.
+
+**Inputs:** `brief.md` + `research.md` (nothing else — the planner must not see the interview or your reasoning).
+
+**Outputs:** `proposal.md`, `design.md`, `tasks.md`, `specs/<capability>/spec.md` (OpenSpec shapes), and `verification-plan.md`.
+
+## Procedure
+
+Spawn a **planner** subagent with the brief + dossier. It writes the OpenSpec artifacts (use the `openspec` CLI scaffolding/templates when available; otherwise follow the archived-change structure) and `verification-plan.md`: a table mapping every AC id → verification method → the concrete scenario/check that will produce the evidence → where the evidence will live. `tasks.md` items must be small, ordered, and independently checkable (typecheck/tests per task).
+
+## Verification loop (2 critics, cap: 3 rounds)
+
+Spawn both critics **concurrently**, fresh-context, inputs = brief + dossier + the plan artifacts only.
+
+**Completeness critic:**
+
+> You verify a plan covers its contract. Inputs: brief (with ACs), research dossier, plan artifacts. For each AC: is it fully satisfied by the design, and does the verification plan give it a concrete, evidence-producing check? Then hunt for what's missing: edge cases, error paths, migrations for persisted state, rollback, recovery/restart interactions, docs the repo expects. Verdict: PASS, or a numbered list of gaps, each tagged blocking/non-blocking.
+
+**Red team:**
+
+> You try to kill this plan. Inputs: brief, dossier, plan artifacts. Attack: (1) blast radius — what else does this touch that the plan doesn't mention? (2) security & sandbox — does anything widen access or violate the constraints in the dossier? (3) simplicity — propose a materially simpler design that meets all ACs; if you can, the plan is over-engineered. (4) "what will this break that no test covers?" Verdict: PASS, or numbered objections, each tagged blocking/non-blocking.
+
+Feed blocking findings back to the planner for revision; re-run only the critic(s) whose findings were addressed. Track rounds in `forge.yaml` `stage_rounds.plan`. If blocking findings survive round 3, stop and take the impasse to the user.
+
+## Exit criteria
+
+Both critics PASS (or only non-blocking notes remain — record them in `design.md` under "Known trade-offs"). **Publish**: post a compact summary of the plan to the user (goal, approach, task count, verification plan highlights, known trade-offs) and proceed without waiting. Commit artifacts + verdicts, set `stage: implement`.

--- a/.claude/skills/forge/stages/3-implement.md
+++ b/.claude/skills/forge/stages/3-implement.md
@@ -1,0 +1,29 @@
+# Stage 3 — Implement
+
+**Purpose:** execute the plan task by task, then verify the diff with two blind reviewers.
+
+**Inputs:** the plan artifacts (`tasks.md` is the contract). In `pr` mode with skipped stages: the reconstructed brief + the existing diff; write a minimal `tasks.md` for the remaining work first.
+
+## Procedure
+
+Implement `tasks.md` **sequentially**. Per task: make the change, run typecheck and the targeted tests for the touched area, flip the checkbox `- [ ]` → `- [x]`, commit. A crashed or resumed run restarts at the first unchecked task. Follow the repo's own conventions (`CLAUDE.md`, surrounding code style); new behavior gets new tests alongside it.
+
+When all tasks are checked: run the full gate — `npm run typecheck`, `npm run build`, `npm test` — and fix anything red before review.
+
+## Verification loop (2 reviewers, cap: 3 rounds)
+
+Spawn both **concurrently**, fresh-context. Inputs: the plan artifacts and the diff (`git diff <base>...HEAD`) — never the implementer's reasoning or this conversation.
+
+**Spec-compliance reviewer:**
+
+> You check a diff against its plan. Inputs: plan artifacts (brief ACs, design, tasks) and the diff. Verify: every task's change is actually present; every code-level claim implied by the ACs is true in the diff; and — equally important — nothing in the diff goes BEYOND the plan (unrequested refactors, drive-by changes, scope creep are defects; the brief's non-goals are binding). Exception: files under `openspec/changes/<change>/` are Forge run state — ignore them entirely. Verdict: PASS or numbered findings, each blocking/non-blocking, each citing `file:line`.
+
+**Adversarial bug hunter:**
+
+> You hunt for real bugs in a diff. Inputs: the diff, read access to the repo, permission to run typecheck/tests. Look for: logic errors, unhandled error paths, races/lifecycle issues (spawn/stop/resume/recovery interactions are this codebase's classic failure mode), broken invariants in persisted state, and test theater. For each NEW test in the diff, mutation-check it: mentally (or actually) revert the fix it guards and confirm the test would fail; a test that passes either way is a finding. Classify each finding CONFIRMED (you can state the failing input/sequence) or PLAUSIBLE. Verdict: PASS or numbered findings with `file:line`.
+
+Fix blocking findings, re-run the affected reviewer. Track `stage_rounds.implement`. Impasse after round 3 → user.
+
+## Exit criteria
+
+Clean typecheck/build/full suite; both reviewers PASS. Commit verdicts, set `stage: qa`.

--- a/.claude/skills/forge/stages/4-qa.md
+++ b/.claude/skills/forge/stages/4-qa.md
@@ -1,0 +1,35 @@
+# Stage 4 — QA
+
+**Purpose:** black-box verification of the acceptance criteria against a live instance, by roles that have never seen the code.
+
+**Inputs for QA roles:** ONLY `brief.md` (the ACs) and `verification-plan.md`. Not the diff, not the design, not this conversation. This blindness is the point.
+
+## Preflight
+
+Check what's available in this environment:
+
+- The **E2E harness skill** (look for `.claude/skills/archie-e2e/` or a successor named in `verification-plan.md`). Until it exists, `live-e2e` ACs cannot be machine-verified — see Degradation below.
+- **Docker**: `docker compose version` works and a `.env` with the required keys exists.
+- The **archie-debug MCP** (`.mcp.json` → `archie-debug`).
+
+## Procedure (when live QA is possible)
+
+Spawn the **QA runner**, fresh-context:
+
+> You are a black-box QA engineer. Inputs: the acceptance criteria and the verification plan; the archie-debug MCP; docker. You have NOT seen the implementation and must not read the diff. For each AC with method `live-e2e` or `integration`: (1) boot the system under test from this branch (`docker compose up --build -d`, wait for `/health` healthy; prefer the cheap-model env preset if the repo defines one); (2) execute the plan's scenario — plant a nonce in the task message, `create_task`, `wait_for_task`, approve edit mode via `approve` when the gate fires, read the knowledge log and events; (3) record evidence per AC into `qa-evidence/<AC-id>/` — the exact assertions checked, event/log excerpts, pass/fail. `unit`/`integration` ACs already covered by the suite: record the test file + case name as evidence. Tear down when done (`docker compose down`). Report per-AC: VERIFIED (evidence attached) / FAILED (repro attached) / BLOCKED (say what's missing).
+
+Then spawn the **QA verdict reviewer**, fresh-context:
+
+> You audit QA evidence. Inputs: acceptance criteria, verification plan, `qa-evidence/`. For each AC, judge whether the recorded evidence actually demonstrates the criterion — not whether the runner says it does. Rule each: VERIFIED / UNCONVINCING (evidence doesn't show what's claimed) / WAIVED-OK (a declared waiver with a credible named post-merge step). Verdict to `verdicts/qa-reviewer-round1.md`.
+
+FAILED or UNCONVINCING ACs route back to Stage 3 with the failing scenario attached (set `stage: implement` and reset `stage_rounds.implement` to 0 — new findings, fresh review budget). At most 2 QA cycles per run; a third failure goes to the user. Keep the failing scenario: copy it into `qa-evidence/regressions/` — future runs replay these.
+
+**Mapping onto `forge.yaml` statuses** (the only vocabulary that persists): runner VERIFIED + reviewer VERIFIED → `verified`; suite-covered (a named test case exists — this also settles `integration` ACs that the suite already exercises; otherwise the runner executes them) → `verified` with the test name as evidence; runner BLOCKED or reviewer WAIVED-OK → `waived` with the named step; runner FAILED or reviewer UNCONVINCING → `failed` (routes back). ACs with method `manual` → ask the user to perform the check now, else `waived` with the step named. `deploy-only` → `waived`.
+
+## Degradation (no harness / no docker / no keys)
+
+Do not fake it. For each AC that cannot be machine-verified here, set `status: waived` in `forge.yaml` with a **named** verification step ("run scenario X after deploy", "verify on local docker via Y") in `evidence`. Waivers surface verbatim in the PR's verification manifest — the existing house convention of candor, as structured output. If EVERY live AC is waived, say so plainly to the user before shipping.
+
+## Exit criteria
+
+Every AC is verified / waived-with-named-step / covered-by-suite, and the verdict reviewer signed off on the evidence. Update AC statuses in `forge.yaml`, commit evidence + verdicts, set `stage: ship`.

--- a/.claude/skills/forge/stages/5-ship.md
+++ b/.claude/skills/forge/stages/5-ship.md
@@ -1,0 +1,17 @@
+# Stage 5 — Ship
+
+**Purpose:** open (or update) the PR with the verification manifest, get it green, and hand the merge decision to the user.
+
+## Procedure
+
+1. **Assemble the PR body** per the repo's `.github/PULL_REQUEST_TEMPLATE.md` (What & why / How it works / Verification / Deployment & follow-ups). The Verification section is the **manifest**: a table of every AC — id, criterion, method, status (`verified`/`waived`, per `forge.yaml`), and evidence (link into `qa-evidence/` on the branch, test case name, or the named post-merge step for waivers). Candor over polish: a waiver stated plainly beats an implied pass. Link the change dir (`openspec/changes/<change>/`) as the plan artifact.
+2. **Push and open the PR** (or update the existing one in `pr` mode) as ready for review. Record the number in `forge.yaml`.
+3. **Watch CI.** On failure: diagnose, fix on the branch, push — re-running the Stage 3 reviewers only if the fix is more than mechanical. On persistent unrelated-looking failure, report to the user rather than force-fixing someone else's breakage.
+4. **Address review feedback.** Reviewer comments route like QA failures: trivial → fix directly; substantive → back through Stage 3's reviewers; scope-changing → back to the user. If a human pushes fixes to the branch directly, treat their diff as ground truth — never revert it; reconcile the plan artifacts to match.
+5. **Merge gate (human).** Never merge without the user's explicit go — per-repo policy may add stricter rules (multiple approvals, manual rollout), which always win.
+
+## Post-merge
+
+- Archive the OpenSpec change (fold spec deltas into `openspec/specs/`; `openspec archive` when the CLI exists, else move to `openspec/changes/archive/<date>-<change>/`).
+- File follow-up issues for every waived AC that has a real post-merge step, so waivers don't evaporate.
+- Set `stage: done`.

--- a/docs/proposals/forge.md
+++ b/docs/proposals/forge.md
@@ -1,0 +1,127 @@
+# Proposal: Forge — idea → verified PR development loop
+
+> **Status:** Accepted — not yet implemented
+
+## Summary
+
+Forge is a staged development process that takes an idea — described in chat, filed as a GitHub issue, or embodied in an existing PR — and produces a verified, end-to-end-tested pull request. It runs as a Claude Code harness in this repo (skills + a `/forge` command + persisted per-run state), reusing three assets that already exist: **OpenSpec** as the plan artifact store, the **archie-debug MCP + REST API** as the headless E2E driver, and the **QA plugin's analyst → independent-reviewer pattern** as the verification model. Forge is the intended basis of Archie's future self-improvement loop: once stable as a local workflow, it ports into Archie itself (`archie-agent` already mounts both `archie-hq` and `archie-plugins`).
+
+The name: raw idea in, forged into a tested artifact out. Commands read naturally as verbs — `/forge <idea>`, `/forge issue 150`, `/forge pr 112`, `/forge resume`.
+
+## Motivation
+
+Analysis of the 30 most recently merged PRs shows a consistent de-facto verification contract — typecheck + full vitest count + targeted new tests, then a candid "couldn't verify here" section — and five recurring gaps that get deferred to "confirm on deploy": the Slack round-trip, live SDK runtime behavior, GitHub Actions workflows, GitHub platform rendering, and production-only state. PR #132 exists solely to observe in production what #129 could not verify pre-deploy. Meanwhile the best PRs already do informally what Forge systematizes: #125 ran a 2-round design review plus an independent subagent review, #129 had an adversarial review pass, #138 mutation-checked its tests, #158 was verified live against a running instance.
+
+The pieces of this process exist but are disconnected: OpenSpec captures plans but nothing drives implementation from them under verification; the QA plugin has a genuine two-pass review loop but it is advisory and never gates engineering work; the debug MCP can drive a live instance but no workflow uses it routinely; idea intake (`sweatcoin-idea-proposal`) dead-ends at a Notion row. Issues #160 (in-sandbox checks), #152 (built-in tool support), #147/#148 (plan mode + artifact UI), #143 (auto-review on Archie PRs), and #139 (merge policy) are all fragments of this same loop.
+
+## Goals
+
+- One repeatable process from idea to verified, tested, mergeable PR — quick and predictable in cost and shape.
+- Every stage produces a persisted artifact, so a run is resumable and the process can be entered at any stage (including "finish and verify this existing PR").
+- Verification is performed by fresh-context subagents with distinct roles, never by the author of the thing being verified, to counter model self-bias.
+- Exactly two human touchpoints in the normal path: inception sign-off and the merge decision. The plan is published for visibility but does not block the run.
+
+## Non-goals (for the initial version)
+
+- Automatic launch on PR-opened / issue-opened webhooks (later phase, see Rollout).
+- Moving the inception interview into GitHub issue conversations (depends on issue tools, #150).
+- Automatic rebase-and-resolve of sibling PRs on merge (later phase).
+- Running inside Archie's production agents (port after the local workflow is proven).
+
+## The stages
+
+Run state lives in the OpenSpec change directory (`openspec/changes/<change>/`) plus a small `forge.yaml` recording the current stage, verdicts, and evidence links. Every artifact is committed with the change.
+
+### Stage 0 — Inception (interactive)
+
+Input: an idea, an issue number, or a PR number. An interviewer role produces an **inception brief**: problem, goals, non-goals, constraints, affected repos, risk class, and — the load-bearing part — **numbered, testable acceptance criteria**. The ACs written here are the contract every later stage verifies against; final QA checks these, not the implementer's claims. For each AC the interviewer forces the verification method to be declared up front: unit / integration / live-instance E2E / deploy-only-with-named-post-merge-step. The interviewer asks the user questions until requirements are unambiguous, and may perform **web research** where an external fact is load-bearing (SDK capabilities, Slack API limits, third-party service behavior) rather than asking the user something the web answers better. Ends with user sign-off on the brief — the first of the two human gates.
+
+### Stage 1 — Research
+
+Parallel fresh-context subagents, each with a distinct lens:
+
+- **Codebase mapper** — subsystems touched, existing patterns to follow, `file:line` citations mandatory.
+- **Prior-art scanner** — open PRs, closed PRs, issues, `docs/plans`, `docs/proposals`, the openspec archive. Prevents re-doing in-flight work or colliding with open PRs.
+- **Constraints scanner** — architecture docs, security model, sandbox rules.
+- **Web researcher** (when the brief flags external unknowns) — upstream SDK/API documentation and changelogs, with sources cited. Recent merged PRs repeatedly hinged on exactly this class of fact (SDK version→model mapping in #157, cache TTL semantics in #166).
+
+Then one verification pass: an adversarial checker re-reads the dossier and tries to refute each factual claim against the actual code or cited source; unverifiable claims are cut. Research that hallucinates poisons everything downstream — this is the cheapest place to catch it. Output: research dossier in the change dir.
+
+### Stage 2 — Plan
+
+A planner (fresh context; input = brief + dossier only) produces the OpenSpec artifacts — `proposal.md`, `design.md`, `tasks.md`, spec deltas — plus a **verification plan** mapping every AC to its method and expected evidence. Two verification passes by *different* critics:
+
+- **Pass A — completeness critic**: does the design satisfy every AC? Missing edge cases, migrations, rollback, recovery-path interactions?
+- **Pass B — red team**: fresh context, instructed to refute — blast radius, security, a simpler-alternative challenge to fight overengineering, and "what does this break that no test covers?"
+
+The planner revises; the loop is capped at 3 rounds. The finished plan is **published to the user but does not block**: the run proceeds directly into implementation. The user can interrupt and redirect at any time; the artifact also satisfies the plan-visibility ask in #147 and, post-merge, archives into `openspec/specs/` as living system documentation.
+
+### Stage 3 — Implement
+
+An implementer works through `tasks.md` sequentially, running typecheck + targeted tests per task and flipping checkboxes (a crashed run resumes at the first unchecked task). Then two verification passes by fresh-context reviewers who see **the diff and the plan, never the implementer's reasoning**:
+
+- **Pass 1 — spec compliance**: every task done, every AC's code-level claim true, nothing beyond the plan (scope creep is a defect).
+- **Pass 2 — adversarial bug hunt**: correctness review with a confirm/refute verdict per finding, including **mutation-checking new tests** (revert the fix, assert the test fails — codifying what #138 did by hand).
+
+Findings route back to the implementer; capped at 3 rounds. Exit: clean typecheck, build, full suite, both reviewers pass.
+
+### Stage 4 — QA (black-box, live instance)
+
+The QA runner receives *only* the inception ACs and the verification plan — mirroring the QA plugin's deliberate-ignorance principle — and:
+
+1. **Boots the system under test from the branch**: `docker compose up --build`, wait for `/health` healthy, seeded with a reproducible workdir fixture.
+2. **Drives real scenarios** through the archie-debug MCP: plant a nonce, `create_task`, `wait_for_task`, approve edit mode via `POST /api/tasks/:id/approve` when the gate fires, read the knowledge log and event JSONL, assert each AC against observed behavior. This exercises the real SDK, real agent spawns, real persistence — the exact category merged PRs kept deferring.
+3. **Records evidence per AC**: event excerpts, log lines, health output. ACs that genuinely cannot be verified locally (Slack rendering, prod-only state) are declared as waived with a named post-merge step — the existing candor convention, but as structured output.
+4. **Second pass — QA verdict reviewer** (qa-reviewer pattern): independently reads the evidence and rules each AC verified / unverified / waived.
+
+Failures route back to Stage 3 with the failing scenario attached, and the scenario is kept as a regression fixture for future runs — the seed of an accumulating eval suite and the self-improvement flywheel.
+
+### Stage 5 — Ship
+
+Assemble the PR in house style (What & why / How it works / Verification), with the **verification manifest** — the AC table with evidence links and explicit waivers — as the Verification section. Link the plan artifact, push, open the PR, watch CI, address review feedback, and apply per-repo merge policy (never auto-merge by default; #139). The merge decision is the second human gate. Post-merge: archive the OpenSpec change and file follow-ups for waived ACs.
+
+## Entry points
+
+- `/forge <idea>` — full run from Stage 0.
+- `/forge issue <n>` — the issue body seeds the inception interview.
+- `/forge pr <n>` — finish-this-PR mode: a reverse-inception pass reconstructs the brief and ACs from the PR description and linked issue (asking the user to confirm gaps — "what would make you comfortable merging this?"), then runs Stages 3→5: finish, verify, QA live, ship.
+- `/forge resume` — continue the active run from its recorded stage.
+
+## Concurrency: one run at a time
+
+Forge runs **serially — WIP limit 1**. Parallel runs would fight over the shared local docker instance (one port, one workdir) during QA, would generate rebase churn against each other (the open-PR history shows changes repeatedly touching the same surfaces: `spawn.ts`, prompts, memory, task lifecycle), and would make cost and wall-clock unpredictable — the opposite of the goal. Parallelism lives *within* stages instead: research lenses fan out concurrently, review passes run concurrently where independent.
+
+The serial discipline also sets the operating order: first drain the existing open-PR backlog via `/forge pr` (merge or close each), then work the issue backlog one at a time.
+
+## Anti-bias mechanics
+
+Every reviewer/critic/QA role is a fresh-context subagent that receives artifacts, never conversation history. Critics are prompted to refute, not appraise. The rings get progressively blinder: plan critics see brief + dossier + plan; implementation reviewers see plan + diff but not rationale; QA sees neither code nor diff — only ACs and the live instance. All loops are capped (2–3 rounds) and every pass emits a structured verdict, keeping runs predictable in cost and shape.
+
+## Tooling to build (prioritized)
+
+1. **E2E harness skill** (extends the draft archie-e2e work in #71 + the debug MCP): boot-from-branch, health-wait, nonce-task, API-approve, evidence capture, teardown. The single biggest unlock — it converts "live runtime not verifiable" into a routine check.
+2. **Cheap-model E2E mode**: an env preset (e.g. `ARCHIE_E2E=1`) pinning the system-under-test's agents to cheaper models so QA runs don't burn premium tokens on scaffolding-level assertions.
+3. **API/connector integration tests**: a supertest-style suite over the Express app (`src/connectors/api/routes.ts` is untested and the whole QA stage depends on it), plus signed synthetic webhook replay into `/github/webhooks` to test CI/review/merge routing without real GitHub events.
+4. **Fixture seeding**: a reproducible `workdir` fixture set (test plugin, sample tasks, optional memory store); `scripts/pull-tasks.sh` already shows the shape.
+5. **Test Slack workspace + Slack-read verification** (deferable): CLI/API ingress exercises nearly all PM logic without Slack; Slack-side rendering (Block Kit, canvases, status) is verified cheapest via a test workspace and Slack API reads, not browser control. Defer browser/headless tooling until something genuinely visual demands it.
+6. **GitHub Actions dry-run**: for workflow-file changes, `act` or a dispatch-with-dry_run convention — closes the changelog PRs' recurring "re-run after merge" gap.
+
+## Rollout phases
+
+- **Phase 0 — backlog drain.** Build the skeleton (`/forge` command, `forge.yaml` state, Stages 0/2/3 wired to OpenSpec, both review passes) plus tooling items 1–2. Dogfood `/forge pr` on the existing open PRs, one at a time, until the backlog is merged or closed.
+- **Phase 1 — issue-driven runs.** Work the issue backlog serially with full six-stage runs. Accumulate QA regression fixtures.
+- **Phase 2 — rebase-on-merge.** When any PR merges, the active run (and remaining open PRs) rebase; conflict resolution is grounded in two inputs — the PR's own plan artifact (its intent) and the merged diff since the branch point — rather than blind textual resolution.
+- **Phase 3 — automation.** Launch Forge automatically: PR-opened → `/forge pr` with the merge decision deferred to a human; issue-opened → a run whose inception interview happens **in the issue conversation** (requires GitHub issue tools, #150, and relates to `docs/proposals/github-mention-workflow.md`). Review comments on Forge-opened PRs are addressed automatically; when a human instead fixes the PR directly, they note in a PR comment what was changed and why, and Forge treats that as ground truth on its next pass rather than reverting it.
+
+## Human touchpoints
+
+Two in the normal path: inception sign-off and the merge decision. In between, the run proceeds autonomously and surfaces structured verdicts; it comes back to the user only if an AC proves unverifiable or the plan requires a genuine scope change.
+
+## Relationship to existing work
+
+- **OpenSpec / opsx skills** — Forge's Stage 2 is the existing propose flow, wrapped with critics and a verification plan; archive-on-merge is the existing archive flow.
+- **archie-debug MCP (`wait_for_task`, spec `openspec/specs/debug-mcp-task-waiting/`)** — Stage 4's driver.
+- **QA plugin (`archie-plugins/qa/`)** — the analyst → independent-reviewer two-pass model and black-box discipline, applied to engine verification.
+- **PR #71 (archie-e2e skill)** — seed of tooling item 1.
+- **Issues #147/#148** — plan visibility is delivered by the published Stage-2 artifact; a richer web view remains #148.
+- **Issue #143** — an automated review on Archie PRs slots into Stage 5 as an additional reviewer signal.

--- a/docs/proposals/forge.md
+++ b/docs/proposals/forge.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-Forge is a staged development process that takes an idea — described in chat, filed as a GitHub issue, or embodied in an existing PR — and produces a verified, end-to-end-tested pull request. It runs as a Claude Code harness in this repo (skills + a `/forge` command + persisted per-run state), reusing three assets that already exist: **OpenSpec** as the plan artifact store, the **archie-debug MCP + REST API** as the headless E2E driver, and the **QA plugin's analyst → independent-reviewer pattern** as the verification model. Forge is the intended basis of Archie's future self-improvement loop: once stable as a local workflow, it ports into Archie itself (`archie-agent` already mounts both `archie-hq` and `archie-plugins`).
+Forge is a staged development process that takes an idea — described in chat, filed as a GitHub issue, or embodied in an existing PR — and produces a verified, end-to-end-tested pull request. It is a **local Claude Code process**, not an Archie runtime workflow: a harness in this repo (skills + a `/forge` command + persisted per-run state) that the operator launches manually, one run at a time. It reuses three assets that already exist: **OpenSpec** as the plan artifact store, the **archie-debug MCP + REST API** as the headless E2E driver, and the **QA plugin's analyst → independent-reviewer pattern** as the verification model. Forge is the intended basis of a self-improvement loop; whether and how it later moves into Archie itself is an open question deferred until the local process is proven.
 
 The name: raw idea in, forged into a tested artifact out. Commands read naturally as verbs — `/forge <idea>`, `/forge issue 150`, `/forge pr 112`, `/forge resume`.
 
@@ -26,7 +26,7 @@ The pieces of this process exist but are disconnected: OpenSpec captures plans b
 - Automatic launch on PR-opened / issue-opened webhooks (later phase, see Rollout).
 - Moving the inception interview into GitHub issue conversations (depends on issue tools, #150).
 - Automatic rebase-and-resolve of sibling PRs on merge (later phase).
-- Running inside Archie's production agents (port after the local workflow is proven).
+- Running inside Archie's production agents. Forge stays a local process for now; an Archie port is reconsidered only once the local loop is proven.
 
 ## The stages
 
@@ -86,6 +86,10 @@ Assemble the PR in house style (What & why / How it works / Verification), with 
 - `/forge issue <n>` — the issue body seeds the inception interview.
 - `/forge pr <n>` — finish-this-PR mode: a reverse-inception pass reconstructs the brief and ACs from the PR description and linked issue (asking the user to confirm gaps — "what would make you comfortable merging this?"), then runs Stages 3→5: finish, verify, QA live, ship.
 - `/forge resume` — continue the active run from its recorded stage.
+
+## Execution model
+
+Forge is run **manually, one run at a time**, in an interactive Claude Code session on the operator's machine: the operator invokes an entry point, answers inception questions in the chat, and makes the merge decision at the end. Since every stage persists its artifacts and `forge.yaml` records the current stage, a run survives interruption and resumes with `/forge resume` — which is all the machinery scheduled or unattended operation would later need. Headless scheduled runs (with human gates handled asynchronously via issue/PR comments) are a possible later step, not part of the initial design.
 
 ## Concurrency: one run at a time
 


### PR DESCRIPTION
## What & why

There is no single repeatable process from "I have an idea" to "here is a verified, end-to-end-tested PR." Analysis of the 30 most recently merged PRs shows a consistent verification recipe (typecheck + vitest counts + candid "couldn't verify here" sections) with the same gaps deferred to "confirm on deploy" again and again: the Slack round-trip, live SDK runtime behavior, GitHub Actions workflows, and prod-only state — PR #132 exists solely to observe in production what #129 couldn't verify pre-merge. Meanwhile the ingredients of a better process already exist but are disconnected: OpenSpec captures plans, the archie-debug MCP can drive a live instance headlessly (`wait_for_task`, API-side edit-mode approval), and the QA plugin has a genuine two-pass independent-review loop that never gates engineering work.

This PR adds both the design and the first implementation:

- `docs/proposals/forge.md` — the Forge design: a staged development loop (inception → research → plan → implement → live-instance QA → ship) that takes an idea, a GitHub issue, or an existing PR and produces a verified PR.
- `.claude/commands/forge.md` + `.claude/skills/forge/` — the runnable skeleton: the `/forge` command, the orchestrator playbook (`SKILL.md`), and six self-contained stage files carrying the exact fresh-context subagent role prompts for every verification pass.

## How it works

Forge is a **local Claude Code process, run manually, one run at a time** — not an Archie runtime workflow. The operator launches it in an interactive session, answers inception questions in chat, and makes the merge decision at the end. Scheduled/headless operation and any port into Archie itself are explicitly deferred until the local loop is proven.

Key mechanics of the skeleton:

- **Testable acceptance criteria written at inception** become the contract; each AC declares its verification method (`unit`/`integration`/`live-e2e`/`manual`/`deploy-only`) up front. Inception and research may do web research where an external fact is load-bearing.
- **Fresh-context adversarial verification at every stage**, with progressively blinder rings: research claims are refuted against the code; the plan gets a completeness critic + a red team (cap 3 rounds, published to the user but not a gate); the diff gets a spec-compliance review + an adversarial bug hunt with mutation-checked tests (cap 3 rounds); QA roles see only the ACs and verification plan — never the diff — and drive a dockerized instance booted from the branch via the archie-debug MCP (`create_task` with a nonce, `wait_for_task`, API-side edit-mode approve).
- **Graceful QA degradation**: until the E2E harness exists (deliberately not built here — see below), `live-e2e` ACs are recorded as waived with a named post-merge step, surfaced verbatim in the PR's per-AC verification manifest.
- **Run state** (`forge.yaml` + artifacts) lives in the OpenSpec change dir on a `forge/*` branch; entry points `/forge <idea>`, `/forge issue <n>`, `/forge pr <n>` (finish-mode), `/forge resume`, `/forge abandon`; a cross-branch scan enforces one-run-at-a-time. The `openspec` CLI is used when present, with a documented manual fallback.

**Deliberately out of scope: the boot-from-branch E2E harness.** It needs configured docker + a live instance to be built honestly, which the authoring environment lacks. It is planned as Forge's own first real run — the harness's ACs get verified by using the harness.

## Verification

- **Structural**: all eight skill/command files parse and are discovered by the Claude Code harness (the `forge` skill registers).
- **Machinery dry-run**: Stage 1 was executed for real with the stage file's verbatim role prompts, on a real target (issue #150's scope). The mapper lens returned 30 factual claims with `file:line` citations; the blind research-verifier (given only the dossier + repo, per the blindness rule) confirmed 29, found 0 wrong, and correctly flagged 1 as unverifiable because it referenced an input the role deliberately doesn't receive — while also catching three accuracy nuances (e.g. the spawn gate is a disallow-list, not an allowlist).
- **Consistency review**: an independent fresh-context reviewer checked the skeleton against the proposal and the repo. It found 3 blocking gaps — `pr` mode never produced `verification-plan.md` though Stage 4 requires it; Forge's own state commits would trip the spec-compliance reviewer's scope-creep rule; active-run detection/resume broke across branches — plus 7 non-blocking inconsistencies (AC-status vocabulary drift, unreachable `abandoned` state, unhandled `manual` method, QA/implement cap interaction, cross-repo state location, CLAUDE.md commit-rule tension, a wrong tool name). All are fixed in the skeleton as landed.
- **Not verifiable here**: an end-to-end `/forge` run with live docker QA. That is intentionally the first manual run on the operator's machine, targeting the E2E harness build.

Docs + Claude Code assets only; no runtime code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaV8NZ3avhy6xrn1mDpgby