### PR TITLE
Guide the PM to attribute post_to_channel messages to the requester

### DIFF
--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -147,7 +147,7 @@ Look around Slack and chime in, separate from task work. **Read/list** reach pub
 
 - `list_channels()` — channels you can read.
 - `read_channel_history(channel, limit?)` / `read_thread(channel, thread_ts)` — read a channel / a thread.
-- `post_to_channel(channel, message, thread_ts?)` — post to **any** channel Archie's in, public or private (e.g. escalate to a private channel); no DMs. Don't relay sensitive task content into a broader or unrelated channel.
+- `post_to_channel(channel, message, thread_ts?)` — post to **any** channel Archie's in, public or private (e.g. escalate to a private channel); no DMs. The message lands in front of people outside this task, so **always say on whose behalf you're posting** — name the person who asked and link back to the originating thread — so readers know who requested it and can trace it. Don't relay sensitive task content into a broader or unrelated channel.
 
 Exploration never touches this task: a `post_to_channel` message is fire-and-forget and its replies never come back here. A reply to a NEW top-level post you make spawns a *separate* task; replying inside someone else's thread doesn't. So don't post something you need answered *here* — reply in this task's thread for that.
 


### PR DESCRIPTION
## What & why

When the PM posts to a channel outside the current task via `post_to_channel` (the task-decoupled explore/escalate tool from #130), the message lands in front of people who aren't part of the task and have no context for why Archie is posting or who asked for it. Without attribution, a message escalated into, say, a management channel reads as coming from Archie out of nowhere. This adds guidance so those readers can see on whose behalf Archie is posting and trace it back to the source thread.

## How it works

Prompt-only change in `prompts/pm-agent.md`: the `post_to_channel` bullet under "Exploring Slack" now tells the PM to **always state on whose behalf it's posting** — name the person who asked and link back to the originating thread.

Deliberately **guidance, not engine enforcement** — no auto-appended attribution footer. Attribution is left to the PM's judgement (the same way other behavioural expectations are guided in the prompt) so it can phrase the context naturally in the message rather than having a rigid line stapled on. Nothing else changes; `post_to_channel` still doesn't link the post to the task.

## Verification

Prompt-text change only — no code paths touched. Confirmed no test asserts the PM prompt's content (the existing `post_to_channel` tests exercise the tool, not the prompt), so `typecheck` / `build` / the unit suite are unaffected by this edit. Not exercised against a live Slack workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzPvfyRLf5oghHPNBWGJKm

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzPvfyRLf5oghHPNBWGJKm)_