### PR TITLE
fix: trust-boundary gaps in webhook branch routing and Slack canvas ingestion

### DIFF
--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -40,6 +40,7 @@ function formatSlackSendError(err: unknown): string {
 }
 import { findSlackUsers, findSlackChannels, getSlackFileInfo, downloadSlackFile } from '../connectors/slack/client.js';
 import { readCanvas } from '../connectors/slack/canvas-read.js';
+import { collectCanvasFileAllowlist } from '../connectors/slack/channel-canvas.js';
 import { scheduleReminder, cancelReminder } from '../system/reminder-scheduler.js';
 import * as chrono from 'chrono-node';
 import { writeFile } from 'fs/promises';
@@ -1749,6 +1750,15 @@ function createFetchSlackReferenceTool(agent: Agent, task: Task) {
       const fileId = extractSlackFileId(args.reference);
       if (!fileId) {
         return err(`No Slack file id found in "${args.reference}". Pass a Slack file link or an F… id.`);
+      }
+      // Scope to canvas-referenced files only: the bot token can read far more
+      // of the workspace than this task should reach, so an unscoped id would
+      // let prompt-influenced input exfiltrate arbitrary accessible files.
+      const allowed = await collectCanvasFileAllowlist(task.metadata);
+      if (!allowed.has(fileId)) {
+        return err(
+          `File ${fileId} is not referenced by an adopted channel canvas for this task — only the canvas itself or files it references can be fetched.`,
+        );
       }
       const cwd = requireSandbox(agent).cwd;
       try {

--- a/src/connectors/slack/__tests__/channel-canvas.test.ts
+++ b/src/connectors/slack/__tests__/channel-canvas.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Channel canvas — creator classification fail-closed + fetch allowlist.
+ *
+ * Regression tests: an unclassifiable creator (lookup failure or missing id)
+ * must never adopt a canvas into PM context, previously classified entries
+ * survive transient failures, and fetch_slack_reference's allowlist covers
+ * exactly the adopted canvases and their referenced files.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TaskMetadata } from '../../../types/task.js';
+
+let tabs: Array<{ file_id: string }> = [];
+let fileInfos: Record<string, { title?: string; user?: string; updated?: number; filetype?: string }> = {};
+let userInfoImpl: (id: string) => Promise<{ external?: boolean }>;
+let storesByChannel: Record<string, unknown> = {};
+let savedStore: { canvases: unknown[]; announced: Record<string, boolean>; checkedAt: number } | null = null;
+
+vi.mock('../client.js', () => ({
+  getChannelCanvasTabs: async () => tabs,
+  getSlackFileInfo: async (id: string) => fileInfos[id] ?? null,
+  getUserInfo: async (id: string) => userInfoImpl(id),
+  isExternalUser: (u: { external?: boolean }) => !!u?.external,
+  postSlackMessage: vi.fn(async () => {}),
+}));
+
+vi.mock('../canvas-read.js', () => ({
+  readCanvas: async () => ({ title: 'Archie Context', markdown: '# standing context', fileIds: ['F_REF1'] }),
+}));
+
+vi.mock('../../../system/channel-store.js', () => ({
+  loadChannelStore: async (channelId: string) => storesByChannel[channelId] ?? null,
+  updateChannelStore: async (channelId: string, updater: (s: never) => never) => {
+    const base = (storesByChannel[channelId] as object | undefined) ?? { canvases: [], announced: {}, checkedAt: 0 };
+    savedStore = updater(JSON.parse(JSON.stringify(base)) as never);
+    return savedStore;
+  },
+}));
+
+vi.mock('../../../system/logger.js', () => ({
+  logger: { warn: vi.fn(), system: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+import { ensureChannelCanvas, collectCanvasFileAllowlist } from '../channel-canvas.js';
+import { postSlackMessage } from '../client.js';
+import { logger } from '../../../system/logger.js';
+
+const CHANNEL = 'C0123456789';
+
+const adoptedEntry = (fileId: string, fileIds: string[] = []) => ({
+  file_id: fileId,
+  title: 'Archie Context',
+  creator: 'U_INTERNAL',
+  external: false,
+  updatedTs: 5,
+  markdown: '# standing context',
+  fileIds,
+});
+
+describe('ensureChannelCanvas — creator classification fails closed', () => {
+  beforeEach(() => {
+    tabs = [{ file_id: 'F_CANVAS' }];
+    fileInfos = { F_CANVAS: { title: 'Archie Context', user: 'U_X', updated: 5 } };
+    userInfoImpl = async () => ({ external: false });
+    storesByChannel = {};
+    savedStore = null;
+    vi.mocked(postSlackMessage).mockClear();
+    vi.mocked(logger.warn).mockClear();
+  });
+
+  it('a new canvas with a failed creator lookup is neither adopted nor announced', async () => {
+    userInfoImpl = async () => {
+      throw new Error('rate limited');
+    };
+
+    await ensureChannelCanvas(CHANNEL);
+
+    expect(savedStore?.canvases).toEqual([]);
+    expect(postSlackMessage).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith('channel-canvas', expect.stringContaining('not adopting yet'));
+  });
+
+  it('a previously adopted canvas survives a transient lookup failure', async () => {
+    storesByChannel[CHANNEL] = { canvases: [adoptedEntry('F_CANVAS')], announced: { F_CANVAS: true }, checkedAt: 0 };
+    userInfoImpl = async () => {
+      throw new Error('rate limited');
+    };
+
+    await ensureChannelCanvas(CHANNEL);
+
+    expect(savedStore?.canvases).toHaveLength(1);
+    expect((savedStore?.canvases[0] as { file_id: string }).file_id).toBe('F_CANVAS');
+    expect(postSlackMessage).not.toHaveBeenCalled();
+  });
+
+  it('a canvas without a creator id is not adopted', async () => {
+    fileInfos.F_CANVAS = { title: 'Archie Context', updated: 5 };
+
+    await ensureChannelCanvas(CHANNEL);
+
+    expect(savedStore?.canvases).toEqual([]);
+    expect(postSlackMessage).not.toHaveBeenCalled();
+  });
+
+  it('control: an internal creator is adopted and announced once', async () => {
+    await ensureChannelCanvas(CHANNEL);
+
+    expect(savedStore?.canvases).toHaveLength(1);
+    expect(savedStore?.announced['F_CANVAS']).toBe(true);
+    expect(postSlackMessage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(postSlackMessage).mock.calls[0][0]).toMatchObject({ channel: CHANNEL });
+  });
+
+  it('control: an external creator is announced as ignored and not stored', async () => {
+    userInfoImpl = async () => ({ external: true });
+
+    await ensureChannelCanvas(CHANNEL);
+
+    expect(savedStore?.canvases).toEqual([]);
+    expect(postSlackMessage).toHaveBeenCalledTimes(1);
+    expect((vi.mocked(postSlackMessage).mock.calls[0][0] as { text: string }).text).toContain("I'm not using it");
+  });
+});
+
+describe('collectCanvasFileAllowlist', () => {
+  beforeEach(() => {
+    storesByChannel = {};
+  });
+
+  it('unions adopted canvas ids with their referenced file ids across linked slack channels, skipping external', async () => {
+    storesByChannel['C1'] = { canvases: [adoptedEntry('F1', ['FA', 'FB'])], announced: {}, checkedAt: 0 };
+    storesByChannel['C2'] = { canvases: [{ ...adoptedEntry('F2', ['FC']), external: true }], announced: {}, checkedAt: 0 };
+
+    const metadata = {
+      channels: {
+        a: { type: 'slack', channel_id: 'C1' },
+        b: { type: 'slack', channel_id: 'C2' },
+        c: { type: 'cli', id: 'cli:local' },
+      },
+    } as unknown as TaskMetadata;
+
+    const allowed = await collectCanvasFileAllowlist(metadata);
+
+    expect([...allowed].sort()).toEqual(['F1', 'FA', 'FB']);
+  });
+
+  it('is empty when no channel has an adopted canvas', async () => {
+    const metadata = { channels: { a: { type: 'slack', channel_id: 'C9' } } } as unknown as TaskMetadata;
+
+    expect((await collectCanvasFileAllowlist(metadata)).size).toBe(0);
+  });
+});

--- a/src/connectors/slack/channel-canvas.ts
+++ b/src/connectors/slack/channel-canvas.ts
@@ -57,13 +57,27 @@ export async function ensureChannelCanvas(channelId: string): Promise<void> {
       if (!info || !ARCHIE_TITLE.test(title)) continue;
 
       const creator = info.user ?? '';
-      let external = false;
+      // Fail closed on unknown classification: a missing creator or a failed
+      // lookup (rate limit, missing scope) must never adopt an unvetted canvas
+      // into standing PM context — external content in a shared channel would
+      // become prompt injection. A previously classified entry is kept as-is;
+      // a new canvas is skipped and retried at the next TTL scan.
+      let external: boolean | null = null;
       if (creator) {
         try {
           external = isExternalUser(await getUserInfo(creator));
         } catch {
-          external = false; // fail-open: don't silently drop a canvas we couldn't classify
+          external = null;
         }
+      }
+      if (external === null) {
+        const prev = pre?.canvases.find((c) => c.file_id === tab.file_id);
+        if (prev) {
+          resolved.push({ fileId: tab.file_id, title, external: false, entry: prev });
+        } else {
+          logger.warn('channel-canvas', `creator classification unavailable for canvas ${tab.file_id} in ${channelId} — not adopting yet`);
+        }
+        continue;
       }
       if (external) {
         resolved.push({ fileId: tab.file_id, title, external: true });
@@ -155,4 +169,26 @@ export async function buildChannelCanvasPromptSection(metadata: TaskMetadata): P
     blocks.join('\n') +
     '\n</channel_project_context>'
   );
+}
+
+/**
+ * File ids the PM may fetch via `fetch_slack_reference` for a task: every
+ * adopted canvas itself plus the files it references, across the task's linked
+ * Slack channels. Anything outside this set is out of scope for the tool —
+ * without the allowlist, any file id the bot token can read would be
+ * exfiltratable into the task workspace.
+ */
+export async function collectCanvasFileAllowlist(metadata: TaskMetadata): Promise<Set<string>> {
+  const allowed = new Set<string>();
+  for (const ch of Object.values(metadata.channels)) {
+    if (ch.type !== 'slack') continue;
+    const store = await loadChannelStore(ch.channel_id);
+    if (!store) continue;
+    for (const c of store.canvases) {
+      if (c.external) continue;
+      allowed.add(c.file_id);
+      for (const id of c.fileIds) allowed.add(id);
+    }
+  }
+  return allowed;
 }

--- a/src/tasks/__tests__/find-task-scan.test.ts
+++ b/src/tasks/__tests__/find-task-scan.test.ts
@@ -1,0 +1,125 @@
+/**
+ * findTaskBy* scanners — fs-based candidate scan.
+ *
+ * Regression tests for the execSync-grep replacement: webhook-controlled
+ * inputs (branch names with quotes, semicolons, `$()`) must resolve correctly
+ * and never reach a shell; JSON-encoded needles must also match values the
+ * old fixed-string grep could not (escaped quotes).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+vi.mock('../../system/workdir.js', async () => {
+  const { tmpdir } = await import('os');
+  const { join } = await import('path');
+  const dir = join(tmpdir(), `archie-findtask-test-${process.pid}-${Math.random().toString(36).slice(2)}`);
+  return { SESSIONS_DIR: dir, WORKDIR: tmpdir() };
+});
+
+vi.mock('../../connectors/slack/client.js', () => ({
+  isExternalUser: () => false,
+  formatSlackChannelRef: vi.fn(),
+  formatSlackChannelDisplay: vi.fn(),
+}));
+
+vi.mock('../../system/logger.js', () => ({
+  logger: { warn: vi.fn(), system: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../system/event-bus.js', () => ({
+  emitEvent: vi.fn(),
+  onEvent: vi.fn(),
+}));
+
+vi.mock('../task.js', () => ({
+  activeTasks: new Map(),
+  migrateRepositoriesShape: (m: unknown) => m,
+}));
+
+import { findTaskByBranch, findTaskByPRNumber, findTaskByThread, findTasksByStatus } from '../persistence.js';
+import { SESSIONS_DIR } from '../../system/workdir.js';
+
+async function writeTask(taskId: string, metadata: Record<string, unknown>): Promise<void> {
+  const dir = join(SESSIONS_DIR, taskId, 'shared');
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'metadata.json'), JSON.stringify({ task_id: taskId, channels: {}, ...metadata }, null, 2), 'utf-8');
+}
+
+function repoTask(branch: string, prNumber?: number): Record<string, unknown> {
+  return {
+    status: 'in_progress',
+    repositories: {
+      backend: [
+        {
+          github: 'sweatco/api',
+          branch,
+          branch_states: { [branch]: prNumber !== undefined ? { pr_number: prNumber } : {} },
+        },
+      ],
+    },
+  };
+}
+
+describe('findTaskBy* fs scanners', () => {
+  beforeEach(async () => {
+    await rm(SESSIONS_DIR, { recursive: true, force: true });
+    await mkdir(SESSIONS_DIR, { recursive: true });
+  });
+
+  it('findTaskByBranch resolves branches containing shell metacharacters', async () => {
+    const evil = "qa/it's; touch pwned; $(id) -- ok";
+    await writeTask('task-20260703-0001-evil', repoTask(evil));
+    await writeTask('task-20260703-0002-other', repoTask('feature/normal'));
+
+    expect(await findTaskByBranch('sweatco/api', evil)).toBe('task-20260703-0001-evil');
+  });
+
+  it('findTaskByBranch resolves branches containing double quotes (old grep false-negative)', async () => {
+    const branch = 'rel/say-"hello"';
+    await writeTask('task-20260703-0003-quote', repoTask(branch));
+
+    expect(await findTaskByBranch('sweatco/api', branch)).toBe('task-20260703-0003-quote');
+  });
+
+  it('findTaskByBranch verifies structurally: repo must match and branch must key branch_states', async () => {
+    await writeTask('task-20260703-0004-repo', repoTask('feature/x'));
+
+    expect(await findTaskByBranch('other/repo', 'feature/x')).toBeNull();
+    expect(await findTaskByBranch('sweatco/api', 'feature/y')).toBeNull();
+  });
+
+  it('findTaskByPRNumber matches repo + pr_number in branch states', async () => {
+    await writeTask('task-20260703-0005-pr', repoTask('feature/pr', 41));
+
+    expect(await findTaskByPRNumber('sweatco/api', 41)).toBe('task-20260703-0005-pr');
+    expect(await findTaskByPRNumber('sweatco/api', 42)).toBeNull();
+    expect(await findTaskByPRNumber('other/repo', 41)).toBeNull();
+  });
+
+  it('findTaskByThread finds the task by serialized thread id', async () => {
+    await writeTask('task-20260703-0006-thread', {
+      status: 'completed',
+      channels: { C1: { type: 'slack', channel_id: 'C1', thread_id: '1234567890.123456' } },
+    });
+
+    expect(await findTaskByThread('1234567890.123456')).toBe('task-20260703-0006-thread');
+    expect(await findTaskByThread('0000000000.000000')).toBeNull();
+  });
+
+  it('findTasksByStatus returns only tasks with the exact status', async () => {
+    await writeTask('task-20260703-0007-a', { status: 'in_progress' });
+    await writeTask('task-20260703-0008-b', { status: 'completed' });
+
+    const inProgress = await findTasksByStatus('in_progress');
+    expect(inProgress.map((t) => t.task_id)).toEqual(['task-20260703-0007-a']);
+  });
+
+  it('tolerates session dirs without metadata.json', async () => {
+    await mkdir(join(SESSIONS_DIR, 'task-20260703-0009-empty'), { recursive: true });
+    await writeTask('task-20260703-0010-real', repoTask('feature/z'));
+
+    expect(await findTaskByBranch('sweatco/api', 'feature/z')).toBe('task-20260703-0010-real');
+  });
+});

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -5,7 +5,7 @@
  * appending to knowledge.log
  */
 
-import { mkdir, readFile, writeFile, appendFile } from 'fs/promises';
+import { mkdir, readdir, readFile, writeFile, appendFile } from 'fs/promises';
 import { createReadStream, existsSync } from 'fs';
 import { createInterface } from 'readline';
 import { join } from 'path';
@@ -552,6 +552,33 @@ export async function readKnowledgeLog(taskId: string): Promise<string> {
 }
 
 /**
+ * Candidate scan: task IDs whose shared/metadata.json contains `needle` as a
+ * plain substring, in directory order. Pure fs — the needles carry external
+ * input (webhook branch names, Slack thread ids), which previously reached a
+ * shell via grep interpolation. A substring hit only narrows candidates;
+ * callers verify matches structurally against the parsed metadata.
+ */
+async function scanMetadataFiles(needle: string): Promise<string[]> {
+  let dirs: string[];
+  try {
+    dirs = await readdir(SESSIONS_DIR);
+  } catch {
+    return [];
+  }
+  const hits: string[] = [];
+  for (const dir of dirs) {
+    if (!dir.startsWith('task-')) continue;
+    try {
+      const text = await readFile(join(SESSIONS_DIR, dir, 'shared', 'metadata.json'), 'utf-8');
+      if (text.includes(needle)) hits.push(dir);
+    } catch {
+      // No readable metadata.json — not a task session.
+    }
+  }
+  return hits;
+}
+
+/**
  * Find a task by Slack thread ID.
  * Checks in-memory active tasks first (instant), then scans disk.
  */
@@ -564,33 +591,19 @@ export async function findTaskByThread(threadId: string): Promise<string | null>
     if (found) return taskId;
   }
 
-  // Disk: grep metadata files not loaded in memory
+  // Disk: scan metadata files not loaded in memory. JSON.stringify matches the
+  // serialized form exactly (saveMetadata writes JSON.stringify(…, 2)).
   await ensureSessionsDir();
-
-  try {
-    const { execSync } = await import('child_process');
-    const grepResult = execSync(
-      `grep -l '"thread_id": "${threadId}"' ${SESSIONS_DIR}/task-*/shared/metadata.json 2>/dev/null || true`,
-      { encoding: 'utf-8' }
-    ).trim();
-
-    if (grepResult) {
-      const taskIdMatch = grepResult.split('\n')[0].match(/task-[a-z0-9-]+/i);
-      if (taskIdMatch) return taskIdMatch[0];
-    }
-  } catch {
-    // Fallback silently if grep fails
-  }
-
-  return null;
+  const hits = await scanMetadataFiles(`"thread_id": ${JSON.stringify(threadId)}`);
+  return hits[0] ?? null;
 }
 
 /**
  * Find a task by PR number and repo.
  *
- * Uses grep to find candidates, then verifies that some agent on the task has
- * an AttachedRepo for the matching github with a branch state pointing at the
- * given PR number.
+ * Scans metadata files for candidates, then verifies that some agent on the
+ * task has an AttachedRepo for the matching github with a branch state
+ * pointing at the given PR number.
  */
 export async function findTaskByPRNumber(
   githubRepo: string,
@@ -599,21 +612,7 @@ export async function findTaskByPRNumber(
   await ensureSessionsDir();
 
   try {
-    // Use grep to find metadata files containing the PR number
-    const { execSync } = await import('child_process');
-    const grepResult = execSync(
-      `grep -l '"pr_number": ${prNumber}' ${SESSIONS_DIR}/task-*/shared/metadata.json 2>/dev/null || true`,
-      { encoding: 'utf-8' }
-    ).trim();
-
-    if (!grepResult) return null;
-
-    // Check each candidate to verify repo matches
-    for (const filePath of grepResult.split('\n')) {
-      const taskIdMatch = filePath.match(/task-[a-z0-9-]+/i);
-      if (!taskIdMatch) continue;
-
-      const taskId = taskIdMatch[0];
+    for (const taskId of await scanMetadataFiles(`"pr_number": ${prNumber}`)) {
       const metadata = await loadMetadata(taskId);
       if (!metadata) continue;
 
@@ -639,7 +638,7 @@ export async function findTaskByPRNumber(
       }
     }
   } catch {
-    // Fallback silently if grep fails
+    // Fallback silently if the scan or metadata walk fails
   }
 
   return null;
@@ -659,23 +658,13 @@ export async function findTaskByBranch(
   if (!branch) return null;
 
   try {
-    const { execSync } = await import('child_process');
-    // Candidate-narrowing grep: the branch string appears as a branch_states
-    // key (it may also match a current_branch/base_branch value — harmless, the
-    // `branch in branch_states` check below filters those out). Fixed-string
-    // (-F) because branch names contain regex-special chars like '/'.
-    const grepResult = execSync(
-      `grep -lF '"${branch}"' ${SESSIONS_DIR}/task-*/shared/metadata.json 2>/dev/null || true`,
-      { encoding: 'utf-8' }
-    ).trim();
-
-    if (!grepResult) return null;
-
-    for (const filePath of grepResult.split('\n')) {
-      const taskIdMatch = filePath.match(/task-[a-z0-9-]+/i);
-      if (!taskIdMatch) continue;
-
-      const taskId = taskIdMatch[0];
+    // Candidate-narrowing scan: the branch appears as a branch_states key (it
+    // may also match a current_branch/base_branch value — harmless, the
+    // `branch in branch_states` check below filters those out). The branch is
+    // webhook-controlled and may contain quotes and shell metacharacters, so
+    // it must never reach a shell; JSON.stringify also matches the serialized
+    // (escaped) form exactly.
+    for (const taskId of await scanMetadataFiles(JSON.stringify(branch))) {
       const metadata = await loadMetadata(taskId);
       if (!metadata) continue;
 
@@ -691,7 +680,7 @@ export async function findTaskByBranch(
       }
     }
   } catch {
-    // Fallback silently if grep fails
+    // Fallback silently if the scan or metadata walk fails
   }
 
   return null;
@@ -699,27 +688,16 @@ export async function findTaskByBranch(
 
 /**
  * Find all tasks with a given status.
- * Uses grep to find matching files in one pass (faster than reading every metadata.json).
+ * Substring scan narrows candidates without parsing every metadata.json.
  */
 export async function findTasksByStatus(
   status: 'in_progress' | 'stopped' | 'completed'
 ): Promise<TaskMetadata[]> {
   await ensureSessionsDir();
 
-  const { execSync } = await import('child_process');
-  const grepResult = execSync(
-    `grep -l '"status": "${status}"' ${SESSIONS_DIR}/task-*/shared/metadata.json 2>/dev/null || true`,
-    { encoding: 'utf-8' }
-  ).trim();
-
-  if (!grepResult) return [];
-
   const tasks: TaskMetadata[] = [];
-  for (const filePath of grepResult.split('\n')) {
-    const taskIdMatch = filePath.match(/task-[a-z0-9-]+/i);
-    if (!taskIdMatch) continue;
-
-    const metadata = await loadMetadata(taskIdMatch[0]);
+  for (const taskId of await scanMetadataFiles(`"status": ${JSON.stringify(status)}`)) {
+    const metadata = await loadMetadata(taskId);
     if (metadata) tasks.push(metadata);
   }
 


### PR DESCRIPTION
## Summary

Three findings from an adversarial (Codex) review of the memory-v2 branch turned out to live on `main`, not in that branch's diff — all three verified against the code and fixed here, decoupled from the memory-v2 merge.

1. **[critical] Shell injection via webhook branch names** — `findTaskByBranch` interpolated GitHub-webhook-controlled branch names into an `execSync` grep string. Git ref rules allow `'`, `;`, and `$()` (verified with `git check-ref-format`), so a crafted branch name could execute commands as the server user; legal quote-bearing branches also silently failed to route. **Fix:** all four grep-based metadata scanners (`findTaskByThread` / `ByPRNumber` / `ByBranch` / `findTasksByStatus`) now share one pure-fs substring scanner (`scanMetadataFiles`) with JSON-encoded needles — no shell, and escaped values now match where fixed-string grep could not.
2. **[high] Unscoped `fetch_slack_reference`** — the PM tool downloaded any `F…` id the bot token could read. **Fix:** requests are gated by `collectCanvasFileAllowlist(task.metadata)` — each adopted channel canvas plus exactly the files it references; anything else is refused with an explanatory error.
3. **[high] Canvas creator classification failed open** — a `getUserInfo` failure (or missing creator id) stored an external-authored `Archie…` canvas as internal and injected it into PM prompts (the fail-open was even commented as intentional). **Fix:** classification fails closed — previously classified entries survive transient failures, new canvases are skipped with a warning and retried on the next TTL scan; adopt/ignore announcements are unaffected.

## Verification

- `npm run typecheck` clean; `npx vitest run` — **542/542** (13 new tests): branch routing with shell metacharacters and double quotes, structural repo/branch verification, PR-number and thread and status scans, missing-metadata tolerance; fail-closed adoption (lookup failure, missing creator), previous-entry survival, adopt/ignore controls; allowlist union + external-skip.
- The scanners are exercised against real files on disk in the tests (no shell involved anywhere in the path).

## Notes

- `feature/memory-v2` carries identical copies of all three files; merging `main` forward after this lands picks the fixes up cleanly (verified: zero divergence in these files between the two branches today).
- `findTasksByStatus`/`findTaskByPRNumber` needles were never injectable (typed inputs) but shared the same shell machinery; migrating all four keeps one code path and removes `child_process` from this module entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbC7H29sppbVu18xBAB8d8