### PR TITLE
fix(agents): block session-only Cron tools; steer agents to set_reminder

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -261,7 +261,18 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
 
   let systemPrompt: string;
   let additionalDirectories: string[] = [sharedPath, ...pluginPaths];
-  let disallowedTools: string[] = ['WebSearch', 'WebFetch', ...(def.disallowedTools || [])];
+  // Cron* are harness tools that only live for the current Claude session — they
+  // die when the agent's ephemeral subprocess exits (which is every time a turn
+  // ends), so a scheduled job never fires. An agent reaching for them to "monitor"
+  // or "check back later" silently gets nothing (observed: task-20260617-1454-i1a08v
+  // set a self-re-arming cron that died at turn-end and never woke for 6 days).
+  // Block them so agents use the durable `set_reminder` instead. Native recurring
+  // triggers are planned separately.
+  let disallowedTools: string[] = [
+    'WebSearch', 'WebFetch',
+    'CronCreate', 'CronList', 'CronDelete',
+    ...(def.disallowedTools || []),
+  ];
   let sandboxOpts: SandboxOptions = {
     cwd,
     denyReadPaths: [WORKDIR],

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -1664,7 +1664,7 @@ function createParseDatetimeTool(agent: Agent, task: Task) {
 function createSetReminderTool(agent: Agent, task: Task) {
   return tool(
     'set_reminder',
-    'Set a reminder to be woken up at the specified time. The task will be reactivated and you will receive a prompt with the reason. Only one reminder can be pending — calling this replaces any existing reminder. Use parse_datetime first to get the correct ISO 8601 value.',
+    'Set a reminder to be woken up at a future time (within 30 days). The task is reactivated and you receive a prompt with the reason. This is the durable way to schedule a follow-up, monitor, or "check back later" — it survives restarts. For recurring monitoring, re-arm on each wake by calling set_reminder again (a self-rescheduling one-shot); native recurring/cron-style triggers are planned but not available yet. Only one reminder can be pending — calling this replaces any existing one. Use parse_datetime first to get the correct ISO 8601 value.',
     {
       datetime: z.string().describe('ISO 8601 datetime, e.g. "2026-04-15T10:00:00Z"'),
       reason: z.string().describe('What to do when woken — this will be shown to you'),


### PR DESCRIPTION
## Problem

archie agents run in **ephemeral SDK subprocesses** that exit at every turn-end. The harness `Cron*` tools (`CronCreate`/`CronList`/`CronDelete`) schedule **session-only** jobs — they die with the subprocess, so the job never fires. An agent reaching for them to "monitor" or "check back later" silently gets nothing.

### Observed — `task-20260617-1454-i1a08v` ("Verify offer codes status")

PM was asked to continuously monitor offer-code stock within one task. It used **`CronCreate`**, not archie's native `set_reminder`:

- `CronCreate {cron: "45 18 2 7 *", durable: true, ...}` → harness returned: *"Scheduled one-shot task `6bb585a4`. **Session-only (not written to disk, dies when Claude exits).**"* — `durable: true` was **ignored** (the durable cron store belongs to the interactive Claude Code harness, not archie's embedded SDK sessions).
- Created 10:05:58, due 18:45 — but PM's turn ended ~10:06, the subprocess exited, and the cron **died ~8 h before it was due**.
- Result: **zero events for 6 days**; the monitor never fired or re-armed. A human (Ivan) had to manually ask on 07-08.

The correct tool — `set_reminder` — persists in `metadata.reminder` and is rebuilt from disk on startup by the reminder scheduler, so it survives subprocess exit *and* restarts.

## Fix

1. **Block the footgun** — add `CronCreate`/`CronList`/`CronDelete` to every agent's `disallowedTools`. They can't work for ephemeral agents, so agents can't pick them.
2. **Steer to `set_reminder`** — its description now states it's the durable path for follow-ups/monitoring (survives restarts) and that for recurring work you re-arm on each wake (self-rescheduling one-shot), with a note that native recurring/cron-style triggers are **planned but not yet available**. (No mention of Cron in the tool text — blocking it is enough.)

## Scope

Config + tool-description only; no logic change. Typecheck clean, suite 639/639.

Follow-up (separate, as flagged): add real cron-style recurring triggers backed by the durable reminder scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)