### PR TITLE
fix(agents): reconcile background tasks at turn-end so none leak

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -629,7 +629,25 @@ Shared folder: ${sharedPath} [READ-ONLY]
         createResearchDefenseTagHook(),
       ],
       Stop: [{
-        hooks: [async () => {
+        hooks: [async (input: unknown) => {
+          // Reconcile in-flight background tasks against the SDK's authoritative
+          // list (StopHookInput.background_tasks — running/pending, empty when
+          // nothing is in flight) before parking. A bg task that settles MID-TURN
+          // never emits a `task_notification` event (the SDK folds it into the
+          // active turn), so without this a completed task leaks in
+          // backgroundTasks and the idle-check's `size > 0` guard wedges the task
+          // until the wall-clock cap (observed: task-20260625-1122-30wkzk). This
+          // fires at turn-end, right before the idle-check, and drops anything the
+          // SDK no longer reports as in flight — no notification parsing needed.
+          const live = new Set(
+            ((input as { background_tasks?: { id: string }[] }).background_tasks ?? []).map((t) => t.id),
+          );
+          for (const id of [...agent.backgroundTasks]) {
+            if (!live.has(id)) {
+              agent.backgroundTasks.delete(id);
+              emitEvent('agent:bg_task', taskId, { action: 'end', key: id, status: 'completed', summary: '' }, def.id);
+            }
+          }
           task.updateAgentState(def.id, false);
           return { continue: true };
         }],


### PR DESCRIPTION
## Problem

A backgrounded Bash/subagent that settles while the agent is **idle** arrives as a `task_notification` **system** event, which drains it from `agent.backgroundTasks` and wakes the agent. But when it settles **mid-turn**, the SDK folds its `<task-notification>` into the active turn as a **queued-command** message — no system event fires, so the entry is **never removed**.

It then **leaks**: the idle-check's `backgroundTasks.size > 0` guard ([recovery.ts](../blob/main/src/tasks/recovery.ts)) treats the agent as busy indefinitely, so the task can't park or recover until the 60-min wall-clock cap.

### Observed — `task-20260625-1122-30wkzk`

A `sleep 210` CI-wait (`bcdbgeo4b`) settled at 14:20:07 while the backend agent was **mid-turn**; it arrived as a `queued_command`, not a system event, so it never drained. After the work finished and PM `report_completion`'d at 14:29:30, the task sat **active-idle ~30 min** — the idle-check kept returning `'wait'` (backend still "busy") — until the wall-clock parked it with a misleading *"waiting on a reply"* message. (A second sleep that settled while the agent was *idle* drained fine — the difference is purely idle-vs-active at settle time.)

## Fix

Reconcile in the **`Stop` hook** against the SDK's authoritative in-flight list — `StopHookInput.background_tasks` (running/pending, empty when nothing is in flight):

```ts
Stop: [{ hooks: [async (input) => {
  const live = new Set((input.background_tasks ?? []).map(t => t.id));
  for (const id of [...agent.backgroundTasks])
    if (!live.has(id)) { agent.backgroundTasks.delete(id); emitEvent('agent:bg_task', taskId, { action: 'end', key: id, ... }); }
  task.updateAgentState(def.id, false);
  return { continue: true };
}]}]
```

- **No notification parsing** — uses the SDK's structured `background_tasks[]`, not the `<task-notification>` text. (Replaces an earlier regex-parsing draft — the structured list is authoritative and cleaner.)
- **Fires at turn-end, right before the idle-check** — a mid-turn settle is dropped before the idle-check reads `backgroundTasks`.
- **Catches every leak cause**, not just the inline path — anything the SDK no longer reports as in flight is dropped.
- The existing `task_started`/`task_notification` handlers stay (the latter still wakes an *idle* agent); this is the backstop for settles they miss.

## Scope

Single change in the Stop hook; no test (the hook wiring needs a live SDK — not unit-isolable — and the reconcile is a set-difference). Typecheck clean, suite 639/639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)