### PR TITLE
feat(forge): pr-mode research-grounded inception; archive at merge gate

### DIFF
--- a/.claude/skills/forge/SKILL.md
+++ b/.claude/skills/forge/SKILL.md
@@ -50,7 +50,7 @@ Parse the invocation input:
 
 - **Idea text** → full run from Stage 0.
 - **`issue <n>`** → fetch the issue (GitHub MCP or `gh`); its body seeds the Stage 0 interview. Derive the change name from the issue title.
-- **`pr <n>`** → finish-this-PR mode. Check out the PR's branch. Stage 0 runs as **reverse inception**: reconstruct the brief and ACs from the PR description, linked issues, and diff; ask the user to confirm gaps ("what would make you comfortable merging this?"). Reverse inception also writes `verification-plan.md` (Stage 2 is skipped, and Stage 4 requires it). Then skip Stages 1–2 unless the reconstruction exposes an unresolved design question, and run Stages 3→5 (finish, verify, QA, ship). The change dir is named `pr-<n>-<slug>`.
+- **`pr <n>`** → finish-this-PR mode. Check out the PR's branch. Stage 0 runs as **reverse inception**, which begins with a mandatory code-grounding research pass (diff mapper, codebase context, base-branch drift — see the stage file) before any brief is presented; the brief is built from the PR *and* that fact-checked dossier, with contradictions surfaced. Reverse inception also writes `research.md` and `verification-plan.md` (Stages 1–2 are skipped, and Stage 4 requires the latter). Then run Stages 3→5 (finish, verify, QA, ship), returning to Stage 2 only if reverse inception exposed an unresolved design question. The change dir is named `pr-<n>-<slug>`.
 - **`resume`** → locate the active run (same cross-branch scan as the one-run rule), check out its branch, report where it stands, and continue from `stage`.
 - **`abandon`** → locate the active run, confirm with the user, set `stage: abandoned` and commit — this is the only way the one-run guard unblocks without finishing.
 

--- a/.claude/skills/forge/stages/0-inception.md
+++ b/.claude/skills/forge/stages/0-inception.md
@@ -22,7 +22,15 @@ Ask explicitly: "how would we know this works end to end?" — the answer usuall
 
 ### Reverse inception (`pr` mode)
 
-Reconstruct the same brief from the PR: description (What & why / Verification sections), linked issues, the diff, and review comments. Mark every reconstructed item as **inferred** and have the user confirm or correct it. Always ask: "what would make you comfortable merging this?" — their answer becomes ACs. Pay special attention to the PR's own "couldn't verify" admissions: each becomes an AC with method `live-e2e` or an explicit `deploy-only` waiver.
+**Research before brief.** Do not build the brief from the PR's description alone — the description is the author's claim, not ground truth. Before presenting anything, run a code-grounding pass with Stage 1's machinery (fresh-context lenses, in parallel; output contract: factual claims with `file:line` citations):
+
+- **Diff mapper** — what the diff actually does, function by function; where it diverges from or exceeds what the PR description claims.
+- **Codebase context** — the subsystems the diff touches, the patterns and invariants there, existing test coverage for the touched area.
+- **Drift check** — what changed on the base branch since this PR branched (commits touching the same files, merged PRs in the same territory); flags for likely conflicts or invalidated assumptions.
+
+Run the Stage 1 research-verifier pass over the merged findings, then write the surviving dossier to `research.md` — it feeds the brief and later stages exactly as in a full run.
+
+Then reconstruct the brief from the PR **and** the dossier: description (What & why / Verification sections), linked issues, review comments, and what the code actually shows. Mark every reconstructed item as **inferred** and have the user confirm or correct it; where the dossier contradicts the PR's claims, surface the contradiction explicitly in the brief. Always ask: "what would make you comfortable merging this?" — their answer becomes ACs. Pay special attention to the PR's own "couldn't verify" admissions: each becomes an AC with method `live-e2e` or an explicit `deploy-only` waiver.
 
 Because Stage 2 is normally skipped in `pr` mode, reverse inception also writes `verification-plan.md`: the AC table expanded with the concrete scenario/check that will produce each AC's evidence and where the evidence will live (Stage 4 requires this file).
 

