### PR TITLE
Support building and running behind a TLS-intercepting egress proxy

### DIFF
--- a/.claude/skills/archie-e2e/SKILL.md
+++ b/.claude/skills/archie-e2e/SKILL.md
@@ -14,6 +14,8 @@ Verify acceptance criteria against a live Archie instance booted from the branch
 
 ## Prerequisites
 
+> Running in a cloud sandbox / CI behind a TLS-intercepting proxy (e.g. Claude Code on the web)? See `docs/guides/e2e-in-cloud-sandbox.md` for the cold-start setup (CA trust, key mapping, bind-mount ownership, `setsid` for long-running processes). The steps below assume direct internet egress.
+
 - Docker (Desktop or daemon) running locally; `docker compose version` works.
 - `.env` at the repo root with a non-empty `ANTHROPIC_API_KEY`. **No Slack tokens are needed** — scenarios enter through the CLI/API channel.
 - The `archie-debug` MCP available (registered in `.mcp.json` as `npx tsx tools/debug-mcp/server.ts`). The harness consumes it as-is and never modifies `tools/debug-mcp/`.

--- a/.dockerignore
+++ b/.dockerignore
@@ -41,3 +41,6 @@ npm-debug.log*
 # Testing
 coverage/
 .nyc_output/
+
+# Opt-in extra CA for TLS-intercepting proxies (build needs it for npm; not a secret)
+!secrets/extra-ca.crt

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ e2e-evidence/
 # Local data snapshots pulled by scripts/pull-remote-data.sh
 archie-data-*
 *.partial.*
+secrets/extra-ca.crt

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,8 +14,21 @@ RUN apt-get update && \
       python3 python3-pip python3-venv && \
     git lfs install && \
     mkdir -p ~/.ssh && \
