### PR TITLE
fix(docker): make the dev build work on a fresh clone (empty secrets/)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,5 +42,12 @@ npm-debug.log*
 coverage/
 .nyc_output/
 
-# Opt-in extra CA for TLS-intercepting proxies (build needs it for npm; not a secret)
+# Keep the tracked placeholder in the build context so Dockerfile.dev's
+# `COPY secrets/` succeeds on a fresh clone. secrets/ is excluded above, and
+# extra-ca.crt is gitignored (absent until an operator drops one), so without
+# this the context's secrets/ would be empty and the COPY would fail with
+# "/secrets: not found". .gitkeep is tracked, so it's always present.
+!secrets/.gitkeep
+# Opt-in extra CA for TLS-intercepting proxies (build needs it for npm; not a secret).
+# When present it's a non-empty PEM; Dockerfile.dev's `[ -s ]` guard skips the empty case.
 !secrets/extra-ca.crt


### PR DESCRIPTION
## Problem

A freshly cloned repo can't `docker compose up` / boot the E2E harness — the build fails immediately:

```
COPY secrets/ /tmp/ca-src/:
"/secrets": not found
```

`Dockerfile.dev` copies `secrets/` to optionally trust an operator-supplied extra CA (for a corporate root / TLS-intercepting egress proxy). But `.dockerignore` excludes `secrets/` and re-includes **only** `!secrets/extra-ca.crt` — which is **gitignored**, so it doesn't exist on a fresh clone. With nothing re-included, the build context's `secrets/` is empty, and `COPY secrets/` fails hard. The only workaround was a manual `touch secrets/extra-ca.crt` before every fresh boot — the "dance" this removes.

(`Dockerfile.prod` has no such COPY, so it's unaffected.)

## Fix

Re-include the already-**tracked** `secrets/.gitkeep` in the build context (`.dockerignore`):

```
!secrets/.gitkeep
!secrets/extra-ca.crt
```

`.gitkeep` is committed, so it's always present → `COPY secrets/` always has content → succeeds on a fresh clone. The CA install stays gated on a **non-empty** `extra-ca.crt` (`RUN if [ -s /tmp/ca-src/extra-ca.crt ]`), so behavior is unchanged when an operator does drop in a real cert.

## Verification

From a fresh-clone state (removed local `extra-ca.crt`, only tracked `.gitkeep` present):
- **Before:** `docker compose build` → `COPY secrets/: "/secrets": not found` (hard fail).
- **After:** `docker compose build` → `archie Built` — passes the COPY step, no CA installed (correct, none supplied).

One-line change (+ explanatory comments); no Dockerfile change, no behavior change for the proxy case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)