--- a/.claude/skills/forge/stages/5-ship.md
+++ b/.claude/skills/forge/stages/5-ship.md
@@ -9,9 +9,8 @@
 3. **Watch CI.** On failure: diagnose, fix on the branch, push — re-running the Stage 3 reviewers only if the fix is more than mechanical. On persistent unrelated-looking failure, report to the user rather than force-fixing someone else's breakage.
 4. **Address review feedback.** Reviewer comments route like QA failures: trivial → fix directly; substantive → back through Stage 3's reviewers; scope-changing → back to the user. If a human pushes fixes to the branch directly, treat their diff as ground truth — never revert it; reconcile the plan artifacts to match.
 5. **Merge gate (human).** Never merge without the user's explicit go — per-repo policy may add stricter rules (multiple approvals, manual rollout), which always win. When asking, include the verification manifest (the per-AC status table) in the chat message itself, plus the PR link — the user decides from the message, not from the PR tab.
+6. **Archive, then merge.** On the user's go, push one final `forge(<change>): archive` commit to the PR branch: archive the OpenSpec change (fold spec deltas into `openspec/specs/`; `openspec archive` when the CLI exists, else move the dir to `openspec/changes/archive/<date>-<change>/`) and set `stage: done` in the archived `forge.yaml`. Wait for CI, then merge. This lands the code and its spec on the base branch atomically — no follow-up archive PR — and is safe precisely because review is already over and only one run exists at a time. If review reopens after the go (rare), revert the archive commit before continuing.
 
 ## Post-merge
 
-- Archive the OpenSpec change (fold spec deltas into `openspec/specs/`; `openspec archive` when the CLI exists, else move to `openspec/changes/archive/<date>-<change>/`).
 - File follow-up issues for every waived AC that has a real post-merge step, so waivers don't evaporate.
-- Set `stage: done`.


### PR DESCRIPTION
## What & why

Two more operator-feedback refinements to the Forge skeleton (follow-up to #174/#177):

1. **`pr` mode trusted the PR description too much.** Reverse inception built the brief from the PR's own What & why / Verification sections — the author's *claims* — and only skimmed the diff. The operator asked for a full explore/research pass before being presented with the brief.
2. **Post-merge archiving needed a vehicle.** With `main` protected, archiving after merge means a noise micro-PR per run — exactly what happened with #182 archiving the e2e-harness change after #178 merged.

## How it works

- `stages/0-inception.md` + `SKILL.md` — reverse inception now starts with a **mandatory code-grounding research pass** using Stage 1's machinery before any brief is shown: a diff mapper (what the diff actually does, where it diverges from the description), a codebase-context lens (touched subsystems, invariants, existing coverage), and a base-branch drift check (what merged since the PR branched), all fact-checked by the Stage 1 research-verifier and persisted as `research.md`. The brief is built from the PR *and* the dossier, with contradictions surfaced explicitly at sign-off.
- `stages/5-ship.md` — **archive moves from post-merge to the merge gate**: on the user's go, one final `forge(<change>): archive` commit on the PR branch folds the spec deltas into `openspec/specs/`, moves the change dir to `archive/`, and sets `stage: done`; then CI, then merge. Code and spec land on `main` atomically, no follow-up archive PR. Safe because review is already closed at that point and Forge runs are WIP-1, so competing spec folds can't occur; if review reopens after the go, the archive commit is reverted first.

## Verification

Prompt-text-only change to the Forge skill files; no runtime code paths. Behavioral confirmation comes from the next `/forge pr <n>` run (research-grounded brief) and the next run's merge (single-PR archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaV8NZ3avhy6xrn1mDpgby

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaV8NZ3avhy6xrn1mDpgby)_