-    ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null && \
+    { ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null || true; } && \
     rm -rf /var/lib/apt/lists/*
+
+# Optional: trust an operator-supplied extra CA (corporate root, or a
+# TLS-intercepting egress proxy). Drop a PEM at ./secrets/extra-ca.crt before
+# building; absent → no-op. This must happen BEFORE `npm ci` below, and
+# NODE_USE_SYSTEM_CA lets Node (the app AND the spawned agent CLIs) validate
+# TLS against the OS trust store we just updated. `secrets/` is otherwise
+# dockerignored — only this one file is re-included (see .dockerignore).
+COPY secrets/ /tmp/ca-src/
+RUN if [ -s /tmp/ca-src/extra-ca.crt ]; then \
+      cp /tmp/ca-src/extra-ca.crt /usr/local/share/ca-certificates/extra-ca.crt && \
+      update-ca-certificates; \
+    fi && rm -rf /tmp/ca-src
+ENV NODE_USE_SYSTEM_CA=1
 
 # Set SHELL environment variable (required by Claude CLI)
 ENV SHELL=/bin/bash

--- a/docs/guides/e2e-in-cloud-sandbox.md
+++ b/docs/guides/e2e-in-cloud-sandbox.md
@@ -1,0 +1,82 @@
+# Running the E2E harness in a cloud sandbox (behind a TLS-intercepting proxy)
+
+This is a cold-start runbook for getting the `archie-e2e` harness to a green run inside an ephemeral cloud container (e.g. Claude Code on the web / CI), where outbound HTTPS is transparently re-terminated by a policy proxy with its own root CA and non-HTTPS egress (port 22) is blocked. It complements the `archie-e2e` skill (which documents the harness lifecycle) and `local-development.md` (which covers a normal laptop). If you are on a laptop with direct internet, you do not need any of this — use `local-development.md`.
+
+A fresh container needs the enabling code change (opt-in CA trust + `ssh-keyscan` made best-effort, all shipped in the repo) plus the environment-side setup below. The code change is a no-op without the CA file, so none of this affects normal setups.
+
+## Prerequisites the environment must supply
+
+- **Docker** (client + compose plugin). The daemon is usually not started for you.
+- **An Anthropic API key**, but note: Claude Code strips `ANTHROPIC_API_KEY` from every tool/subprocess it spawns, so it will not be in your shell even if set. Provide it under a non-reserved name — in this sandbox it arrives as `E2E_ANTHROPIC_API_KEY` — and map it into `.env` (below). Other secrets (e.g. `GH_TOKEN`) are not stripped.
+- **The proxy's root CA** on disk. In this sandbox it is `/root/.ccr/ca-bundle.crt`.
+
+## One-time setup (all steps are local and gitignored)
+
+Run from the repo root.
+
+1. Start the Docker daemon detached, so it survives tool-call teardown, and wait for it:
+   ```bash
+   setsid dockerd >/tmp/dockerd.log 2>&1 </dev/null &
+   until docker info >/dev/null 2>&1; do sleep 1; done
+   ```
+2. Write `.env`, mapping the non-reserved key var into the name the app expects (the value never needs to be printed):
+   ```bash
+   printf 'ANTHROPIC_API_KEY=%s\n' "$E2E_ANTHROPIC_API_KEY" > .env
+   printf 'PORT=3000\n' >> .env
+   chmod 600 .env
+   ```
+3. Stage the proxy CA where the dev image picks it up (the Dockerfile installs it before `npm ci` and sets `NODE_USE_SYSTEM_CA=1`; `.gitignore`/`.dockerignore` already handle this path):
+   ```bash
+   cp /root/.ccr/ca-bundle.crt secrets/extra-ca.crt
+   ```
+4. Give the workdir a plugin set and the container's runtime dirs:
+   ```bash
+   npm run example:setup                 # symlinks examples/plugins -> workdir/plugins
+   mkdir -p claude-data && echo '{}' > claude-data/.claude.json
+   ```
+5. Fix bind-mount ownership for native-Linux Docker. The container runs as uid 1001 (`archie`); on native Linux the mounts keep host (root) ownership, so the app cannot create `/workdir/repos` etc. (Docker Desktop remaps this automatically and does not need it):
+   ```bash
+   chown 1001:1001 workdir claude-data
+   chown -R 1001:1001 claude-data secrets
+   ```
+
+## Run the harness
+
+Boot (build + health-poll). Launch detached with `setsid` — a foreground poll loop can hit the tool-call timeout and its SIGTERM would otherwise kill the build:
+```bash
+setsid bash -c 'npx tsx tools/e2e/boot.ts --timeout-seconds 480 > /tmp/boot.log 2>&1' </dev/null &
+# then poll /tmp/boot.log for the terminal line:
+#   ARCHIE_URL=http://localhost:3000     (success, with an "Attested:" line above it)
+#   Boot failed ...                      (failure — read the diagnostics block)
+```
+Cold build is ~1–3 min; the first attempt after a Dockerfile change re-runs apt + `npm ci`. If the app comes up unhealthy with `EACCES /workdir/repos`, you missed step 5 — fix ownership and `docker compose restart archie`.
+
+Drive the `basic-nonce` scenario. If the `archie-debug` MCP is registered in your session, use its tools (`create_task` → `wait_for_task` → assert). If it is not (common in a fresh session), drive Archie's HTTP API directly — the MCP is only a thin wrapper:
+```bash
+NONCE="E2E-$(openssl rand -hex 4)"
+TASK=$(curl -fsS -X POST http://localhost:3000/api/tasks -H 'Content-Type: application/json' \
+  -d "{\"message\":\"[$NONCE] What agents are configured in this instance? Reply with a short list and do not modify anything.\"}" \
+  | grep -oE '"task_id":"[^"]+"' | cut -d'"' -f4)
+# poll GET /api/tasks/$TASK for .metadata.status == completed, then read
+# GET /api/tasks/$TASK/events (expect a message from pm-agent) and
+# GET /api/tasks/$TASK (its .knowledgeLog must contain $NONCE)
+```
+A completed task with a PM reply is the real proof: it means a spawned agent CLI reached `api.anthropic.com` through the proxy (the CA propagation working end to end).
+
+Capture evidence and tear down:
+```bash
+cat payload.json | npx tsx tools/e2e/evidence.ts --out-dir ./e2e-evidence   # writes <scenario>.{json,md}
+npx tsx tools/e2e/teardown.ts                                               # docker compose down; verifies no containers remain
+```
+
+## Gotchas that cost time
+
+- **Launch every long-running process with `setsid … </dev/null &`.** `nohup … &` alone does not survive a Bash tool-call timeout — the timeout SIGTERMs the whole process group and takes the build/daemon with it.
+- **`npm ci` failing with `SELF_SIGNED_CERT_IN_CHAIN`** means the CA step (setup step 3) was skipped or the file was empty.
+- **Agents "hang" or the task never completes** with the CA present usually means the CA is trusted in the parent but not forwarded to the spawned CLI — that forwarding is what the code change adds; make sure you are on the branch that has it.
+- **`ssh-keyscan`** failing the build is the blocked-port-22 symptom; the branch makes it best-effort.
+
+## What this does NOT cover
+
+- **The `edit-mode-approval` scenario.** It needs (a) a repo-agent plugin in the workdir (the example plugins are generic only) and (b) GitHub credentials. Archie authenticates to GitHub exclusively as a **GitHub App** — both its API (Octokit) and git transport (`scripts/github-token.ts`) require `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY_PATH` (a PEM in `secrets/`) + `GITHUB_INSTALLATION_ID`. The sandbox's built-in `GH_TOKEN` is a session token, not an App identity, and cannot be reused for this. `basic-nonce` needs no GitHub at all.
+- **Daemon persistence.** `dockerd` is not a managed service here; if the container recycles, re-run step 1.

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -588,6 +588,12 @@ Shared folder: ${sharedPath} [READ-ONLY]
     env: {
       NODE_ENV: process.env.NODE_ENV || 'development',
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      // CA-trust config for the spawned CLI. The SDK REPLACES env (see note
+      // above), so without forwarding these an operator-provided CA (e.g. a
+      // TLS-intercepting egress proxy) never reaches the child and its
+      // Anthropic API calls fail cert validation. No-op when both are unset.
+      ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
+      ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
       PATH: process.env.PATH,
       HOME: process.env.HOME,
       CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -82,6 +82,9 @@ Respond with JSON only.`;
         env: {
           NODE_ENV: process.env.NODE_ENV || 'development',
           ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+          // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
+          ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
+          ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
           PATH: process.env.PATH,
         },
         tools: [],

--- a/src/memory/extractor.ts
+++ b/src/memory/extractor.ts
@@ -241,6 +241,10 @@ export async function runExtraction(
         env: {
           NODE_ENV: process.env.NODE_ENV || 'development',
           ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+          // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
+          // Adds TLS trust only — not tools/permissions — so the minimal-env invariant holds.
+          ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
+          ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
           PATH: process.env.PATH,
         },
         stderr: (data: string) => {

--- a/src/memory/housekeeping.ts
+++ b/src/memory/housekeeping.ts
@@ -270,6 +270,10 @@ async function runHousekeeperAgent(fileContent: string): Promise<string> {
       env: {
         NODE_ENV: process.env.NODE_ENV || 'development',
         ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+        // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
+        // Adds TLS trust only — not tools/permissions — so the minimal-env invariant holds.
+        ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
+        ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
         PATH: process.env.PATH,
       },
       stderr: (data: string) => {

--- a/src/system/triage.ts
+++ b/src/system/triage.ts
@@ -58,6 +58,9 @@ async function runTriage<T extends z.ZodType>(
       env: {
         NODE_ENV: process.env.NODE_ENV || "development",
         ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+        // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
+        ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
+        ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
         PATH: process.env.PATH,
       },
       allowedTools: ["Glob", "Grep", "Read"],

--- a/src/tasks/title-generator.ts
+++ b/src/tasks/title-generator.ts
@@ -103,6 +103,9 @@ Respond with JSON only.`;
         env: {
           NODE_ENV: process.env.NODE_ENV || 'development',
           ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+          // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
+          ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
+          ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
           PATH: process.env.PATH,
         },
         tools: [],


### PR DESCRIPTION
## What & why

Cloud/CI sessions (including Claude Code on the web) route outbound HTTPS through a policy proxy that re-terminates TLS with its own root CA, and often block non-HTTPS egress such as port 22. In that environment the dev image fails to build — `npm ci` rejects the proxy's certificate with `SELF_SIGNED_CERT_IN_CHAIN` — and even after a manual build the spawned agent CLIs cannot reach `api.anthropic.com`, so no task ever completes. This blocks the archie-e2e harness (and any real use) in those environments.

These changes let an operator opt into trusting an extra CA end to end. They are a complete no-op when the CA file is absent, so nothing changes for local / direct-egress setups.

## How it works

Two independent egress problems, both fixed opt-in:

- **CA trust.** Drop the proxy's root CA at `secrets/extra-ca.crt`; the dev image installs it into the OS trust store before `npm ci` and sets `NODE_USE_SYSTEM_CA=1`, so Node validates TLS against that store. `.dockerignore` re-includes just that one file (a CA cert, not a secret) while keeping the rest of `secrets/` out of the build context, and `.gitignore` keeps the local copy out of git. The subtle part: the Agent SDK *replaces* `process.env` for the CLI it spawns, so the CA vars must be forwarded explicitly — done in `spawn.ts` and the five other `query()` call sites (title generation, memory extractor/housekeeper, research-tools, triage). Without that the parent trusts the CA but every agent turn still fails cert validation.
- **ssh-keyscan.** `ssh-keyscan github.com` in the image build seeds `known_hosts` for git-over-SSH; when port 22 is blocked it exits non-zero and failed the whole `RUN`. Made best-effort (`|| true`) since the seeding is optional.

Out of scope: the API key and the CA file are supplied by the operator/environment, not committed. On native Linux the bind-mounted workdir must be owned by the container's `archie` uid — an operator setup step, not a code change (noted below).

## Verification

- `npm run typecheck` (`tsc --noEmit`) passes.
- Built the dev image and booted it via `tools/e2e/boot.ts` behind exactly this kind of proxy: reaches `/health` and passes the `git_sha` checkout attestation.
- Ran the archie-e2e `basic-nonce` scenario against the live instance — the PM agent replied and the task reached `completed` (proving a spawned agent CLI reached the Anthropic API through the proxy), the nonce landed in the shared knowledge log, and `tools/e2e/evidence.ts` recorded PASS 3/3. `tools/e2e/teardown.ts` reported a clean teardown.
- Not verified here: the `edit-mode-approval` scenario, which needs a configured engineering (repo) agent in the workdir; the example plugins ship only generic agents.

## Deployment & follow-ups

- To run behind an intercepting proxy: place the proxy's root CA at `secrets/extra-ca.crt` before `docker compose up --build`. No CA file → unchanged behavior.
- On native Linux, ensure the bind-mounted `workdir/`, `claude-data/`, and `secrets/` are owned by the container's `archie` uid (1001) so the app can create its runtime directories (Docker Desktop remaps this automatically; native Linux does not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pAKSpUiByrstHWd9QbVr5

---
_Generated by [Claude Code](https://claude.ai/code/session_019pAKSpUiByrstHWd9QbVr5)_