### PR TITLE
Add triggers — persistent "do Y when X happens" rules

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -7,7 +7,7 @@ Archie (Autonomous Responsive and Collaborative Hyper Intelligent Employee) is a
 - **Human-like behavior**: To users, Archie presents as a single AI assistant. Internal agent coordination is never exposed. The PM agent writes as "I", not "my agent" or "the backend agent."
 - **Context-aware sessions**: Each task gets its own runtime with per-agent message delivery, metadata, and a shared `knowledge.log` that all agents read for context.
 - **Direct agent communication**: Agents communicate peer-to-peer via `send_message_to_agent`, with messages delivered through simple in-memory queues in the task runtime.
-- **Non-proactive**: Archie only acts in response to external events (Slack messages, GitHub webhooks). It never initiates work on its own.
+- **Mostly reactive, with triggers**: Archie acts in response to external events (Slack messages, GitHub webhooks). It can also act on **triggers** — persistent, user-approved "do Y when X happens" rules (a schedule, or a new channel message) that spawn a fresh task when they fire. Triggers are the one sanctioned form of self-initiated work; every trigger is created via an explicit Approve/Deny gate. See [triggers.md](./triggers.md).
 - **Interruptible**: Tasks can be stopped, resumed, and recovered. Edit mode requires explicit user approval via Slack buttons.
 
 ## System Architecture

--- a/docs/architecture/triggers.md
+++ b/docs/architecture/triggers.md
@@ -1,0 +1,138 @@
+# Triggers
+
+Triggers let a user say, in plain language, "do Y when X happens" and have Archie set up a persistent rule that spawns a fresh task when the condition fires. They are the one sanctioned form of self-initiated work — everything else is reactive (Slack messages, GitHub webhooks).
+
+Two condition types ship in v1:
+
+- **Schedule** — fires on a recurring cadence (hourly / daily / weekdays / weekly at a time) or once at a future time.
+- **Channel-message** — fires on a new **top-level** message in a watched channel matching an optional filter (substring and/or author).
+
+A trigger is **bound** to a delivery target. In v1 that is a **channel** (results posted there). A `user` (DM) binding exists in the type but is **not offered at creation yet** — the fired PM has no DM-capable delivery tool under the current channel model, so `propose_trigger` accepts channel bindings only. User-DM delivery is a planned follow-up.
+
+> Design bias: reuse, no new scheduling engine. The firing loop is the reminder scheduler's index-and-tick pattern; creation reuses the edit-mode Approve/Deny flow; fired tasks are ordinary read-only tasks. The only added dependency is [`croner`](https://www.npmjs.com/package/croner) (a tiny, DST-correct cron parser) used solely to compute next-run times.
+
+## Triggers vs. reminders
+
+These are separate features that share only a pattern:
+
+| | Reminder (`set_reminder`) | Trigger |
+| --- | --- | --- |
+| Effect | Re-wakes the **current** task later | Spawns a **new** task on a saved rule |
+| Lifetime | One-shot, lives on the task | Persistent, lives in the trigger store |
+| Floor | none ("remind me in 5 min" works) | ≥1h, **recurring schedules only** |
+
+The two schedulers (`reminder-scheduler.ts`, `trigger-scheduler.ts`) run side by side and never interfere.
+
+## Data model
+
+`src/types/trigger.ts`:
+
+```ts
+interface Trigger {
+  id: string;                                  // "trg-YYYYMMDD-HHMM-random6"
+  status: 'pending' | 'enabled' | 'paused';   // pending = proposed, awaiting approval
+  created_by: string;                          // Slack user ID who requested it
+  created_at: string;
+  approved_by?: string;                        // who clicked Approve / typed y
+  binding: TriggerBinding;                     // channel thread or user DM
+  conditions: TriggerCondition[];              // any match fires
+  action: { prompt: string };                  // seeded to the PM when fired
+  last_fired_at?: string;
+}
+```
+
+- A **recurring** schedule condition carries a `cron` expression plus a precomputed `next_run_at`; after each fire `next_run_at` is recomputed with `croner`.
+- A **one-off** schedule condition has only `next_run_at` (no `cron`); it auto-pauses after firing once.
+- **Channel privacy is deliberately not stored** on the binding — it's resolved live at list time (see Visibility), so a public↔private conversion can't leak a now-private channel's triggers.
+
+Storage: one JSON file per trigger under `$ARCHIE_WORKDIR/triggers/` (`src/system/trigger-store.ts`).
+
+## Scheduling: cron, kept internal
+
+Schedule triggers store an absolute `next_run_at` ISO timestamp — exactly like a reminder — so the 60s tick is unchanged. Cron is **never user-facing**: the PM translates natural language → a cron expression at creation, the system validates the ≥1h floor (two successive runs must be ≥1h apart), and `list_triggers` renders the rule back to prose. One-off schedules bypass cron entirely (a single `next_run_at`, parsed via `parse_datetime`/`chrono-node`).
+
+Offloading DST-correct recurrence math to a tested library is the dumb-simple choice; a hand-rolled helper would take on the same DST problem in custom code.
+
+## Lifecycle
+
+```
+User asks in plain language
+   → PM agent gathers cadence/channel + what to do + where to deliver
+   → propose_trigger  →  status:'pending'  →  Approve/Deny prompt
+        Approve → status:'enabled', indexed in the scheduler, announced
+        Deny    → pending file deleted
+   → (enabled) condition fires → fireTrigger spawns a fresh read-only task
+   → that task does the work and posts the result to the bound channel
+```
+
+A one-off schedule auto-pauses after it fires (its condition is consumed). **Rescheduling a paused trigger auto-resumes it:** `update_trigger` treats new conditions on a paused trigger as intent to make it live again — it re-enables (re-checking caps) and reports the resume back to the PM so the user is told. Editing only the prompt/summary of a paused trigger does *not* resume it (a deliberate pause is respected). An explicit `status: 'paused'` in the same call always wins.
+
+### Firing
+
+`fireTrigger(trigger, context)` (`src/system/trigger-scheduler.ts`) is shared by the scheduler (schedule context) and the Slack dispatch hook (message context):
+
+1. Create a fresh task; set `metadata.triggered_by = trigger.id`.
+2. Wire delivery — for a message-context fire, link the triggering thread as the default channel (no post); for a schedule fire, the spawned PM opens the destination itself.
+3. Seed the PM with `AGENT_PROMPTS.triggered(...)` and let it do the work.
+
+**Firing posts no preamble.** The spawned PM does the work and posts the result itself, so the first thing the channel sees is the actual output — not an "I was triggered" line.
+
+### Channel-message dispatch
+
+A single hook in `handleSlackEvent` (`src/connectors/slack/events.ts`) fires channel-message triggers, gated to ambient chatter: no existing task on the thread, not an `@mention`, not a DM, and a top-level message (not a thread reply). So a message that both mentions Archie and matches a trigger creates a direct task and does **not** also fire the trigger. External/guest authors are filtered upstream and can never fire a trigger.
+
+## Confirmation gate (channel-agnostic)
+
+Trigger creation reuses the edit-mode approval mechanism, which is already channel-agnostic:
+
+- `propose_trigger` stashes the proposed id on `task.metadata.pending_trigger_id` and calls `postInteractiveToUser(..., 'trigger')`, which always emits an `approval:requested` event.
+- **Slack** renders Approve/Deny buttons; **the CLI** renders the same request as `[y] approve / [n] deny`.
+- Both converge on the task-level handlers `handleTriggerApproval` / `handleTriggerDenial`. The Slack buttons carry the trigger id; the CLI `POST /tasks/:id/approve` body is just `{ type:'trigger', approve }`, so the handler falls back to `pending_trigger_id`.
+
+There is **no operator bypass** — approving from the CLI is exactly equivalent to clicking Approve in Slack.
+
+## Visibility & privacy
+
+Scoped by the **tier of the space the request comes from** (`src/system/trigger-visibility.ts`):
+
+- **From a public channel:** all public-channel triggers. Never DM or private-channel triggers.
+- **From a private channel:** this private channel's triggers + all public-channel triggers.
+- **From a DM:** your own DM triggers + all public-channel triggers.
+- **Hard invariant:** a private space's triggers are never visible from outside that exact space.
+
+Privacy is resolved from the **workspace channel map** (`listWorkspaceChannels()` → `conversations.list`, `id → isPrivate`, a process-wide ~10-min cache shared with the `find_slack_channel` tool), so a listing is O(1) lookups with no per-channel Slack calls. A channel not in the cached map (brand-new, just-converted, or archived) falls through to a live `conversations.info` lookup. Both paths **fail closed** — an unresolved channel is treated as private — so a private trigger is never leaked into a public/DM listing. The trade is a bounded ≤10-min staleness window after a public→private conversion of an already-cached channel.
+
+The **operator CLI** (`/api/triggers`, the `t` view) operates at operator trust and sees all triggers, consistent with the existing CLI task list.
+
+## Announcements (no silent changes)
+
+Every **configuration change** — created/enabled, edited, paused/resumed, deleted — posts a one-line notice to the channel the trigger is bound to, even when the change was made from a DM. Firing is **not** a config change and is never announced.
+
+## Protections & limits
+
+- **Propose-then-confirm** — no agent enables a trigger from a model decision alone.
+- **Human approval is the loop guard** — a trigger-spawned task *may* call `propose_trigger`, but that only ever creates a `pending` trigger; nothing enables (or fires) without a human clicking Approve, and a task has no way to self-approve (approval comes only from the Slack button or the CLI `/approve` endpoint). So there is no autonomous amplification loop to gate against — the approval step already breaks it. (Runaway pending-proposal spam is bounded by the daily fire cap.)
+- **Read-only by default** — a fired task is an ordinary task; any write/push still needs in-the-moment edit-mode approval.
+- **Limits** — recurring schedules ≥1h apart; per-user and per-channel active-trigger caps; a per-account daily fired-run cap (in-memory, reset daily).
+- **Kill switch** — `ARCHIE_TRIGGERS_ENABLED=false` disables all firing and creation globally.
+
+## CLI & API surface
+
+- `GET /api/triggers`, `GET /api/triggers/:id`, `PATCH /api/triggers/:id` (pause/resume/edit prompt), `DELETE /api/triggers/:id` — operator endpoints, mirroring `/api/tasks`.
+- `POST /api/tasks/:id/approve` accepts `type:'trigger'` for the CLI approval gate.
+- CLI: press `t` from the task list to open the trigger list (status, bound channel, `[p]` pause/resume, `[d]` delete).
+
+## Key files
+
+| File | Responsibility |
+| --- | --- |
+| `src/types/trigger.ts` | `Trigger`, `TriggerBinding`, `TriggerCondition` |
+| `src/system/trigger-store.ts` | One-JSON-file-per-trigger persistence |
+| `src/system/trigger-scheduler.ts` | In-memory index, 60s tick, cron math, `fireTrigger`, announcements |
+| `src/system/trigger-visibility.ts` | Pure visibility decision (privacy injected) |
+| `src/agents/tools.ts` | PM tools: `propose_trigger`, `list_triggers`, `update_trigger`, `delete_trigger` |
+| `src/tasks/task.ts` | `handleTriggerApproval` / `handleTriggerDenial`, `linkSlackThread` |
+| `src/connectors/slack/events.ts` | Approve/Deny buttons + channel-message dispatch hook |
+| `src/connectors/api/routes.ts` | `/triggers` endpoints + the `trigger` approval branch |
+| `skills/triggers/SKILL.md` | Engine-owned PM skill (the orchestration playbook), loaded via the `Skill` tool |
+| `prompts/pm-agent.md` | Short always-present blurb so the PM knows triggers exist before loading the skill |

--- a/docs/plans/v31-triggers.md
+++ b/docs/plans/v31-triggers.md
@@ -1,0 +1,180 @@
+# Triggers — Implementation Plan
+
+## Context
+
+Archie is purely reactive: it acts only on an inbound Slack message or a GitHub webhook. The one piece of proactivity — the reminder scheduler (`src/system/reminder-scheduler.ts`) — can only re-wake an *existing* task; it cannot start work on its own.
+
+**Triggers** let a user say, in plain language, "do Y when X happens" and have Archie set up a persistent rule that spawns a fresh task when the condition fires. Two types ship in v1:
+
+- **Schedule trigger** — fires on a recurring cadence (hourly / daily / weekdays / weekly at a time) or once at a future time. Bound to a **user** (delivers by DM) or a **channel** (posts a thread).
+- **Channel-message trigger** — fires on a new **top-level** message in a bound channel matching an optional filter. Bound to a **channel**.
+
+GitHub-event triggers are a deliberate follow-up (webhook plumbing in `src/connectors/github/` already exists).
+
+**Design bias: reuse, dumb-simple, no new scheduling engine.** The firing engine is the reminder scheduler's index-and-tick pattern (the only added dependency is `croner`, a tiny zero-dep cron parser, used solely to compute next-run times). Creation reuses the edit-mode Approve/Deny button flow. Channel binding reuses `postToUser` targets. Fired tasks are ordinary read-only tasks. The only genuinely new surface is a small trigger store, a scheduler clone, four PM tools, two Slack action handlers, and one dispatch hook.
+
+### Scheduling: cron, kept internal
+
+Schedule triggers store an absolute `next_run_at` ISO timestamp — exactly like `reminder.trigger_at` — so the 60s tick is unchanged. After a recurring fire we recompute `next_run_at` with a **cron** library (`croner` — zero runtime deps, built-in IANA timezone + DST handling) via a single `.nextRun()` call. Cron is **never user-facing**: the PM translates natural language → a cron expression at creation, validates the ≥1h floor (reject if two successive fires are < 1h apart), and renders cron → prose ("weekdays at 9am") for `list_triggers`. One-off schedules bypass cron entirely — a single stored `next_run_at` (parsed via the existing `parse_datetime`/`chrono-node` path) that fires once and auto-pauses.
+
+Rationale: DST-correct recurrence math is the one genuinely subtle part here, and offloading it to a tested library is the dumb-simple choice. A hand-rolled recurrence helper would take on the same DST problem in custom code while being less flexible — a worse trade. `croner` keeps the dependency footprint trivial.
+
+## Data Model
+
+**New file `src/types/trigger.ts`:**
+
+```ts
+interface Trigger {
+  id: string;                                  // "trg-YYYYMMDD-HHMM-random6"
+  status: 'pending' | 'enabled' | 'paused';   // pending = proposed, awaiting Approve
+  created_by: string;                          // Slack user ID who requested it
+  created_at: string;
+  binding: TriggerBinding;
+  conditions: TriggerCondition[];              // N conditions, any match fires (mixing)
+  action: { prompt: string };                  // PM instruction seeded when fired
+  last_fired_at?: string;
+}
+
+type TriggerBinding =
+  | { type: 'channel'; channel_id: string; channel_name: string } // privacy resolved live, not stored
+  | { type: 'user'; user_id: string };         // delivers via DM
+
+type TriggerCondition =
+  | { type: 'schedule'; tz: string; next_run_at: string; cron?: string } // recurring if cron set; one-off if absent
+  | { type: 'channel_message'; channel_id: string; match?: { contains?: string; from_user?: string } };
+```
+
+`next_run_at` is the precomputed next fire instant. **Channel privacy is deliberately NOT stored on the trigger** — it is resolved live at list time (see Visibility), because a channel can be converted public↔private after the trigger is created and a stale cached value would leak a now-private channel's triggers into public contexts.
+
+**New file `src/system/trigger-store.ts`** — mirrors `src/tasks/persistence.ts` path/load/save helpers. Add `TRIGGERS_DIR = join(WORKDIR, 'triggers')` to `src/system/workdir.ts` (alongside `SESSIONS_DIR`, `src/system/workdir.ts:26-36`). Functions: `saveTrigger`, `loadTrigger`, `listTriggers`, `deleteTrigger`, `enableProposedTrigger(id, approverId)`. One JSON file per trigger.
+
+## Scheduler Module
+
+**New file `src/system/trigger-scheduler.ts`** — a near-copy of `reminder-scheduler.ts:33-149`:
+
+- In-memory index of `enabled` triggers that have a schedule condition.
+- `initTriggerScheduler()`: `rebuildFromDisk()` scans `${TRIGGERS_DIR}/*.json`, then `setInterval(checkDue, 60_000)` + an immediate `checkDue()` to fire overdue runs after downtime.
+- `checkDue()`: for each schedule condition with `next_run_at <= now`, call `fireTrigger(...)`; then, if `cron` is set, recompute `next_run_at = new Cron(cron, { timezone: tz }).nextRun()` (recurring); if `cron` is absent, set the trigger `status: 'paused'` (one-off auto-disable). Persist.
+- **Downtime catch-up guard:** a run more than one full interval overdue fires once, not once per missed window.
+- Next-run computation is a single `croner` call — no hand-rolled date math. The ≥1h floor is validated at creation by checking two successive `nextRun()` values are ≥ 1h apart.
+
+**`fireTrigger(trigger, context)`** (shared by scheduler and the message dispatch hook):
+
+1. `const task = await Task.create()` (`src/tasks/task.ts:124-161`).
+2. Establish the comms channel via `postToUser` (`src/tasks/task.ts:327-390`, `PostTarget` at `:16-23`), which auto-registers the channel through `registerSlackChannel` (`:600-613`) and promotes it to `default_channel`:
+   - `binding.type === 'user'` → `task.postToUser(seed, 'system', { new_dm: user_id })`.
+   - `binding.type === 'channel'` + message context → reuse the triggering thread (`{ channel: <key> }` or register the message thread).
+   - `binding.type === 'channel'` + schedule context → `{ new_thread: channel_id }`.
+3. Set `task.metadata.triggered_by = trigger.id`.
+4. `task.sendMessage(AGENT_PROMPTS.triggered(reason, context), 'pm-agent')` (`src/tasks/task.ts:201-211`) — activates the task and spawns the PM.
+5. `emitEvent('trigger:fired', ...)` (for observability/logs only — not a Slack message), set `last_fired_at`, persist. The task itself posts its actual result to the channel when the work is done; there is no separate "I was triggered" preamble.
+
+## Channel-Message Dispatch
+
+One hook in `handleSlackEvent` (`src/connectors/slack/events.ts`), placed right after `findTaskByThread(threadId)` (~`:452`) and gated so it only handles ambient channel chatter:
+
+```
+if (!taskId && event.type === 'message' && !event.channel.startsWith('D') && !isThreadReply) { ...check trigger index... }
+```
+
+- Reuses existing self-message filtering (`routeSlackEvent`, `:360-370`) and external/guest filtering (`isExternalUser`, `:393-404`).
+- Skips `app_mention`/DM (those create a direct task) so a message aimed at Archie never double-fires a channel trigger.
+- For each `channel_message` trigger bound to `event.channel` whose `match` passes, call `fireTrigger(trigger, { kind: 'message', text, ts })`.
+
+## PM Tools
+
+Four PM-only tools added to `createOrchestrationMcpServer()` (`src/agents/tools.ts:1556-1568`), modeled on `createSetReminderTool` (`:1478-1506`) and `createRequestEditModeTool` (`:463-531`):
+
+- **`propose_trigger(binding, conditions, action_prompt)`** — validates (schedule interval ≥ 1h; per-user & per-channel active-trigger caps via counting trigger files; **refuses if `task.metadata.triggered_by` is set** → triggered tasks cannot create triggers), writes a `status:'pending'` trigger, stores its id on `task.metadata.pending_trigger_id`, then calls `task.postInteractiveToUser(text, blocks, 'trigger')` — which renders Approve/Deny buttons in Slack (`action_id`s `approve_trigger`/`deny_trigger`, `value: trigger.id`) and the same `[y]/[n]` prompt in the CLI. Does **not** pause the task.
+- **`list_triggers()`** — no params. Returns **everything visible from the current context** (per the Visibility rules below). The PM filters/narrows conversationally from there ("which ones are in this channel", "just the schedules") — no scope argument needed.
+- **`update_trigger(id, { status?, action_prompt?, conditions? })`** — pause/resume/edit; re-validates, re-indexes the scheduler, announces.
+- **`delete_trigger(id)`** — removes the file, de-indexes, announces.
+
+`update_trigger`/`delete_trigger` first assert the trigger is visible from the current context (privacy rule); anything visible is manageable (no owner-lock).
+
+## Confirmation Flow
+
+Reuses the edit-mode approval mechanism exactly — and that mechanism is **already channel-agnostic**, so the gate works identically in Slack and in the CLI with no special-casing. `postInteractiveToUser` (`src/tasks/task.ts:472`) always `emitEvent('approval:requested', ...)`; Slack renders Approve/Deny buttons, the CLI's `TaskDetail` renders the same request as `⏳ … [y] approve / [n] deny` and POSTs to `/tasks/:id/approve` (`routes.ts:216-253`). Both front-ends converge on the same task-level handlers.
+
+- Extend the `approvalType` union (`src/tasks/task.ts:472`) and the CLI's matching type (`src/cli/components/TaskDetail.tsx:105-120`) to `'edit_mode' | 'research_budget' | 'trigger'`.
+- Add task methods `handleTriggerApproval()` / `handleTriggerDenial()` next to `handleEditModeApproval()` (`src/tasks/task.ts:885-913`). Approval sets the proposed trigger `status:'enabled'`, indexes the scheduler (computing `next_run_at`), announces to the bound channel, emits `trigger:created`; denial deletes the pending file. Because the CLI `/approve` body is only `{ type, approve }` (no id), `propose_trigger` stashes the proposed id on `task.metadata.pending_trigger_id`, and the handler reads it from there — exactly how the edit-mode handler reads task state.
+- **Both entry points call those methods:** the Slack `approve_trigger`/`deny_trigger` Bolt action handlers (added next to `approve_edit_mode`, `src/connectors/slack/events.ts:201-251`) `ack()` + `updateMessage(...)` to swap the buttons, then call the task method; the `/tasks/:id/approve` endpoint gains a `type === 'trigger'` branch that calls the same method. The Slack button still carries `trigger.id` in `value` for its own `updateMessage`, but the enable/deny logic lives in the shared task method.
+
+## Visibility & Privacy
+
+Scoped by the **tier of the space the request comes from** (the task's originating channel/DM). You can only ask from a space you're already in, so membership is enforced implicitly.
+
+- **From a public channel:** see all **public-channel** triggers. Never any DM or private-channel trigger.
+- **From a private channel:** see this private channel's triggers + all public-channel triggers. Never *other* private channels or DMs.
+- **From a DM:** see your own DM triggers + all public-channel triggers. Never private channels or other DMs.
+- **Hard invariant:** a private space's triggers are never visible from outside that exact space.
+
+**Privacy is resolved live, not cached.** `list_triggers` enumerates trigger files, then for each candidate channel trigger resolves the channel's *current* public/private state via `conversations.info` (extended `getChannelInfo`), memoized per call so each distinct channel is looked up at most once. This is correct across a public↔private conversion — a channel that became private immediately drops out of public/DM listings even though the trigger was created while it was public. Listing is infrequent (a user explicitly asks), so the extra Slack lookups are not a hot path.
+
+## Announcements (no silent changes)
+
+A **configuration change** — created/enabled, edited, paused/resumed, deleted — posts a one-line notice to the channel where the trigger is bound (via `postToUser` targeting the binding), even when the change was made from a DM. This is the transparency guarantee: you can manage a channel's trigger from afar, but the channel always sees that its configuration changed.
+
+**Firing is not a config change and is not announced.** When a trigger fires, the spawned task simply does its work and posts its result to the bound channel like any task — no "I was triggered" preamble (that would be noise, especially for a message-triggered task already replying in-thread).
+
+## CLI & API surface
+
+Triggers must be fully usable from the operator CLI, not only Slack — both the **list view** ("see what triggers exist, and which channel each is bound to") and the **approval gate** ("approve/deny a proposed trigger without Slack"). The CLI is an HTTP client of the local API (`src/connectors/api/routes.ts`, `src/cli/api.ts`), which already lists tasks (with their bound `channel_name` and reminders) at `GET /tasks` (`routes.ts:69-117`) and renders them in `src/cli/components/TaskList.tsx`.
+
+- **Approval, not bypass.** The same propose-then-confirm gate runs on the CLI — there is no operator bypass. Creation via natural language to the PM proposes the trigger; the proposal surfaces in the CLI as `[y] approve / [n] deny` (see Confirmation Flow, which already routes through the channel-agnostic `approval:requested` → `/tasks/:id/approve` path). Approving from the CLI is exactly equivalent to clicking Approve in Slack. The bound Slack channel still gets the config-change announcement.
+- **List view connected to channels.** Add `GET /triggers` (returning each trigger with its resolved bound `channel_name`/DM, status, schedule prose, and `last_fired_at`), mirroring the `/tasks` shape, plus a `TriggerList` CLI component mirroring `TaskList.tsx` — so the operator sees every trigger and which channel it's wired to, the same way the task list shows `#channel` / `cli` / `DM with …`.
+- **Lifecycle endpoints** — `PATCH /triggers/:id` (pause/resume/edit) and `DELETE /triggers/:id`, both flowing through `trigger-store.ts` and (un)indexing the scheduler, so CLI and Slack act on one source of truth.
+- **CLI visibility = operator trust level.** The per-Slack-context privacy rules below are an end-user concept for the Slack `list_triggers` tool. The operator CLI already sees all tasks/sessions (including DMs), so the CLI `/triggers` list shows all triggers regardless of binding privacy — consistent with the existing CLI task list.
+
+## Protections & Limits
+
+- **Propose-then-confirm** — no agent enables a trigger from a model decision alone.
+- **Provenance gate** — `propose_trigger` refuses when `triggered_by` is set (no amplification loops) and relies on the existing external/guest bail-out (`events.ts:393-404`) so outsiders can't create triggers or fire channel triggers.
+- **Read-only by default** — a fired task is an ordinary task; any write/push still requires in-the-moment edit-mode approval in-channel (`request_edit_mode`).
+- **Limits** — the **≥1h floor applies ONLY to *recurring* schedule triggers** (the runaway-loop risk). It does **not** apply to one-off schedule triggers, and it has **nothing to do with reminders**. Plus per-user & per-channel active-trigger caps; per-account daily fired-run cap (in-memory counter in the scheduler, reset daily). Over a cap → reject creation / drop the fire and notify.
+- **Kill switch** — `ARCHIE_TRIGGERS_ENABLED` env flag disables all firing and creation globally.
+
+### Triggers vs. reminders (no interference)
+
+Reminders are a separate, untouched feature: `set_reminder`/`parse_datetime` wake the **current** task later (`reminder-scheduler.ts`). Triggers spawn a **new** task on a saved rule. They share only the index-and-tick *pattern*, not state or limits. So **"remind me in 5 minutes to do X" keeps working exactly as today** — it's a one-off reminder on the live task, not a recurring trigger, so the 1h floor never touches it. The two schedulers run side by side.
+
+## Other Small Changes
+
+- `src/types/task.ts:204-233` — add `triggered_by?: string` and `pending_trigger_id?: string` to `TaskMetadata`.
+- `src/connectors/api/routes.ts:216-253` — add a `type === 'trigger'` branch to `POST /tasks/:id/approve` that calls `task.handleTriggerApproval()`/`handleTriggerDenial()`, so the CLI's `[y]/[n]` enables/denies a proposed trigger exactly like the Slack button.
+- `src/cli/components/TaskDetail.tsx:105-120` — widen the rendered `approvalType` union to include `'trigger'`.
+- `src/agents/spawn.ts:261-304` — when `metadata.triggered_by` is set, push a context line (next to the existing `reminder` line at ~`:280`) so the PM frames its first message correctly.
+- `src/agents/prompts.ts:9-32` — add `triggered: (reason, context) => ...` to `AGENT_PROMPTS`.
+- `src/system/event-bus.ts:10-23` — add `trigger:created | trigger:fired | trigger:paused | trigger:deleted` to `EventType`.
+- `src/index.ts:240-242` — call `initTriggerScheduler()` right after `initReminderScheduler()` (after recovery, before opening webhooks).
+- `src/connectors/slack/client.ts` — extend `getChannelInfo` (`:1029-1050`) to also return `isPrivate`/`isIm` (already on the raw `conversations.info` response) for live privacy resolution in `list_triggers`; reuse `openDMChannel` (`:1431`) and `getUserInfo().tz` (`:889-928`).
+- `src/connectors/api/routes.ts` + `src/cli/api.ts` + `src/cli/components/TriggerList.tsx` — `GET /triggers` (+ `PATCH`/`DELETE`) endpoints and a CLI trigger-list view showing each trigger's bound channel, mirroring `TaskList.tsx` (see CLI & API surface).
+- PM skill `skills/triggers/SKILL.md` in **archie-hq** (engine-owned, alongside `self-awareness` — triggers are a core engine capability, not a domain plugin) — intake (cadence/channel/DM, what to do), the propose-then-confirm protocol, visibility/announcement rules, delivery format. Plus a short always-present blurb in `prompts/pm-agent.md` so the PM knows triggers exist before loading the skill.
+- Docs: add `docs/architecture/triggers.md` and note in `docs/architecture/overview.md` that Archie is no longer purely reactive.
+- `package.json` — add `croner` (zero-dependency cron parser with built-in tz/DST). `chrono-node` is already present for one-off parsing.
+
+## Edge Cases
+
+- **Restart** — scheduler rebuilds from trigger files; overdue schedules fire once (catch-up guard).
+- **Bound channel deleted / bot removed** — firing fails to post; mark trigger `paused`, best-effort DM the creator.
+- **Concurrent fires** — each fire is an independent new task; no reuse.
+- **Message both @mentions Archie and matches a channel trigger** — direct task wins; channel trigger skipped (dispatch gating).
+- **One-off schedule** — auto-`paused` after firing; re-enable by editing.
+- **Creator leaves workspace** — trigger keeps running; anyone in the bound space can pause/delete it.
+- **Stale `pending` triggers** (proposed, never approved) — never indexed; GC'd on the boot scan.
+
+## Verification
+
+1. **Typecheck/build:** `npm run typecheck` && `npm run build`.
+2. **Unit tests:** add tests for next-run computation (`croner` `.nextRun()` across hourly/daily/weekly cron + a DST boundary in a non-UTC tz), the ≥1h-floor validator (reject `* * * * *`), and `list_triggers` visibility filtering (public-from-public, private-isolation, DM-isolation). Run `npm test`.
+3. **End-to-end (local dev, `npm run dev`):**
+   - **Schedule:** ask the PM in a DM "every minute, post hi here" (temporarily relax the 1h floor in dev), Approve → confirm a new task spawns each interval and posts to the DM; confirm the bound channel got the **enable** announcement and that firing produces **only** the task's own post (no "I was triggered" line).
+   - **One-off:** "in 2 minutes summarize X" → fires once, trigger flips to `paused`.
+   - **Reminder coexistence:** in the same session, "remind me in 5 minutes to check the build" → confirm the reminder fires on the *current* task at 5 min and is unaffected by the trigger 1h floor.
+   - **Channel-message:** create a trigger watching a test channel for `contains: "bug"`; post a top-level "found a bug" → confirm a task spawns in that thread; post a reply inside an existing Archie thread → confirm it does *not* double-fire.
+   - **Confirmation gate:** propose a trigger, click Deny → confirm the pending file is deleted and nothing fires.
+   - **Provenance:** from inside a triggered task, ask the PM to create a trigger → confirm `propose_trigger` refuses.
+   - **Visibility + privacy change:** from a public channel ask "list triggers" → see public ones only; from a DM → see your DM + public, never another private space. Then convert the bound channel to private and re-list from a DM → confirm that trigger disappears from the listing (live resolution).
+   - **CLI:** from a CLI task, ask the PM to set up a trigger → confirm the proposal renders as `[y] approve / [n] deny`, pressing `y` enables it and announces in the bound channel (no Slack needed); then open the CLI trigger-list view → confirm every trigger shows with its bound channel, and pause/delete from the CLI works.
+   - **Kill switch:** set `ARCHIE_TRIGGERS_ENABLED=false`, restart → confirm nothing fires and creation is refused.
+4. **Restart recovery:** create an enabled schedule trigger, restart the app, confirm it reloads and still fires.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@slack/bolt": "^4.6.0",
         "@slack/web-api": "^7.19.0",
         "chrono-node": "^2.9.0",
+        "croner": "^9.1.0",
         "dotenv": "^17.4.2",
         "gray-matter": "^4.0.3",
         "ink": "^7.1.0",
@@ -2607,6 +2608,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/croner": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-9.1.0.tgz",
+      "integrity": "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.19.0",
     "chrono-node": "^2.9.0",
+    "croner": "^9.1.0",
     "dotenv": "^17.4.2",
     "gray-matter": "^4.0.3",
     "ink": "^7.1.0",

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -18,6 +18,8 @@ Some teammates can reach external systems through **MCP integrations** — shown
 
 **IMPORTANT**: You have domain-specific skills available via the `Skill` tool. Before delegating to any team member, you MUST load the relevant skill first — it contains the workflow, decision framework, and coordination patterns for that domain. Never delegate without first loading and reading the skill. If you're unsure which skill applies, list available skills by calling the `Skill` tool.
 
+**Triggers**: Beyond replying to messages, you can set up **triggers** — persistent "do Y when X happens" rules that run on their own. A trigger fires on a schedule (recurring or one-off) or when a new message is posted in a watched channel, and spawns a fresh task to do the work. Every trigger is created through an explicit user Approve/Deny step. When a user asks for something recurring or event-driven ("every weekday at 9am…", "whenever someone posts X in #support…", "at 5pm today…"), or asks what automations are set up, load the `triggers` skill for the full workflow before acting.
+
 ## Core Mental Models
 
 To handle your responsibilities effectively, internalize these mental models:

--- a/skills/triggers/SKILL.md
+++ b/skills/triggers/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: triggers
+description: Set up, list, or manage triggers — persistent "do Y when X happens" rules. Use when someone asks Archie to do something on a schedule ("every weekday at 9am…", "every morning post…", "remind the channel weekly…"), to react to new messages in a channel ("whenever someone posts X in #support, …"), or to list/pause/stop an automation they set up earlier. Also covers one-off future actions ("at 5pm today, summarise…").
+---
+
+# Triggers
+
+You are setting up or managing a **trigger** — a persistent rule that makes Archie act on its own when a condition fires, instead of only when someone messages it. This is the one place Archie initiates work, so every new trigger goes through an explicit approval step before it runs.
+
+### Two kinds of trigger
+
+- **Schedule** — fires on a repeating cadence (hourly, daily, weekdays, weekly at a time) or **once** at a future moment.
+- **Channel-message** — fires when a new top-level message is posted in a watched channel, optionally only when the message contains some text or comes from a specific person.
+
+Each trigger **delivers** its result to a **channel** (Archie posts there). Delivering to a person's DM is a planned follow-up and isn't supported yet — set triggers up to post in a channel.
+
+### Don't confuse this with a reminder
+
+A reminder ("remind me in 10 minutes") wakes the *current* conversation later and is a one-shot — keep using that for short, in-conversation nudges. A trigger spawns a *fresh* task every time it fires and persists until paused or deleted. Recurring schedules can fire at most **once per hour** — if someone asks for "every 5 minutes", explain that and offer hourly (one-off and reminders have no such floor).
+
+### Intake — gather before proposing
+
+Don't propose a trigger until you have:
+
+1. **What to do when it fires** — the concrete action, in enough detail that a fresh task with no prior context could carry it out (it genuinely starts clean each time). Also give it a **short, friendly name** — a few words, a noun phrase, not a full sentence and not ending in a period (e.g. "Daily #bot-test summary", "Reply to messages mentioning Archie"). That name is what the user sees in the approval card and the channel notices, so it must describe **what the automation produces/does** — not restate the schedule (the cadence is rendered automatically) and, for a message-watch trigger, not restate the triggering condition ("A new message was posted…"). Keep the detailed instruction in the action prompt, behind the scenes.
+2. **When / what to watch** —
+   - Schedule: the cadence or the one-off time, **and the timezone** (confirm it if you're not sure — "9am" is meaningless without one).
+   - Channel-message: which channel, and any filter (a keyword, a specific sender).
+3. **Where to deliver** — which channel to post the result in. Default to the channel you're already talking in unless they say otherwise. (DM delivery isn't supported yet; if someone asks for a DM, explain it'll post to a channel for now.)
+
+If anything is missing or ambiguous, ask in Slack before proposing.
+
+### Propose, then let the user approve
+
+When you have the details, propose the trigger. This posts an **Approve / Deny** prompt to the user — the trigger does **not** run until they approve (in Slack they click a button; in the CLI they press y). You don't need to stop the conversation while it's pending; just make clear you've put it up for approval.
+
+Never describe a trigger as "set up" or "running" until it has actually been approved.
+
+### Visibility & privacy — what you can see and manage
+
+You can only see and manage triggers that belong to the space the user is talking to you from:
+
+- From a **public channel**: every public-channel trigger.
+- From a **private channel**: that channel's triggers, plus public ones.
+- From a **DM**: that person's own DM triggers, plus public ones.
+
+A private channel's or a DM's triggers are never visible from anywhere else. When someone asks "what's set up here", list everything you can see and narrow it conversationally if they want just one channel or just the schedules. When they ask to pause, resume, edit, or delete one, do it by its id — anything you can see, you can manage.
+
+### Changes are announced; firing is not
+
+Whenever a trigger is created, edited, paused, resumed, or deleted, Archie automatically posts a one-line notice to the channel that trigger is bound to — so a channel always knows what automation runs in it, even if the change was made from a DM. You don't need to post that notice yourself.
+
+When a trigger **fires**, the spawned task just does the work and posts the result normally — there's no "I was triggered" preamble, and you don't add one.
+
+### A few hard rules
+
+- You can set up a trigger even from a task that was itself started by a trigger — it still requires the user's Approve/Deny, so there's no runaway risk.
+- Fired tasks are read-only like any task; if the work needs code changes, the usual edit-mode approval still applies in the moment.
+- There are caps on how many active triggers a channel or person can have. If you hit one, tell the user and offer to remove an existing trigger first.
+
+### Delivering results
+
+- **Setup confirmation**: once approved, confirm in one line what was set up and where it will deliver (e.g. "Done — I'll post a digest in #standup every weekday at 9am London time").
+- **Listing**: present visible triggers as a short list — what each does, where it delivers, whether it's active or paused.
+- **Revision**: if the user wants a change, edit or replace the trigger rather than stacking a second one. Rescheduling a trigger that had been paused (including a one-off that already fired) automatically re-enables it — the update tool tells you when that happened, so pass that on to the user ("done — rescheduled and back on for 4pm") rather than leaving them to wonder whether it's live.

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -138,6 +138,10 @@ const PM_ORCHESTRATION_TOOLS = [
   'mcp__orchestration-tools__get_agents_status',
   'mcp__orchestration-tools__list_available_repos',
   'mcp__orchestration-tools__spawn_repo_agent',
+  'mcp__orchestration-tools__propose_trigger',
+  'mcp__orchestration-tools__list_triggers',
+  'mcp__orchestration-tools__update_trigger',
+  'mcp__orchestration-tools__delete_trigger',
 ];
 
 const PM_SCHEDULING_TOOLS = [

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -23,6 +23,8 @@ Read knowledge.log to see where you left off, then take action.`,
 
   reminder: (reason: string) => `Your scheduled reminder has fired. Reason: ${reason}\n\nCheck knowledge.log for the latest context and decide what to do next.`,
 
+  triggered: (prompt: string, context: string) => `A trigger you were set up with has fired (${context}).\n\nDo the following now: ${prompt}\n\nThis is a fresh task spawned by the trigger — there is no prior conversation. Carry out the instruction and post the result to the bound channel. You are read-only by default; if the work requires code changes, request edit mode first.`,
+
   reinforceAgent: `RECOVERY: You went idle without reporting back.
 
 Your turn must end with:

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -324,6 +324,9 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     if (metadata.reminder) {
       contextLines.push(`Reminder: ${metadata.reminder.trigger_at} — ${metadata.reminder.reason}`);
     }
+    if (metadata.triggered_by) {
+      contextLines.push(`Spawned by trigger: ${metadata.triggered_by} (this is a fresh, trigger-initiated task — deliver the result as instructed in the first message)`);
+    }
     // Surface the live plugins-repo version so the PM can tell users when the
     // plugins/agents were last updated. Refreshed on every task start/load.
     const pluginsHead = await getPluginsHeadInfo();

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -34,6 +34,10 @@ import {
   fetchExploreThread,
   postSlackMessage,
   assertPostableChannel,
+  getChannelInfo,
+  getUserInfo,
+  listWorkspaceChannels,
+  fetchChannelIsPrivate,
 } from '../connectors/slack/client.js';
 import { readCanvas } from '../connectors/slack/canvas-read.js';
 import { collectCanvasFileAllowlist } from '../connectors/slack/channel-canvas.js';
@@ -87,6 +91,32 @@ import { scheduleReminder, cancelReminder } from '../system/reminder-scheduler.j
 import * as chrono from 'chrono-node';
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
+import type { Trigger, TriggerBinding, TriggerCondition } from '../types/trigger.js';
+import {
+  generateTriggerId,
+  saveTrigger,
+  loadTrigger,
+  listTriggers,
+  deleteTrigger,
+  countActiveTriggers,
+} from '../system/trigger-store.js';
+import {
+  computeNextRun,
+  validateRecurringInterval,
+  planStatusChange,
+  indexTrigger,
+  deindexTrigger,
+  announceTriggerChange,
+  describeTrigger,
+  triggerWhat,
+  triggerWhen,
+  triggerWhere,
+  triggersEnabled,
+  MAX_TRIGGERS_PER_USER,
+  MAX_TRIGGERS_PER_CHANNEL,
+} from '../system/trigger-scheduler.js';
+import { emitEvent } from '../system/event-bus.js';
+import { triggerVisibleFrom, type TriggerOrigin } from '../system/trigger-visibility.js';
 
 // Re-export branch state helpers for consumers that import from tools.ts
 export { hydrateBranchState, findBranchStateByPR };
@@ -2010,6 +2040,345 @@ function createFetchSlackReferenceTool(agent: Agent, task: Task) {
   );
 }
 
+// ============================================================================
+// Trigger tools (PM-only) — propose / list / update / delete persistent triggers
+// ============================================================================
+
+/** Zod shape for one tool-supplied trigger condition (shared by propose/update). */
+const triggerConditionObject = z.object({
+  type: z.enum(['schedule', 'channel_message']),
+  cron: z.string().optional().describe('5-field cron expression for a RECURRING schedule (e.g. "0 9 * * 1-5"). Must fire at most once per hour. Omit for one-off.'),
+  run_at: z.string().optional().describe('ISO 8601 datetime for a ONE-OFF schedule (use parse_datetime). Omit for recurring.'),
+  tz: z.string().optional().describe('IANA timezone, e.g. "America/New_York". Defaults to the requesting user\'s timezone.'),
+  channel_id: z.string().optional().describe('Channel to watch (required for channel_message).'),
+  contains: z.string().optional().describe('Only fire when the new message contains this substring (channel_message).'),
+  from_user: z.string().optional().describe('Only fire for messages from this Slack user ID (channel_message).'),
+});
+
+type RawCondition = z.infer<typeof triggerConditionObject>;
+
+/**
+ * Resolve the task's originating context for trigger visibility. A Slack non-DM
+ * channel → channel origin; a Slack DM → dm origin (with the partner's user id);
+ * a CLI/absent default → operator (full visibility, matching the CLI surface).
+ */
+async function resolveTriggerOrigin(task: Task): Promise<TriggerOrigin> {
+  const key = task.metadata.default_channel;
+  const ch = key ? task.metadata.channels[key] : null;
+  if (!ch || ch.type !== 'slack') return { kind: 'operator' };
+  try {
+    const info = await getChannelInfo(ch.channel_id);
+    if (info.isIm) return { kind: 'dm', userId: info.imUserId };
+    return { kind: 'channel', channelId: ch.channel_id };
+  } catch {
+    // Fail closed: a Slack lookup failure must not widen visibility. Treat the
+    // origin as this exact channel (sees public + its own triggers only), never
+    // operator. A DM misclassified this way under-permits, which is the safe way.
+    return { kind: 'channel', channelId: ch.channel_id };
+  }
+}
+
+/** Memoized live channel-privacy resolver for one list/visibility pass. */
+function makePrivacyResolver(): (channelId: string) => Promise<boolean> {
+  const cache = new Map<string, Promise<boolean>>();
+  // Built once per resolver: the workspace channel map (id → isPrivate), served
+  // from listWorkspaceChannels()'s 10-min process-wide cache. The common case is
+  // then an O(1) lookup with zero per-channel Slack calls. On a workspace-list
+  // failure the map is empty and every channel falls through to the live path.
+  let mapPromise: Promise<Map<string, boolean>> | undefined;
+  const workspaceMap = () => {
+    if (!mapPromise) {
+      mapPromise = listWorkspaceChannels()
+        .then((channels) => new Map(channels.map((c) => [c.id, c.isPrivate])))
+        .catch(() => new Map<string, boolean>());
+    }
+    return mapPromise;
+  };
+  return (channelId: string) => {
+    let p = cache.get(channelId);
+    if (!p) {
+      p = workspaceMap().then((map) => {
+        if (map.has(channelId)) return map.get(channelId)!;
+        // Miss — a brand-new, just-converted, or (crucially) a private channel
+        // the bot was removed from and so dropped out of the workspace cache.
+        // Resolve it live via the STRICT lookup that throws on error, and fail
+        // closed on any error (treat as private) so a private channel is never
+        // leaked into a public/DM listing. getChannelInfo can't be used here —
+        // it swallows errors and returns isPrivate:false (i.e. fails open).
+        return fetchChannelIsPrivate(channelId).catch(() => true);
+      });
+      cache.set(channelId, p);
+    }
+    return p;
+  };
+}
+
+/** Best-effort Slack user id of whoever is asking (only known in a DM). */
+async function resolveRequester(task: Task): Promise<string | undefined> {
+  const origin = await resolveTriggerOrigin(task);
+  return origin.kind === 'dm' ? origin.userId : undefined;
+}
+
+/**
+ * Validate + normalize tool-supplied conditions into stored TriggerConditions.
+ * Recurring schedules are interval-checked (≥1h) and get an initial next_run_at;
+ * one-offs parse run_at and must be in the future.
+ */
+function buildConditions(raw: RawCondition[], defaultTz: string): { conditions: TriggerCondition[] } | { error: string } {
+  const conditions: TriggerCondition[] = [];
+  for (const c of raw) {
+    if (c.type === 'schedule') {
+      const tz = c.tz || defaultTz;
+      if (c.cron) {
+        const v = validateRecurringInterval(c.cron, tz);
+        if (!v.ok) return { error: v.error };
+        const next = computeNextRun(c.cron, tz);
+        if (!next) return { error: `Could not compute the next run for cron "${c.cron}".` };
+        conditions.push({ type: 'schedule', tz, cron: c.cron, next_run_at: next.toISOString() });
+      } else if (c.run_at) {
+        const when = new Date(c.run_at);
+        if (isNaN(when.getTime())) return { error: `Invalid run_at "${c.run_at}" — use parse_datetime for an ISO 8601 value.` };
+        if (when.getTime() <= Date.now()) return { error: 'A one-off schedule must be in the future.' };
+        conditions.push({ type: 'schedule', tz, next_run_at: when.toISOString() });
+      } else {
+        return { error: 'A schedule condition needs either `cron` (recurring) or `run_at` (one-off).' };
+      }
+    } else if (c.type === 'channel_message') {
+      if (!c.channel_id) return { error: 'A channel_message condition needs `channel_id`.' };
+      const match: { contains?: string; from_user?: string } = {};
+      if (c.contains) match.contains = c.contains;
+      if (c.from_user) match.from_user = c.from_user;
+      conditions.push({ type: 'channel_message', channel_id: c.channel_id, ...(Object.keys(match).length ? { match } : {}) });
+    } else {
+      return { error: `Unknown condition type "${(c as { type: string }).type}".` };
+    }
+  }
+  if (conditions.length === 0) return { error: 'At least one condition is required.' };
+  return { conditions };
+}
+
+function createProposeTriggerTool(agent: Agent, task: Task) {
+  return tool(
+    'propose_trigger',
+    'Propose a persistent trigger ("do Y when X happens") for the user to approve. The trigger is created in a pending state and an Approve/Deny prompt is posted — it will NOT run until the user approves. Use this after you and the user have agreed on the cadence (or channel to watch), what to do, and which channel to deliver to. Results are delivered to a channel; delivery to a user DM is not supported yet. You do not need to pause the task.',
+    {
+      binding: z.object({
+        type: z.enum(['channel']),
+        channel_id: z.string().describe('Slack channel ID where fired results are delivered.'),
+        channel_name: z.string().describe('Channel name without the leading #.'),
+      }).describe('Where fired results are delivered — a channel (DM delivery is not supported yet).'),
+      conditions: z.array(triggerConditionObject).min(1).describe('One or more conditions; any match fires the trigger.'),
+      action_prompt: z.string().describe('The full internal instruction seeded to the task when the trigger fires — detailed and imperative. NOT shown to the user.'),
+      summary: z.string().describe('A short, friendly one-liner describing what this does, shown to the user in the approval prompt and announcements, e.g. "Daily summary of #bot-test" or "Reply to messages mentioning Archie". Keep it under ~60 chars; do not restate the schedule (that is rendered automatically).'),
+    },
+    async (args) => {
+      if (!triggersEnabled()) return ok('Triggers are currently disabled on this instance (ARCHIE_TRIGGERS_ENABLED=false).');
+
+      const b = args.binding;
+      if (!b.channel_id || !b.channel_name) return ok('A trigger needs both channel_id and channel_name for delivery.');
+      const binding: TriggerBinding = { type: 'channel', channel_id: b.channel_id, channel_name: b.channel_name };
+
+      // Best-effort creator id (only known in a DM) — used for cap accounting and
+      // failure notices, not for delivery. Triggers deliver to a channel in v1.
+      const createdBy = await resolveRequester(task);
+      let defaultTz = 'UTC';
+      if (createdBy) {
+        try { defaultTz = (await getUserInfo(createdBy)).tz || 'UTC'; } catch { /* keep UTC */ }
+      }
+
+      const built = buildConditions(args.conditions, defaultTz);
+      if ('error' in built) return ok(`Could not create the trigger: ${built.error}`);
+
+      if (binding.type === 'channel') {
+        const channelId = binding.channel_id;
+        const perChannel = await countActiveTriggers((t) => t.binding.type === 'channel' && t.binding.channel_id === channelId);
+        if (perChannel >= MAX_TRIGGERS_PER_CHANNEL) {
+          return ok(`This channel already has the maximum of ${MAX_TRIGGERS_PER_CHANNEL} active triggers. Remove one first.`);
+        }
+      }
+      if (createdBy) {
+        const perUser = await countActiveTriggers((t) => t.created_by === createdBy);
+        if (perUser >= MAX_TRIGGERS_PER_USER) {
+          return ok(`You already have the maximum of ${MAX_TRIGGERS_PER_USER} active triggers. Remove one first.`);
+        }
+      }
+
+      const trigger: Trigger = {
+        id: generateTriggerId(),
+        status: 'pending',
+        created_by: createdBy || 'unknown',
+        created_at: new Date().toISOString(),
+        binding,
+        conditions: built.conditions,
+        action: { prompt: args.action_prompt },
+        summary: args.summary,
+      };
+      await saveTrigger(trigger);
+      task.metadata.pending_trigger_id = trigger.id;
+      task.debouncedSave();
+      await appendAgentFinding(task.taskId, 'system', `Trigger proposed: ${describeTrigger(trigger)}`, 'decision');
+
+      // Scannable approval card: what / when / where as separate fields instead
+      // of dumping the raw cron + internal prompt.
+      const what = triggerWhat(trigger);
+      const when = triggerWhen(trigger);
+      const where = triggerWhere(trigger);
+      const blocks = [
+        { type: 'section', text: { type: 'mrkdwn', text: '*Set up this automation?*' } },
+        {
+          type: 'section',
+          fields: [
+            { type: 'mrkdwn', text: `*What*\n${what}` },
+            { type: 'mrkdwn', text: `*When*\n${when}` },
+            { type: 'mrkdwn', text: `*Where*\n${where}` },
+          ],
+        },
+        {
+          type: 'actions',
+          elements: [
+            { type: 'button', text: { type: 'plain_text', text: 'Approve' }, action_id: 'approve_trigger', value: trigger.id, style: 'primary' },
+            { type: 'button', text: { type: 'plain_text', text: 'Deny' }, action_id: 'deny_trigger', value: trigger.id, style: 'danger' },
+          ],
+        },
+      ];
+      await task.postInteractiveToUser(`Set up this automation? ${what} · ${when} · ${where}`, blocks, 'trigger', undefined, undefined, trigger.id);
+      return ok('Trigger proposed and posted for approval. It will not run until the user approves (or types y in the CLI). No need to pause — continue if there is other work.');
+    },
+  );
+}
+
+function createListTriggersTool(_agent: Agent, task: Task) {
+  return tool(
+    'list_triggers',
+    'List the triggers visible from this conversation (per privacy rules). Returns everything visible — filter or narrow it yourself when the user asks for "the ones in this channel", "just the schedules", etc.',
+    {},
+    async () => {
+      const all = (await listTriggers()).filter((t) => t.status !== 'pending');
+      const origin = await resolveTriggerOrigin(task);
+      const resolvePrivacy = makePrivacyResolver();
+      const visible: Trigger[] = [];
+      for (const t of all) {
+        if (await triggerVisibleFrom(t, origin, resolvePrivacy)) visible.push(t);
+      }
+      if (visible.length === 0) return ok('There are no triggers set up that are visible from here.');
+      const lines = visible.map((t) => {
+        const where = t.binding.type === 'channel' ? `#${t.binding.channel_name}` : 'a DM';
+        const last = t.last_fired_at ? `; last fired ${t.last_fired_at}` : '';
+        return `• [${t.id}] (${t.status}) ${describeTrigger(t)} — delivers to ${where}${last}`;
+      });
+      return ok(`Triggers visible here (${visible.length}):\n${lines.join('\n')}`);
+    },
+  );
+}
+
+function createUpdateTriggerTool(_agent: Agent, task: Task) {
+  return tool(
+    'update_trigger',
+    'Pause, resume, or edit an existing trigger. You can only manage triggers visible from this conversation. Posts a one-line change notice to the trigger\'s bound channel.',
+    {
+      id: z.string().describe('Trigger ID (from list_triggers).'),
+      status: z.enum(['paused', 'enabled']).optional().describe('"paused" to pause, "enabled" to resume.'),
+      action_prompt: z.string().optional().describe('Replace the internal instruction run when the trigger fires (not shown to the user).'),
+      summary: z.string().optional().describe('Replace the short, friendly user-facing name. Update this whenever you change action_prompt so the notices stay accurate.'),
+      conditions: z.array(triggerConditionObject).optional().describe('Replace the conditions entirely (same shape as propose_trigger).'),
+    },
+    async (args) => {
+      const trigger = await loadTrigger(args.id);
+      if (!trigger || trigger.status === 'pending') return ok(`No trigger ${args.id} found.`);
+      const origin = await resolveTriggerOrigin(task);
+      if (!(await triggerVisibleFrom(trigger, origin, makePrivacyResolver()))) {
+        return ok(`Trigger ${args.id} isn't visible from here, so it can't be managed from this conversation.`);
+      }
+
+      const editedContent = Boolean(args.action_prompt || args.conditions || args.summary);
+      let statusChange: 'paused' | 'resumed' | null = null;
+
+      if (args.action_prompt) trigger.action.prompt = args.action_prompt;
+      if (args.summary) trigger.summary = args.summary;
+      if (args.conditions) {
+        const defaultTz = trigger.conditions.find((c): c is Extract<TriggerCondition, { type: 'schedule' }> => c.type === 'schedule')?.tz || 'UTC';
+        const built = buildConditions(args.conditions, defaultTz);
+        if ('error' in built) return ok(`Could not update the trigger: ${built.error}`);
+        trigger.conditions = built.conditions;
+      }
+      // Decide the target state (auto-resume a rescheduled paused trigger, etc.)
+      // via the pure planner, then apply the cap check for any (re-)enable.
+      const plan = planStatusChange({
+        currentStatus: trigger.status as 'enabled' | 'paused',
+        hasNewConditions: !!args.conditions,
+        requestedStatus: args.status,
+      });
+      const autoResume = plan.autoResume;
+      if (plan.target === 'enabled') {
+        // Re-check caps when (re-)enabling, so pausing to slip under a cap and
+        // then resuming can't exceed it. (Counts exclude this paused trigger.)
+        if (trigger.binding.type === 'channel') {
+          const channelId = trigger.binding.channel_id;
+          const perChannel = await countActiveTriggers((t) => t.binding.type === 'channel' && t.binding.channel_id === channelId);
+          if (perChannel >= MAX_TRIGGERS_PER_CHANNEL) return ok(`Can't enable — this channel is already at the maximum of ${MAX_TRIGGERS_PER_CHANNEL} active triggers.`);
+        }
+        if (trigger.created_by && trigger.created_by !== 'unknown') {
+          const perUser = await countActiveTriggers((t) => t.created_by === trigger.created_by);
+          if (perUser >= MAX_TRIGGERS_PER_USER) return ok(`Can't enable — you're already at the maximum of ${MAX_TRIGGERS_PER_USER} active triggers.`);
+        }
+      }
+      if (plan.target !== 'unchanged') {
+        trigger.status = plan.target;
+        statusChange = plan.statusChange;
+      }
+
+      if (!editedContent && !statusChange) return ok('Nothing to update — pass status, action_prompt, summary, or conditions.');
+
+      await saveTrigger(trigger);
+      if (trigger.status === 'enabled') indexTrigger(trigger);
+      else deindexTrigger(trigger.id);
+
+      if (statusChange === 'paused') emitEvent('trigger:paused', task.taskId, { trigger_id: trigger.id });
+      else if (statusChange === 'resumed') emitEvent('trigger:resumed', task.taskId, { trigger_id: trigger.id });
+
+      await announceTriggerChange(trigger, editedContent ? 'edited' : statusChange!);
+
+      // Report state back so the PM can relay it — especially the auto-resume,
+      // which the user didn't explicitly ask for and should be told about.
+      const verb = editedContent ? 'updated' : (statusChange === 'paused' ? 'paused' : 'resumed');
+      let msg = `Trigger ${trigger.id} ${verb}.`;
+      if (statusChange === 'resumed') {
+        msg += autoResume
+          ? ` It had been paused, so I re-enabled it — it's now active and will run ${triggerWhen(trigger)}.`
+          : ` It's now active and will run ${triggerWhen(trigger)}.`;
+      } else if (trigger.status === 'enabled' && editedContent) {
+        msg += ` It's active and will run ${triggerWhen(trigger)}.`;
+      } else if (trigger.status === 'paused') {
+        msg += ` It's paused and won't run until it's resumed.`;
+      }
+      return ok(msg);
+    },
+  );
+}
+
+function createDeleteTriggerTool(_agent: Agent, task: Task) {
+  return tool(
+    'delete_trigger',
+    'Delete a trigger permanently. You can only delete triggers visible from this conversation. Posts a one-line notice to the bound channel.',
+    {
+      id: z.string().describe('Trigger ID (from list_triggers).'),
+    },
+    async (args) => {
+      const trigger = await loadTrigger(args.id);
+      if (!trigger) return ok(`No trigger ${args.id} found.`);
+      const origin = await resolveTriggerOrigin(task);
+      if (trigger.status !== 'pending' && !(await triggerVisibleFrom(trigger, origin, makePrivacyResolver()))) {
+        return ok(`Trigger ${args.id} isn't visible from here, so it can't be deleted from this conversation.`);
+      }
+      deindexTrigger(trigger.id);
+      await deleteTrigger(trigger.id);
+      emitEvent('trigger:deleted', task.taskId, { trigger_id: trigger.id });
+      if (trigger.status !== 'pending') await announceTriggerChange(trigger, 'deleted');
+      return ok(`Trigger ${trigger.id} deleted.`);
+    },
+  );
+}
+
 // ---- MCP Server creation ----
 
 /**
@@ -2193,6 +2562,10 @@ export function createOrchestrationMcpServer(agent: Agent, task: Task) {
       createGetAgentsStatusTool(agent, task),
       createListAvailableReposTool(agent, task),
       createSpawnRepoAgentTool(agent, task),
+      createProposeTriggerTool(agent, task),
+      createListTriggersTool(agent, task),
+      createUpdateTriggerTool(agent, task),
+      createDeleteTriggerTool(agent, task),
     ],
   });
 }

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3,10 +3,11 @@ import { Box, Text, useInput, useApp, useStdout } from 'ink';
 import { connectSSE, createTask } from './api.js';
 import { TaskList } from './components/TaskList.js';
 import { TaskDetail } from './components/TaskDetail.js';
+import { TriggerList } from './components/TriggerList.js';
 import { StatusBar } from './components/StatusBar.js';
 import { MessageInput } from './components/MessageInput.js';
 
-type View = 'list' | 'detail' | 'create';
+type View = 'list' | 'detail' | 'create' | 'triggers';
 
 export function App() {
   const { exit } = useApp();
@@ -42,6 +43,11 @@ export function App() {
         if (view === 'list' && event.type?.startsWith('task:')) {
           refresh();
         }
+
+        // For triggers view: refresh on trigger-level events
+        if (view === 'triggers' && event.type?.startsWith('trigger:')) {
+          refresh();
+        }
       },
       onConnect: () => setConnected(true),
       onDisconnect: () => setConnected(false),
@@ -56,6 +62,11 @@ export function App() {
   useInput((input, key) => {
     if (view === 'create') return; // create view captures input
     if (view === 'detail') return; // detail view handles its own navigation (esc to go back)
+    if (view === 'triggers') return; // triggers view handles its own navigation
+    if (view === 'list' && (input === 't' || input === 'T')) {
+      setView('triggers');
+      return;
+    }
     if (input === 'q' || input === 'Q') {
       exit();
     }
@@ -127,6 +138,13 @@ export function App() {
         )}
         {view === 'create' && (
           <CreateTaskPrompt onSubmit={handleCreateTask} onCancel={handleCancelCreate} />
+        )}
+        {view === 'triggers' && (
+          <TriggerList
+            onBack={() => setView('list')}
+            active={view === 'triggers'}
+            refreshTrigger={refreshTrigger}
+          />
         )}
       </Box>
 

--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -61,11 +61,35 @@ export async function fetchTaskEvents(
   return res.json() as Promise<{ events: any[]; total: number }>;
 }
 
+export async function fetchTriggers(): Promise<{ triggers: any[]; total: number }> {
+  const res = await fetch(`${getBaseUrl()}/api/triggers`);
+  if (!res.ok) throw new Error(`Failed to fetch triggers: ${res.status}`);
+  return res.json() as Promise<{ triggers: any[]; total: number }>;
+}
+
+export async function updateTrigger(
+  id: string,
+  patch: { status?: 'paused' | 'enabled'; action_prompt?: string },
+): Promise<void> {
+  const res = await fetch(`${getBaseUrl()}/api/triggers/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw new Error(`Failed to update trigger: ${res.status}`);
+}
+
+export async function deleteTrigger(id: string): Promise<void> {
+  const res = await fetch(`${getBaseUrl()}/api/triggers/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`Failed to delete trigger: ${res.status}`);
+}
+
 export async function sendApproval(
   taskId: string,
-  type: 'edit_mode' | 'research_budget' | 'merge',
+  type: 'edit_mode' | 'research_budget' | 'merge' | 'trigger',
   approve: boolean,
   identity?: { github: string; pr_number: number },
+  ref?: string,
 ): Promise<void> {
   // merge-type resolutions must carry the PR identity or the API 400s — this
   // was the CLI approval bug (blank screen on a merge prompt). Other types omit
@@ -77,6 +101,7 @@ export async function sendApproval(
       type,
       approve,
       ...(identity ? { github: identity.github, pr_number: identity.pr_number } : {}),
+      ...(ref ? { ref } : {}),
     }),
   });
   if (!res.ok) throw new Error(`Failed to send approval: ${res.status}`);

--- a/src/cli/components/StatusBar.tsx
+++ b/src/cli/components/StatusBar.tsx
@@ -11,7 +11,7 @@ export function StatusBar({ connected, view }: StatusBarProps) {
   const statusColor = connected ? 'green' : 'red';
 
   const hints = view === 'list'
-    ? 'arrows: navigate | enter: open | n: new task | q: quit'
+    ? 'arrows: navigate | enter: open | n: new task | t: triggers | q: quit'
     : 'esc: back | tab: focus input | q: quit';
 
   return (

--- a/src/cli/components/TaskDetail.tsx
+++ b/src/cli/components/TaskDetail.tsx
@@ -128,7 +128,7 @@ export function TaskDetail({ taskId, onBack, liveEvents, onConnect }: TaskDetail
   const logHeight = Math.max(5, termHeight - reservedLines);
 
   // Build log lines with inline approvals
-  const logLines: { node: React.ReactNode; approval?: { approvalType: 'edit_mode' | 'research_budget' | 'merge'; eventIndex: number; github?: string; pr_number?: number } }[] = [];
+  const logLines: { node: React.ReactNode; approval?: { approvalType: 'edit_mode' | 'research_budget' | 'merge' | 'trigger'; eventIndex: number; github?: string; pr_number?: number; ref?: string } }[] = [];
 
   // Fold pr_card events so a card renders once, at its most recent `post`
   // (anchor), showing the latest merged state. `update` events refresh the data
@@ -196,7 +196,8 @@ export function TaskDetail({ taskId, onBack, liveEvents, onConnect }: TaskDetail
             logLines.push({
               node: <Text color="yellow" bold>⏳ {event.data.text as string}  [y] approve / [n] deny</Text>,
               approval: {
-                approvalType: event.data.approvalType as 'edit_mode' | 'research_budget' | 'merge',
+                approvalType: event.data.approvalType as 'edit_mode' | 'research_budget' | 'merge' | 'trigger',
+                ref: event.data.ref as string | undefined,
                 eventIndex: idx,
                 // Merge approvals carry the PR identity; the API requires it on
                 // resolution. Absent for other types (undefined → omitted).
@@ -388,11 +389,11 @@ export function TaskDetail({ taskId, onBack, liveEvents, onConnect }: TaskDetail
       // Scroll mode / approval handling
       if (input === 'q' || input === 'Q') exit();
       if (focusedApproval && (input === 'y' || input === 'Y')) {
-        sendApproval(taskId, focusedApproval.approvalType, true, mergeIdentity(focusedApproval)).catch((err: any) => setError(err.message));
+        sendApproval(taskId, focusedApproval.approvalType, true, mergeIdentity(focusedApproval), focusedApproval.ref).catch((err: any) => setError(err.message));
         setFocusedApprovalLine(null);
         setInputActive(true);
       } else if (focusedApproval && (input === 'n' || input === 'N')) {
-        sendApproval(taskId, focusedApproval.approvalType, false, mergeIdentity(focusedApproval)).catch((err: any) => setError(err.message));
+        sendApproval(taskId, focusedApproval.approvalType, false, mergeIdentity(focusedApproval), focusedApproval.ref).catch((err: any) => setError(err.message));
         setFocusedApprovalLine(null);
         setInputActive(true);
       }

--- a/src/cli/components/TriggerList.tsx
+++ b/src/cli/components/TriggerList.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import { fetchTriggers, updateTrigger, deleteTrigger } from '../api.js';
+
+interface TriggerSummary {
+  id: string;
+  status: string;
+  created_by: string;
+  created_at: string;
+  last_fired_at: string | null;
+  binding_kind: 'channel' | 'user';
+  channel_name: string;
+  action_prompt: string;
+  summary: string;
+}
+
+interface TriggerListProps {
+  onBack: () => void;
+  active: boolean;
+  refreshTrigger: number;
+}
+
+function StatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case 'enabled': return <Text color="green">[on]</Text>;
+    case 'paused': return <Text color="yellow">[--]</Text>;
+    default: return <Text color="gray">[?]</Text>;
+  }
+}
+
+export function TriggerList({ onBack, active, refreshTrigger }: TriggerListProps) {
+  const { stdout } = useStdout();
+  const termHeight = stdout?.rows ?? 24;
+  const visibleRows = Math.max(1, termHeight - 5);
+
+  const [triggers, setTriggers] = useState<TriggerSummary[]>([]);
+  const [cursor, setCursor] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      const { triggers: t } = await fetchTriggers();
+      setTriggers(t);
+      setError(null);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    load();
+  }, [load, refreshTrigger]);
+
+  useInput((input, key) => {
+    if (!active) return;
+    if (key.escape || input === 'b' || input === 'B') {
+      onBack();
+    } else if (key.upArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+    } else if (key.downArrow) {
+      setCursor((c) => Math.min(triggers.length - 1, c + 1));
+    } else if ((input === 'p' || input === 'P') && triggers[cursor]) {
+      const t = triggers[cursor];
+      const next = t.status === 'enabled' ? 'paused' : 'enabled';
+      updateTrigger(t.id, { status: next }).then(load).catch((e: any) => setError(e.message));
+    } else if ((input === 'd' || input === 'D') && triggers[cursor]) {
+      deleteTrigger(triggers[cursor].id).then(() => {
+        setCursor((c) => Math.max(0, c - 1));
+        return load();
+      }).catch((e: any) => setError(e.message));
+    } else if (input === 'r' || input === 'R') {
+      load();
+    }
+  });
+
+  if (loading) {
+    return <Box padding={1}><Text dimColor>Loading triggers...</Text></Box>;
+  }
+
+  if (error) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="red">Error: {error}</Text>
+        <Text dimColor>Press <Text color="cyan" bold>b</Text> to go back</Text>
+      </Box>
+    );
+  }
+
+  if (triggers.length === 0) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text bold>No triggers set up</Text>
+        <Text dimColor>Ask Archie in Slack or the CLI to "remind me…" or "every weekday at 9am…". Press <Text color="cyan" bold>b</Text> to go back.</Text>
+      </Box>
+    );
+  }
+
+  const scrollTop = Math.max(0, Math.min(cursor - Math.floor(visibleRows / 2), triggers.length - visibleRows));
+  const visible = triggers.slice(scrollTop, scrollTop + visibleRows);
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Box marginBottom={1}>
+        <Text bold>Triggers ({triggers.length})</Text>
+        <Text dimColor>   [p] pause/resume  [d] delete  [r] refresh  [b] back</Text>
+      </Box>
+      {visible.map((t, i) => {
+        const selected = scrollTop + i === cursor;
+        const where = t.binding_kind === 'channel' ? `#${t.channel_name}` : 'DM';
+        return (
+          <Box key={t.id} paddingX={1}>
+            <Text wrap="truncate-end">
+              <Text color={selected ? 'cyan' : undefined} bold={selected}>{selected ? '> ' : '  '}</Text>
+              <StatusIcon status={t.status} />
+              <Text color={selected ? 'cyan' : undefined} bold={selected}> {t.id}</Text>
+              <Text dimColor>  {where}</Text>
+              <Text>  {t.summary}</Text>
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/connectors/api/routes.ts
+++ b/src/connectors/api/routes.ts
@@ -23,6 +23,9 @@ import {
 import { SESSIONS_DIR } from '../../system/workdir.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
 import { logger } from '../../system/logger.js';
+import { listTriggers, loadTrigger, saveTrigger, deleteTrigger, countActiveTriggers } from '../../system/trigger-store.js';
+import { indexTrigger, deindexTrigger, announceTriggerChange, describeTrigger, MAX_TRIGGERS_PER_USER, MAX_TRIGGERS_PER_CHANNEL } from '../../system/trigger-scheduler.js';
+import type { Trigger } from '../../types/trigger.js';
 
 /**
  * Mount API routes on an existing Express app.
@@ -218,7 +221,7 @@ export function mountApiRoutes(app: Application): void {
   router.post('/tasks/:id/approve', async (req: Request, res: Response) => {
     try {
       const taskId = req.params.id as string;
-      const { type, approve, approver, github, pr_number } = req.body as {
+      const { type, approve, approver, github, pr_number, ref } = req.body as {
         type: string;
         approve: boolean;
         // Optional resolved human (id/name/email) to author commits as. CLI/API
@@ -229,6 +232,9 @@ export function mountApiRoutes(app: Application): void {
         // pending request inside the Task resolution methods.
         github?: string;
         pr_number?: number;
+        // Optional opaque id the approval applies to (e.g. a trigger id), echoed
+        // from the approval event so the right pending item resolves.
+        ref?: string;
       };
 
       if (!type || typeof approve !== 'boolean') {
@@ -292,6 +298,16 @@ export function mountApiRoutes(app: Application): void {
           });
           return;
         }
+      } else if (type === 'trigger') {
+        // CLI [y]/[n] on a proposed trigger — same task-level handler the Slack
+        // Approve/Deny buttons call. `ref` carries the specific trigger id (the
+        // CLI echoes it from the approval event), so the right one resolves even
+        // when several proposals are outstanding. Approver is the CLI operator.
+        if (approve) {
+          await task.handleTriggerApproval('cli', ref);
+        } else {
+          await task.handleTriggerDenial(ref);
+        }
       } else {
         res.status(400).json({ error: `Unknown approval type: ${type}` });
         return;
@@ -305,6 +321,126 @@ export function mountApiRoutes(app: Application): void {
     }
   });
 
+  // ---- Triggers (operator surface — full visibility, mirrors /tasks) ----
+
+  /** Shape a trigger for the CLI/API, surfacing its bound channel like /tasks. */
+  const shapeTrigger = (t: Trigger) => ({
+    id: t.id,
+    status: t.status,
+    created_by: t.created_by,
+    created_at: t.created_at,
+    last_fired_at: t.last_fired_at ?? null,
+    binding_kind: t.binding.type,
+    channel_name: t.binding.type === 'channel' ? t.binding.channel_name : 'DM',
+    action_prompt: t.action.prompt,
+    summary: describeTrigger(t),
+  });
+
+  // GET /triggers — list all triggers with their bound channel
+  router.get('/triggers', async (_req: Request, res: Response) => {
+    try {
+      const triggers = (await listTriggers())
+        .filter((t) => t.status !== 'pending')
+        .sort((a, b) => b.created_at.localeCompare(a.created_at));
+      res.json({ triggers: triggers.map(shapeTrigger), total: triggers.length });
+    } catch (error) {
+      logger.error('api', 'Failed to list triggers', error);
+      res.status(500).json({ error: 'Failed to list triggers' });
+    }
+  });
+
+  // GET /triggers/:id — trigger detail
+  router.get('/triggers/:id', async (req: Request, res: Response) => {
+    try {
+      const trigger = await loadTrigger(req.params.id as string);
+      if (!trigger || trigger.status === 'pending') {
+        res.status(404).json({ error: 'Trigger not found' });
+        return;
+      }
+      res.json({ trigger });
+    } catch (error) {
+      logger.error('api', 'Failed to get trigger', error);
+      res.status(500).json({ error: 'Failed to get trigger' });
+    }
+  });
+
+  // PATCH /triggers/:id — pause/resume or edit the action prompt
+  router.patch('/triggers/:id', async (req: Request, res: Response) => {
+    try {
+      const id = req.params.id as string;
+      const { status, action_prompt } = req.body as { status?: 'paused' | 'enabled'; action_prompt?: string };
+      const trigger = await loadTrigger(id);
+      if (!trigger || trigger.status === 'pending') {
+        res.status(404).json({ error: 'Trigger not found' });
+        return;
+      }
+
+      const editedContent = typeof action_prompt === 'string';
+      let statusChange: 'paused' | 'resumed' | null = null;
+      if (editedContent) trigger.action.prompt = action_prompt as string;
+      if (status && status !== trigger.status) {
+        // Re-check caps on resume so pause→resume can't bypass the limit.
+        if (status === 'enabled') {
+          if (trigger.binding.type === 'channel') {
+            const channelId = trigger.binding.channel_id;
+            const perChannel = await countActiveTriggers((t) => t.binding.type === 'channel' && t.binding.channel_id === channelId);
+            if (perChannel >= MAX_TRIGGERS_PER_CHANNEL) {
+              res.status(409).json({ error: `Channel is at the maximum of ${MAX_TRIGGERS_PER_CHANNEL} active triggers.` });
+              return;
+            }
+          }
+          if (trigger.created_by && trigger.created_by !== 'unknown') {
+            const createdBy = trigger.created_by;
+            const perUser = await countActiveTriggers((t) => t.created_by === createdBy);
+            if (perUser >= MAX_TRIGGERS_PER_USER) {
+              res.status(409).json({ error: `User is at the maximum of ${MAX_TRIGGERS_PER_USER} active triggers.` });
+              return;
+            }
+          }
+        }
+        trigger.status = status;
+        statusChange = status === 'paused' ? 'paused' : 'resumed';
+      }
+      if (!editedContent && !statusChange) {
+        res.status(400).json({ error: 'Pass status or action_prompt to update.' });
+        return;
+      }
+
+      await saveTrigger(trigger);
+      if (trigger.status === 'enabled') indexTrigger(trigger);
+      else deindexTrigger(trigger.id);
+
+      if (statusChange === 'paused') emitEvent('trigger:paused', trigger.id, { trigger_id: trigger.id });
+      else if (statusChange === 'resumed') emitEvent('trigger:resumed', trigger.id, { trigger_id: trigger.id });
+      await announceTriggerChange(trigger, editedContent ? 'edited' : statusChange!);
+
+      res.json({ ok: true, trigger: shapeTrigger(trigger) });
+    } catch (error) {
+      logger.error('api', 'Failed to update trigger', error);
+      res.status(500).json({ error: 'Failed to update trigger' });
+    }
+  });
+
+  // DELETE /triggers/:id — remove a trigger
+  router.delete('/triggers/:id', async (req: Request, res: Response) => {
+    try {
+      const id = req.params.id as string;
+      const trigger = await loadTrigger(id);
+      if (!trigger) {
+        res.status(404).json({ error: 'Trigger not found' });
+        return;
+      }
+      deindexTrigger(id);
+      await deleteTrigger(id);
+      emitEvent('trigger:deleted', id, { trigger_id: id });
+      if (trigger.status !== 'pending') await announceTriggerChange(trigger, 'deleted');
+      res.json({ ok: true });
+    } catch (error) {
+      logger.error('api', 'Failed to delete trigger', error);
+      res.status(500).json({ error: 'Failed to delete trigger' });
+    }
+  });
+
   app.use('/api', router);
-  logger.plain('API routes: /api/tasks, /api/events/stream');
+  logger.plain('API routes: /api/tasks, /api/triggers, /api/events/stream');
 }

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -1250,27 +1250,51 @@ export async function postEphemeral(
 /**
  * Get channel info
  */
-export async function getChannelInfo(channelId: string): Promise<{ id: string; name: string }> {
+export async function getChannelInfo(
+  channelId: string,
+): Promise<{ id: string; name: string; isPrivate: boolean; isIm: boolean; imUserId?: string }> {
   const client = getSlackClient();
 
   try {
     const result = await client.conversations.info({ channel: channelId });
-    const channel = result.channel as { name?: string; is_im?: boolean; user?: string } | undefined;
+    const channel = result.channel as
+      | { name?: string; is_im?: boolean; is_private?: boolean; user?: string }
+      | undefined;
+
+    const isIm = channel?.is_im === true;
+    // DMs are inherently private; otherwise read the channel's is_private flag.
+    const isPrivate = isIm || channel?.is_private === true;
 
     // For DMs, resolve the other user's name instead of showing a raw ID
-    if (channel?.is_im && channel.user) {
+    if (isIm && channel?.user) {
       const userInfo = await getUserInfo(channel.user);
-      return { id: channelId, name: `DM with ${userInfo.realName}` };
+      return { id: channelId, name: `DM with ${userInfo.realName}`, isPrivate, isIm, imUserId: channel.user };
     }
 
     return {
       id: channelId,
       name: channel?.name || channelId,
+      isPrivate,
+      isIm,
     };
   } catch (error) {
     logger.warn('Slack', `Failed to get channel info for ${channelId}`);
-    return { id: channelId, name: channelId };
+    return { id: channelId, name: channelId, isPrivate: false, isIm: false };
   }
+}
+
+/**
+ * Resolve a channel's current privacy, **throwing** on any API error rather than
+ * swallowing it. Unlike `getChannelInfo` (which returns `isPrivate:false` on
+ * failure), this lets callers that must fail *closed* — e.g. trigger visibility,
+ * where an unresolvable channel must be treated as private, never public —
+ * distinguish a genuine public channel from an unreachable one. A DM is private.
+ */
+export async function fetchChannelIsPrivate(channelId: string): Promise<boolean> {
+  const client = getSlackClient();
+  const result = await client.conversations.info({ channel: channelId });
+  const channel = result.channel as { is_im?: boolean; is_private?: boolean } | undefined;
+  return channel?.is_im === true || channel?.is_private === true;
 }
 
 // ---- Channel canvas tabs + file reads (project-context canvases) ----------
@@ -1391,6 +1415,29 @@ export async function fetchSlackFileBody(fileUrl: string): Promise<string> {
   }
 
   return await response.text();
+}
+
+/**
+ * Probe whether a channel can currently receive a post from the bot. Returns
+ * false when the channel no longer exists or is archived (e.g. deleted, or the
+ * bot was removed and the channel archived). A successful `conversations.info`
+ * on a live, non-archived channel returns true. Note: a public channel returns
+ * true even if the bot isn't a member (Slack allows posting), so this primarily
+ * catches the deleted/archived cases — the strongest signal available without
+ * actually posting.
+ */
+export async function isChannelReachable(channelId: string): Promise<boolean> {
+  try {
+    // getSlackClient() is inside the try on purpose: if the client isn't
+    // initialized it throws, and this probe must return false (→ fireTrigger
+    // pauses the trigger) rather than propagate and error-loop every tick.
+    const client = getSlackClient();
+    const result = await client.conversations.info({ channel: channelId });
+    const channel = result.channel as { is_archived?: boolean } | undefined;
+    return channel ? channel.is_archived !== true : false;
+  } catch {
+    return false;
+  }
 }
 
 

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -34,6 +34,8 @@ import { AGENT_PROMPTS } from '../../agents/prompts.js';
 import { logger } from '../../system/logger.js';
 import { getIsShuttingDown } from '../../system/shutdown.js';
 import { findTaskByThread } from '../../tasks/persistence.js';
+import { getChannelMessageTriggers, fireTrigger, triggerWhat } from '../../system/trigger-scheduler.js';
+import type { Trigger } from '../../types/trigger.js';
 import { generateTaskTitle } from '../../tasks/title-generator.js';
 import { setAssistantThreadTitle } from './title.js';
 import type { SlackThread, SlackAuthor } from '../../types/task.js';
@@ -164,10 +166,17 @@ export async function mountSlackApp(
 
     const isDm = event.channel?.startsWith('D');
     const isThreadReply = event.thread_ts && event.thread_ts !== event.ts;
+    // A top-level channel post is normally ignored (ambient chatter). We only
+    // forward it when an enabled channel-message trigger is watching this exact
+    // channel — kept cheap via the in-memory index, so unwatched channels stay
+    // a no-op. handleSlackEvent then runs the same own-bot/external/@mention
+    // filtering before firing any trigger.
+    const isTopLevelChannelMsg = !isDm && !isThreadReply && !event.thread_ts;
+    const watchedByTrigger = isTopLevelChannelMsg && getChannelMessageTriggers(event.channel).length > 0;
     if (
       event.type === 'message' &&
       (!event.subtype || ['file_share', 'thread_broadcast'].includes(event.subtype)) &&
-      (isThreadReply || isDm)
+      (isThreadReply || isDm || watchedByTrigger)
     ) {
       // In channels, @mentions are handled by app_mention handler, so skip them here
       // to avoid double-processing. But in DMs, app_mention doesn't fire, so we must
@@ -344,6 +353,75 @@ export async function mountSlackApp(
   });
 
   registerMergeActionHandlers(app!);
+
+  // Handle trigger approval button
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app!.action('approve_trigger', async ({ action, ack, body }: any) => {
+    await ack();
+
+    const triggerId = action.value;
+    const userId = body.user?.id || 'unknown';
+    // The approval prompt was posted into a task thread; that task carries the
+    // pending_trigger_id. Find it by the message thread so the same task-level
+    // handler (shared with the CLI /approve path) runs.
+    const threadId = body.message?.thread_ts || body.message?.ts;
+
+    logger.server(`Trigger ${triggerId} approved by ${userId}`);
+
+    try {
+      // Enable first so we have the trigger to describe, then swap the card for a
+      // friendly confirmation (the full details also post to the bound channel
+      // via the announcement inside handleTriggerApproval).
+      const taskId = threadId ? await findTaskByThread(threadId) : null;
+      let trigger: import('../../types/trigger.js').Trigger | null = null;
+      if (taskId) {
+        const task = await Task.get(taskId);
+        trigger = await task.handleTriggerApproval(userId, triggerId);
+      } else {
+        logger.warn('Server', `approve_trigger: no task found for thread ${threadId}; enabling trigger directly`);
+        const { enableProposedTrigger } = await import('../../system/trigger-store.js');
+        const { indexTrigger, announceTriggerChange } = await import('../../system/trigger-scheduler.js');
+        trigger = await enableProposedTrigger(triggerId, userId);
+        if (trigger) { indexTrigger(trigger); await announceTriggerChange(trigger, 'enabled'); }
+      }
+      if (body.channel?.id && body.message?.ts) {
+        const text = trigger
+          ? `✅ Approved by <@${userId}> — *${triggerWhat(trigger)}* is now on.`
+          : `⚠️ Approved by <@${userId}>, but the automation couldn't be enabled (it may already be active or a limit was reached).`;
+        await updateMessage(body.channel.id, body.message.ts, text, []);
+      }
+    } catch (error) {
+      logger.error('Server', 'Error handling trigger approval', error);
+    }
+  });
+
+  // Handle trigger denial button
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app!.action('deny_trigger', async ({ action, ack, body }: any) => {
+    await ack();
+
+    const triggerId = action.value;
+    const userId = body.user?.id || 'unknown';
+    const threadId = body.message?.thread_ts || body.message?.ts;
+
+    logger.server(`Trigger ${triggerId} denied by ${userId}`);
+
+    try {
+      if (body.channel?.id && body.message?.ts) {
+        await updateMessage(body.channel.id, body.message.ts, `❌ Declined by <@${userId}> — no automation was set up.`, []);
+      }
+      const taskId = threadId ? await findTaskByThread(threadId) : null;
+      if (taskId) {
+        const task = await Task.get(taskId);
+        await task.handleTriggerDenial(triggerId);
+      } else {
+        const { deleteTrigger } = await import('../../system/trigger-store.js');
+        await deleteTrigger(triggerId);
+      }
+    } catch (error) {
+      logger.error('Server', 'Error handling trigger denial', error);
+    }
+  });
 
   // Return a lifecycle handle. start()/stop() are no-ops in HTTP mode —
   // the shared HTTP server in src/index.ts drives the ExpressReceiver.
@@ -642,8 +720,49 @@ async function handleSlackEvent(event: {
     }
     await sendSharedChannelWarnings(task, event.channel, threadId, thread, shared);
     await task.sendMessage(AGENT_PROMPTS.newTask);
+  } else if (event.type === 'message' && !event.channel.startsWith('D') && !event.thread_ts) {
+    // Ambient top-level channel message (no task, not an @mention, not a thread
+    // reply) — the only place channel-message triggers fire. @mentions and DMs
+    // are excluded above so a message aimed at Archie never also fires a trigger.
+    await dispatchChannelMessageTriggers(event, thread.channel.name);
   }
   // Otherwise: a reply in a human-started thread the bot wasn't part of — ignore
+}
+
+/**
+ * Fire any channel-message triggers watching this channel whose filter matches
+ * the message. Each match spawns an independent read-only task that replies in
+ * the triggering thread. External authors are already filtered upstream.
+ */
+async function dispatchChannelMessageTriggers(
+  event: { channel: string; user: string; text: string; ts: string },
+  channelName: string,
+): Promise<void> {
+  const triggers = getChannelMessageTriggers(event.channel);
+  if (triggers.length === 0) return;
+
+  const matches = (trigger: Trigger): boolean =>
+    trigger.conditions.some((c) => {
+      if (c.type !== 'channel_message' || c.channel_id !== event.channel) return false;
+      if (c.match?.contains && !event.text.toLowerCase().includes(c.match.contains.toLowerCase())) return false;
+      if (c.match?.from_user && event.user !== c.match.from_user) return false;
+      return true;
+    });
+
+  for (const trigger of triggers) {
+    if (!matches(trigger)) continue;
+    try {
+      await fireTrigger(trigger, {
+        kind: 'message',
+        text: event.text,
+        threadId: event.ts,
+        channelId: event.channel,
+        channelName,
+      });
+    } catch (err) {
+      logger.error('Slack', `Failed to fire channel-message trigger ${trigger.id}`, err);
+    }
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { configureGitIdentity } from './connectors/github/client.js';
 import { recoverActiveTasks } from './tasks/recovery.js';
 import { initEventPersistence } from './tasks/persistence.js';
 import { initReminderScheduler } from './system/reminder-scheduler.js';
+import { initTriggerScheduler } from './system/trigger-scheduler.js';
 import { initMemory } from './memory/index.js';
 
 /**
@@ -257,6 +258,7 @@ async function main(): Promise<void> {
 
     await recoverActiveTasks();
     await initReminderScheduler();
+    await initTriggerScheduler();
 
     // Now accept events: start the HTTP server and open the Socket Mode WebSocket.
     await new Promise<void>((resolve) => server.listen(config.port, resolve));

--- a/src/system/__tests__/trigger-scheduler.test.ts
+++ b/src/system/__tests__/trigger-scheduler.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the trigger scheduler's pure helpers — cron next-run computation
+ * (including a DST boundary) and the ≥1h recurring-interval floor.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeNextRun, validateRecurringInterval, MIN_RECURRING_INTERVAL_MS, describeSchedule, friendlyTz } from '../trigger-scheduler.js';
+
+describe('computeNextRun', () => {
+  it('computes the next weekday-9am run after a given instant', () => {
+    // Friday 2026-06-26 10:00 UTC → next weekday 9am is Monday 2026-06-29 09:00 UTC
+    const from = new Date('2026-06-26T10:00:00Z');
+    const next = computeNextRun('0 9 * * 1-5', 'UTC', from);
+    expect(next?.toISOString()).toBe('2026-06-29T09:00:00.000Z');
+  });
+
+  it('computes hourly runs', () => {
+    const from = new Date('2026-06-26T10:30:00Z');
+    const next = computeNextRun('0 * * * *', 'UTC', from);
+    expect(next?.toISOString()).toBe('2026-06-26T11:00:00.000Z');
+  });
+
+  it('honours timezone + DST — 9am local stays 9am across the US spring-forward', () => {
+    // US DST 2026 begins Sun Mar 8. A daily 9am America/New_York job:
+    //  - Sat Mar 7 fires at 14:00 UTC (EST, UTC-5)
+    //  - Sun Mar 8 fires at 13:00 UTC (EDT, UTC-4) — still 9am local
+    const beforeDst = computeNextRun('0 9 * * *', 'America/New_York', new Date('2026-03-07T15:00:00Z'));
+    expect(beforeDst?.toISOString()).toBe('2026-03-08T13:00:00.000Z');
+  });
+
+  it('returns null for an invalid cron expression', () => {
+    expect(computeNextRun('not a cron', 'UTC')).toBeNull();
+  });
+});
+
+describe('validateRecurringInterval (≥1h floor)', () => {
+  it('rejects an every-minute schedule', () => {
+    const r = validateRecurringInterval('* * * * *', 'UTC');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an every-30-minutes schedule', () => {
+    const r = validateRecurringInterval('0,30 * * * *', 'UTC');
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts an hourly schedule (exactly at the floor)', () => {
+    const r = validateRecurringInterval('0 * * * *', 'UTC');
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts weekday-9am', () => {
+    expect(validateRecurringInterval('0 9 * * 1-5', 'America/New_York').ok).toBe(true);
+  });
+
+  it('rejects a sub-hour gap even when the first inter-run gap is wide', () => {
+    // 9:00 and 9:30 daily: the 9:00→9:30 gap (30m) is below the floor, even
+    // though 9:30→next-day-9:00 is ~23.5h. The tightest-gap check must catch it.
+    expect(validateRecurringInterval('0,30 9 * * *', 'UTC').ok).toBe(false);
+  });
+
+  it('accepts two daily runs that are ≥1h apart', () => {
+    expect(validateRecurringInterval('0 9,18 * * *', 'UTC').ok).toBe(true);
+  });
+
+  it('rejects an invalid cron expression with an error', () => {
+    const r = validateRecurringInterval('nonsense', 'UTC');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/cron/i);
+  });
+
+  it('the floor constant is one hour', () => {
+    expect(MIN_RECURRING_INTERVAL_MS).toBe(60 * 60_000);
+  });
+});
+
+describe('friendlyTz', () => {
+  it('maps IANA zones to a city label', () => {
+    expect(friendlyTz('Europe/London')).toBe('London time');
+    expect(friendlyTz('America/New_York')).toBe('New York time');
+  });
+  it('keeps UTC as-is', () => {
+    expect(friendlyTz('UTC')).toBe('UTC');
+  });
+});
+
+describe('describeSchedule (cron → plain English)', () => {
+  it('daily at a time', () => {
+    expect(describeSchedule('0 9 * * *', 'Europe/London')).toBe('every day at 9:00 AM (London time)');
+  });
+  it('afternoon time in 12h clock (min=10, hour=15 → 3:10 PM)', () => {
+    expect(describeSchedule('10 15 * * *', 'Europe/London')).toBe('every day at 3:10 PM (London time)');
+  });
+  it('weekdays', () => {
+    expect(describeSchedule('0 9 * * 1-5', 'UTC')).toBe('every weekday at 9:00 AM (UTC)');
+  });
+  it('a single weekday', () => {
+    expect(describeSchedule('30 8 * * 1', 'UTC')).toBe('every Monday at 8:30 AM (UTC)');
+  });
+  it('multiple weekdays', () => {
+    expect(describeSchedule('0 9 * * 1,3,5', 'UTC')).toBe('every Monday, Wednesday, Friday at 9:00 AM (UTC)');
+  });
+  it('hourly with no minute offset', () => {
+    expect(describeSchedule('0 * * * *', 'UTC')).toBe('every hour');
+  });
+  it('hourly at a minute offset', () => {
+    expect(describeSchedule('7 * * * *', 'UTC')).toBe('every hour at :07');
+  });
+  it('monthly on a day-of-month', () => {
+    expect(describeSchedule('0 9 1 * *', 'UTC')).toBe('on the 1st of each month at 9:00 AM (UTC)');
+  });
+  it('midnight and noon read correctly', () => {
+    expect(describeSchedule('0 0 * * *', 'UTC')).toBe('every day at 12:00 AM (UTC)');
+    expect(describeSchedule('0 12 * * *', 'UTC')).toBe('every day at 12:00 PM (UTC)');
+  });
+  it('falls back to a generic phrase for unusual crons (never shows raw cron)', () => {
+    const out = describeSchedule('5 4 2 5 1', 'UTC');
+    expect(out).not.toContain('5 4 2 5 1');
+  });
+});

--- a/src/system/__tests__/trigger-store.test.ts
+++ b/src/system/__tests__/trigger-store.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for the trigger-id validator that guards every store filesystem path
+ * against traversal (CodeQL: uncontrolled data in path expression).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isValidTriggerId, generateTriggerId, getTriggerPath } from '../trigger-store.js';
+
+describe('isValidTriggerId', () => {
+  it('accepts a freshly generated id', () => {
+    expect(isValidTriggerId(generateTriggerId())).toBe(true);
+  });
+
+  it('accepts the canonical shape', () => {
+    expect(isValidTriggerId('trg-20260710-1152-a3f9k2')).toBe(true);
+  });
+
+  it('rejects path-traversal attempts', () => {
+    expect(isValidTriggerId('../../etc/passwd')).toBe(false);
+    expect(isValidTriggerId('trg-../secret')).toBe(false);
+    expect(isValidTriggerId('trg-/etc/passwd')).toBe(false);
+    expect(isValidTriggerId('trg-..')).toBe(false);
+  });
+
+  it('rejects ids without the trg- prefix or with unsafe chars', () => {
+    expect(isValidTriggerId('passwd')).toBe(false);
+    expect(isValidTriggerId('trg-a.b')).toBe(false);
+    expect(isValidTriggerId('trg_a')).toBe(false);
+    expect(isValidTriggerId('')).toBe(false);
+  });
+});
+
+describe('getTriggerPath', () => {
+  it('throws on a malformed id rather than building a traversal path', () => {
+    expect(() => getTriggerPath('../../evil')).toThrow(/Invalid trigger id/);
+  });
+
+  it('builds a path inside the triggers dir for a valid id', () => {
+    const p = getTriggerPath('trg-20260710-1152-a3f9k2');
+    expect(p.endsWith('/trg-20260710-1152-a3f9k2.json')).toBe(true);
+    expect(p).not.toContain('..');
+  });
+});

--- a/src/system/__tests__/trigger-tick.test.ts
+++ b/src/system/__tests__/trigger-tick.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for planTick — the pure per-tick planning step of the firing engine.
+ * Covers the catch-up rule (M1) and per-condition expiry + dedupe (M2).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { planTick } from '../trigger-scheduler.js';
+import type { Trigger, TriggerCondition } from '../../types/trigger.js';
+
+function trig(conditions: TriggerCondition[]): Trigger {
+  return {
+    id: 'trg-20260101-0900-abc123',
+    status: 'enabled',
+    created_by: 'U1',
+    created_at: '2026-01-01T00:00:00Z',
+    binding: { type: 'channel', channel_id: 'C1', channel_name: 'general' },
+    conditions,
+    action: { prompt: 'do it' },
+  };
+}
+
+const daily9 = (nextRunAt: string): TriggerCondition => ({
+  type: 'schedule', tz: 'UTC', cron: '0 9 * * *', next_run_at: nextRunAt,
+});
+const oneOff = (nextRunAt: string): TriggerCondition => ({
+  type: 'schedule', tz: 'UTC', next_run_at: nextRunAt,
+});
+const onMessage: TriggerCondition = { type: 'channel_message', channel_id: 'C1' };
+
+describe('planTick — catch-up (M1)', () => {
+  it('a recurring window missed during downtime is due, and advances to the NEXT future run (catch up once)', () => {
+    // next_run_at was yesterday 09:00; now is today 09:05 — the process was down.
+    const now = new Date('2026-06-25T09:05:00Z');
+    const plan = planTick(trig([daily9('2026-06-24T09:00:00Z')]), now);
+    expect(plan.dueCount).toBe(1);
+    expect(plan.stillActive).toBe(true);
+    const sched = plan.nextConditions[0] as Extract<TriggerCondition, { type: 'schedule' }>;
+    // Advanced to the next future 09:00 (tomorrow) — every missed window collapses to one fire.
+    expect(sched.next_run_at).toBe('2026-06-26T09:00:00.000Z');
+  });
+
+  it('a not-yet-due recurring condition is left untouched', () => {
+    const now = new Date('2026-06-25T08:00:00Z');
+    const plan = planTick(trig([daily9('2026-06-25T09:00:00Z')]), now);
+    expect(plan.dueCount).toBe(0);
+    expect(plan.stillActive).toBe(true);
+    const sched = plan.nextConditions[0] as Extract<TriggerCondition, { type: 'schedule' }>;
+    expect(sched.next_run_at).toBe('2026-06-25T09:00:00Z');
+  });
+});
+
+describe('planTick — per-condition + dedupe (M2)', () => {
+  it('a fired one-off is dropped but a sibling recurring survives', () => {
+    const now = new Date('2026-06-25T09:05:00Z');
+    const plan = planTick(trig([oneOff('2026-06-25T09:00:00Z'), daily9('2026-06-25T09:00:00Z')]), now);
+    expect(plan.dueCount).toBe(2); // both due this tick...
+    // ...but only the recurring remains, advanced; the one-off is gone.
+    expect(plan.nextConditions).toHaveLength(1);
+    const sched = plan.nextConditions[0] as Extract<TriggerCondition, { type: 'schedule' }>;
+    expect(sched.cron).toBe('0 9 * * *');
+    expect(sched.next_run_at).toBe('2026-06-26T09:00:00.000Z');
+    expect(plan.stillActive).toBe(true);
+  });
+
+  it('a lone one-off leaves the trigger spent (pause)', () => {
+    const now = new Date('2026-06-25T09:05:00Z');
+    const plan = planTick(trig([oneOff('2026-06-25T09:00:00Z')]), now);
+    expect(plan.dueCount).toBe(1);
+    expect(plan.nextConditions).toHaveLength(0);
+    expect(plan.stillActive).toBe(false);
+  });
+
+  it('a channel_message condition keeps the trigger active after a one-off fires', () => {
+    const now = new Date('2026-06-25T09:05:00Z');
+    const plan = planTick(trig([oneOff('2026-06-25T09:00:00Z'), onMessage]), now);
+    expect(plan.dueCount).toBe(1);
+    expect(plan.nextConditions).toEqual([onMessage]);
+    expect(plan.stillActive).toBe(true);
+  });
+
+  it('reports due count so the caller fires once even when multiple conditions coincide', () => {
+    const now = new Date('2026-06-25T09:05:00Z');
+    const plan = planTick(trig([daily9('2026-06-25T09:00:00Z'), daily9('2026-06-25T09:00:00Z')]), now);
+    expect(plan.dueCount).toBe(2); // caller uses dueCount>0 → exactly one fire
+    expect(plan.nextConditions).toHaveLength(2); // both advanced
+  });
+});

--- a/src/system/__tests__/trigger-update.test.ts
+++ b/src/system/__tests__/trigger-update.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for planStatusChange — the pure decision behind update_trigger's
+ * enabled/paused handling, including auto-resume on reschedule.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { planStatusChange } from '../trigger-scheduler.js';
+
+describe('planStatusChange', () => {
+  it('auto-resumes a paused trigger when it is rescheduled (new conditions, no explicit status)', () => {
+    // e.g. a one-off that already fired (auto-paused) being given a new time.
+    expect(planStatusChange({ currentStatus: 'paused', hasNewConditions: true })).toEqual({
+      target: 'enabled', statusChange: 'resumed', autoResume: true,
+    });
+  });
+
+  it('does NOT auto-resume when only the prompt/summary changed (no new conditions)', () => {
+    expect(planStatusChange({ currentStatus: 'paused', hasNewConditions: false })).toEqual({
+      target: 'unchanged', statusChange: null, autoResume: false,
+    });
+  });
+
+  it('an explicit pause wins even when conditions are also being changed', () => {
+    expect(planStatusChange({ currentStatus: 'paused', hasNewConditions: true, requestedStatus: 'paused' })).toEqual({
+      target: 'unchanged', statusChange: null, autoResume: false,
+    });
+    expect(planStatusChange({ currentStatus: 'enabled', hasNewConditions: true, requestedStatus: 'paused' })).toEqual({
+      target: 'paused', statusChange: 'paused', autoResume: false,
+    });
+  });
+
+  it('an explicit resume is a normal (non-auto) resume', () => {
+    expect(planStatusChange({ currentStatus: 'paused', hasNewConditions: false, requestedStatus: 'enabled' })).toEqual({
+      target: 'enabled', statusChange: 'resumed', autoResume: false,
+    });
+  });
+
+  it('rescheduling an already-enabled trigger changes nothing about its status', () => {
+    expect(planStatusChange({ currentStatus: 'enabled', hasNewConditions: true })).toEqual({
+      target: 'unchanged', statusChange: null, autoResume: false,
+    });
+  });
+
+  it('is a no-op when the requested status already matches', () => {
+    expect(planStatusChange({ currentStatus: 'enabled', hasNewConditions: false, requestedStatus: 'enabled' })).toEqual({
+      target: 'unchanged', statusChange: null, autoResume: false,
+    });
+    expect(planStatusChange({ currentStatus: 'paused', hasNewConditions: false, requestedStatus: 'paused' })).toEqual({
+      target: 'unchanged', statusChange: null, autoResume: false,
+    });
+  });
+});

--- a/src/system/__tests__/trigger-visibility.test.ts
+++ b/src/system/__tests__/trigger-visibility.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for trigger visibility scoping — public triggers are visible from every
+ * tier, private-channel triggers only from that channel, DM triggers only from
+ * that user's DM, and the operator (CLI) sees everything.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { triggerVisibleFrom, type TriggerOrigin } from '../trigger-visibility.js';
+import type { Trigger } from '../../types/trigger.js';
+
+function channelTrigger(channelId: string): Trigger {
+  return {
+    id: `trg-${channelId}`,
+    status: 'enabled',
+    created_by: 'U1',
+    created_at: '2026-06-24T00:00:00Z',
+    binding: { type: 'channel', channel_id: channelId, channel_name: channelId },
+    conditions: [{ type: 'schedule', tz: 'UTC', cron: '0 9 * * *', next_run_at: '2026-06-25T09:00:00Z' }],
+    action: { prompt: 'do the thing' },
+  };
+}
+
+function dmTrigger(userId: string): Trigger {
+  return {
+    id: `trg-dm-${userId}`,
+    status: 'enabled',
+    created_by: userId,
+    created_at: '2026-06-24T00:00:00Z',
+    binding: { type: 'user', user_id: userId },
+    conditions: [{ type: 'schedule', tz: 'UTC', cron: '0 9 * * *', next_run_at: '2026-06-25T09:00:00Z' }],
+    action: { prompt: 'do the thing' },
+  };
+}
+
+// Privacy resolver driven by an explicit private-set.
+const privacyFn = (privateChannels: Set<string>) => async (channelId: string) => privateChannels.has(channelId);
+
+describe('triggerVisibleFrom', () => {
+  const publicResolver = privacyFn(new Set());
+
+  it('public-channel trigger is visible from a public channel', async () => {
+    const origin: TriggerOrigin = { kind: 'channel', channelId: 'C_OTHER' };
+    expect(await triggerVisibleFrom(channelTrigger('C_PUB'), origin, publicResolver)).toBe(true);
+  });
+
+  it('public-channel trigger is visible from a DM', async () => {
+    const origin: TriggerOrigin = { kind: 'dm', userId: 'U9' };
+    expect(await triggerVisibleFrom(channelTrigger('C_PUB'), origin, publicResolver)).toBe(true);
+  });
+
+  it('private-channel trigger is hidden from a different public channel', async () => {
+    const resolver = privacyFn(new Set(['C_PRIV']));
+    const origin: TriggerOrigin = { kind: 'channel', channelId: 'C_PUB' };
+    expect(await triggerVisibleFrom(channelTrigger('C_PRIV'), origin, resolver)).toBe(false);
+  });
+
+  it('private-channel trigger is visible from that same private channel', async () => {
+    const resolver = privacyFn(new Set(['C_PRIV']));
+    const origin: TriggerOrigin = { kind: 'channel', channelId: 'C_PRIV' };
+    expect(await triggerVisibleFrom(channelTrigger('C_PRIV'), origin, resolver)).toBe(true);
+  });
+
+  it('private-channel trigger is hidden from a DM', async () => {
+    const resolver = privacyFn(new Set(['C_PRIV']));
+    const origin: TriggerOrigin = { kind: 'dm', userId: 'U9' };
+    expect(await triggerVisibleFrom(channelTrigger('C_PRIV'), origin, resolver)).toBe(false);
+  });
+
+  it('a channel that became private drops out of public listings (live resolution)', async () => {
+    // Same trigger; only the resolver's verdict changed (public → private).
+    const t = channelTrigger('C_FLIP');
+    const origin: TriggerOrigin = { kind: 'channel', channelId: 'C_PUB' };
+    expect(await triggerVisibleFrom(t, origin, privacyFn(new Set()))).toBe(true);
+    expect(await triggerVisibleFrom(t, origin, privacyFn(new Set(['C_FLIP'])))).toBe(false);
+  });
+
+  it('DM trigger is visible only from that user\'s DM', async () => {
+    expect(await triggerVisibleFrom(dmTrigger('U1'), { kind: 'dm', userId: 'U1' }, publicResolver)).toBe(true);
+    expect(await triggerVisibleFrom(dmTrigger('U1'), { kind: 'dm', userId: 'U2' }, publicResolver)).toBe(false);
+    expect(await triggerVisibleFrom(dmTrigger('U1'), { kind: 'channel', channelId: 'C_PUB' }, publicResolver)).toBe(false);
+  });
+
+  it('operator (CLI) sees everything', async () => {
+    const resolver = privacyFn(new Set(['C_PRIV']));
+    expect(await triggerVisibleFrom(channelTrigger('C_PRIV'), { kind: 'operator' }, resolver)).toBe(true);
+    expect(await triggerVisibleFrom(dmTrigger('U1'), { kind: 'operator' }, resolver)).toBe(true);
+  });
+});

--- a/src/system/event-bus.ts
+++ b/src/system/event-bus.ts
@@ -14,7 +14,8 @@ export type EventType =
   | 'status'
   | 'approval:requested' | 'approval:resolved'
   | 'pr_card'
-  | 'reminder:set' | 'reminder:cancelled' | 'reminder:fired';
+  | 'reminder:set' | 'reminder:cancelled' | 'reminder:fired'
+  | 'trigger:created' | 'trigger:fired' | 'trigger:paused' | 'trigger:resumed' | 'trigger:deleted';
 
 export interface SystemEvent {
   type: EventType;

--- a/src/system/trigger-scheduler.ts
+++ b/src/system/trigger-scheduler.ts
@@ -1,0 +1,574 @@
+/**
+ * Trigger Scheduler
+ *
+ * In-memory index of enabled triggers, backed by the trigger store on disk.
+ * A 60s interval checks schedule conditions and fires due ones. Channel-message
+ * triggers are fired by the Slack dispatch hook (see connectors/slack/events.ts),
+ * which queries this module's index by channel.
+ *
+ * Mirrors reminder-scheduler.ts's index-and-tick pattern. The only genuinely new
+ * piece is recurrence math, offloaded to `croner` (DST-correct, zero deps).
+ */
+
+import { Cron } from 'croner';
+import { Task } from '../tasks/task.js';
+import type { Trigger, TriggerBinding, TriggerCondition } from '../types/trigger.js';
+import { listTriggers, saveTrigger, deleteTrigger } from './trigger-store.js';
+import { AGENT_PROMPTS } from '../agents/prompts.js';
+import { emitEvent } from './event-bus.js';
+import { logger } from './logger.js';
+import { postSlackMessage, isChannelReachable } from '../connectors/slack/client.js';
+
+// ---- Limits / config ----
+
+/** Recurring schedule triggers must fire no more often than once per hour. */
+export const MIN_RECURRING_INTERVAL_MS = 60 * 60_000;
+/** Per-account cap on fired runs per calendar day (runaway-loop backstop). */
+const DAILY_FIRE_CAP = 200;
+/** Caps on concurrently-enabled triggers. */
+export const MAX_TRIGGERS_PER_USER = 20;
+export const MAX_TRIGGERS_PER_CHANNEL = 20;
+
+/** Global kill switch — set ARCHIE_TRIGGERS_ENABLED=false (or 0) to disable. */
+export function triggersEnabled(): boolean {
+  const v = process.env.ARCHIE_TRIGGERS_ENABLED;
+  return v !== 'false' && v !== '0';
+}
+
+// ---- In-memory index (enabled triggers only) ----
+
+const enabledTriggers = new Map<string, Trigger>();
+let schedulerTimer: ReturnType<typeof setInterval> | undefined;
+
+// ---- Daily fire cap (reset on date change) ----
+
+let fireDay = '';
+let fireCount = 0;
+function withinDailyCap(): boolean {
+  const today = new Date().toISOString().slice(0, 10);
+  if (today !== fireDay) {
+    fireDay = today;
+    fireCount = 0;
+  }
+  if (fireCount >= DAILY_FIRE_CAP) return false;
+  fireCount++;
+  return true;
+}
+
+// ---- Cron helpers (exported for tools + tests) ----
+
+/** Next fire instant for a cron expression in a timezone, after `from` (default now). */
+export function computeNextRun(cron: string, tz: string, from?: Date): Date | null {
+  try {
+    return new Cron(cron, { timezone: tz }).nextRun(from ?? new Date());
+  } catch (err) {
+    logger.warn('trigger-scheduler', `Invalid cron "${cron}" (${tz}): ${err}`);
+    return null;
+  }
+}
+
+/**
+ * Validate that a recurring cron fires no more often than once per hour.
+ * Returns `{ ok }` or `{ ok: false, error }`. Checks the gap between the next
+ * two occurrences — the tightest cadence the expression produces.
+ */
+export function validateRecurringInterval(cron: string, tz: string): { ok: true } | { ok: false; error: string } {
+  let runs: Date[];
+  try {
+    // Sample several upcoming runs and check the TIGHTEST gap, not just the
+    // first — a schedule like "0 9,9:30 …" can have a wide first gap but a
+    // sub-hour gap later in its cycle.
+    runs = new Cron(cron, { timezone: tz }).nextRuns(6);
+  } catch (err) {
+    return { ok: false, error: `Invalid cron expression: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  if (runs.length < 2) {
+    return { ok: false, error: 'Cron expression does not produce a recurring schedule.' };
+  }
+  let minGap = Infinity;
+  for (let i = 1; i < runs.length; i++) {
+    minGap = Math.min(minGap, runs[i].getTime() - runs[i - 1].getTime());
+  }
+  if (minGap < MIN_RECURRING_INTERVAL_MS) {
+    return { ok: false, error: 'Recurring triggers must fire at most once per hour.' };
+  }
+  return { ok: true };
+}
+
+// ---- Public API ----
+
+/**
+ * Initialize the trigger scheduler. Rebuilds the in-memory index from disk,
+ * then starts a 60s tick (plus an immediate check to fire overdue schedules
+ * after downtime). No-op firing if the kill switch is off, but the index is
+ * still built so list/management endpoints stay consistent.
+ */
+export async function initTriggerScheduler(): Promise<void> {
+  await rebuildFromDisk();
+  const count = enabledTriggers.size;
+  if (count > 0) {
+    logger.system(`Trigger scheduler: loaded ${count} enabled trigger(s)`);
+  }
+  if (!triggersEnabled()) {
+    logger.system('Trigger scheduler: firing disabled (ARCHIE_TRIGGERS_ENABLED=false)');
+    return;
+  }
+  schedulerTimer = setInterval(() => {
+    checkDue().catch((err) => logger.error('trigger-scheduler', 'Error checking due triggers', err));
+  }, 60_000);
+  checkDue().catch((err) => logger.error('trigger-scheduler', 'Error on initial trigger check', err));
+}
+
+/** Pending proposals older than this are GC'd on the boot scan. */
+const PENDING_TTL_MS = 24 * 60 * 60_000;
+
+/**
+ * Rebuild the in-memory index from disk (enabled triggers only). Also GC's
+ * stale `pending` proposals — a proposal that was never approved/denied (e.g.
+ * the process restarted before the user acted) would otherwise leave an inert
+ * file forever. Pending triggers are never indexed regardless, so this is pure
+ * cleanup.
+ */
+async function rebuildFromDisk(): Promise<void> {
+  enabledTriggers.clear();
+  try {
+    const now = Date.now();
+    for (const trigger of await listTriggers()) {
+      if (trigger.status === 'enabled') {
+        indexTrigger(trigger);
+      } else if (trigger.status === 'pending' && now - new Date(trigger.created_at).getTime() > PENDING_TTL_MS) {
+        await deleteTrigger(trigger.id);
+        logger.system(`Trigger ${trigger.id}: GC'd stale pending proposal`);
+      }
+    }
+  } catch (err) {
+    logger.error('trigger-scheduler', 'Failed to rebuild triggers from disk', err);
+  }
+}
+
+/**
+ * Add (or refresh) an enabled trigger in the index. Computes an initial
+ * `next_run_at` only for a recurring condition that is MISSING one (e.g. a
+ * legacy record). A *past* `next_run_at` is deliberately left untouched so the
+ * next `checkDue` fires the missed window once before advancing — this is what
+ * makes boot catch-up work (M1): `checkDue` runs right after `rebuildFromDisk`,
+ * sees the overdue condition, fires it a single time, then advances past all
+ * missed windows via `computeNextRun(now)`.
+ */
+export function indexTrigger(trigger: Trigger): void {
+  if (trigger.status !== 'enabled') {
+    enabledTriggers.delete(trigger.id);
+    return;
+  }
+  for (const cond of trigger.conditions) {
+    if (cond.type === 'schedule' && cond.cron && !cond.next_run_at) {
+      const next = computeNextRun(cond.cron, cond.tz);
+      if (next) cond.next_run_at = next.toISOString();
+    }
+  }
+  enabledTriggers.set(trigger.id, trigger);
+}
+
+/** Remove a trigger from the index. */
+export function deindexTrigger(id: string): void {
+  enabledTriggers.delete(id);
+}
+
+/** All enabled channel-message triggers bound to / watching a given channel. */
+export function getChannelMessageTriggers(channelId: string): Trigger[] {
+  const out: Trigger[] = [];
+  for (const trigger of enabledTriggers.values()) {
+    if (trigger.conditions.some((c) => c.type === 'channel_message' && c.channel_id === channelId)) {
+      out.push(trigger);
+    }
+  }
+  return out;
+}
+
+// ---- Schedule firing ----
+
+interface FireContext {
+  kind: 'schedule' | 'message';
+  /** For message context: the triggering message text. */
+  text?: string;
+  /** For message context: the thread to reply in + its channel. */
+  channelId?: string;
+  channelName?: string;
+  threadId?: string;
+}
+
+/**
+ * Pure planning step for a single tick: given a trigger and the current instant,
+ * decide what changes. Returns how many schedule conditions are due, the
+ * post-fire condition set, and whether the trigger stays enabled. No I/O, so the
+ * catch-up (M1) and per-condition (M2) rules are unit-testable.
+ *
+ * Rules:
+ * - A due recurring condition is advanced to its next future run
+ *   (`computeNextRun(now)` skips every window missed during downtime → one
+ *   catch-up fire, not one per missed window).
+ * - A due one-off condition is dropped (fires once, then gone) — WITHOUT
+ *   disturbing sibling conditions (M2: a mixed one-off + recurring trigger keeps
+ *   its recurring schedule).
+ * - The trigger stays active while any schedule condition still has a
+ *   `next_run_at` or any `channel_message` condition remains; otherwise it's
+ *   spent and should be paused.
+ */
+export function planTick(
+  trigger: Trigger,
+  now: Date,
+): { dueCount: number; nextConditions: TriggerCondition[]; stillActive: boolean } {
+  const nowMs = now.getTime();
+  let dueCount = 0;
+  const nextConditions: TriggerCondition[] = [];
+  for (const cond of trigger.conditions) {
+    const isDueSchedule =
+      cond.type === 'schedule' && !!cond.next_run_at && new Date(cond.next_run_at).getTime() <= nowMs;
+    if (!isDueSchedule) {
+      nextConditions.push(cond);
+      continue;
+    }
+    dueCount++;
+    if (cond.type === 'schedule' && cond.cron) {
+      const next = computeNextRun(cond.cron, cond.tz, now);
+      if (next) nextConditions.push({ ...cond, next_run_at: next.toISOString() });
+      // else: cron became uncomputable → drop this condition (don't re-fire forever)
+    }
+    // one-off due → dropped (not pushed)
+  }
+  const stillActive = nextConditions.some(
+    (c) => (c.type === 'schedule' && !!c.next_run_at) || c.type === 'channel_message',
+  );
+  return { dueCount, nextConditions, stillActive };
+}
+
+/**
+ * Pure decision for how an `update_trigger` call should change a trigger's
+ * enabled/paused state. Kept separate from the cap check (which is I/O) so the
+ * intent rules are unit-testable.
+ *
+ * - Explicit `status` wins.
+ * - Otherwise, giving a *paused* trigger new conditions auto-resumes it — the
+ *   user is rescheduling something that had stopped (e.g. a fired one-off) and
+ *   clearly wants it live again. Editing only the prompt/summary of a paused
+ *   trigger does NOT resume it (a deliberate pause is respected).
+ *
+ * `target` is the resulting status ('unchanged' = leave as-is); `statusChange`
+ * is what to announce; `autoResume` flags an implicit resume so the caller can
+ * tell the user.
+ */
+export function planStatusChange(input: {
+  currentStatus: 'enabled' | 'paused';
+  hasNewConditions: boolean;
+  requestedStatus?: 'enabled' | 'paused';
+}): { target: 'enabled' | 'paused' | 'unchanged'; statusChange: 'resumed' | 'paused' | null; autoResume: boolean } {
+  const explicitPause = input.requestedStatus === 'paused';
+  const autoResume = input.hasNewConditions && input.currentStatus === 'paused' && !explicitPause;
+  const wantEnable = input.requestedStatus === 'enabled' || autoResume;
+
+  if (wantEnable && input.currentStatus !== 'enabled') {
+    return { target: 'enabled', statusChange: 'resumed', autoResume };
+  }
+  if (explicitPause && input.currentStatus !== 'paused') {
+    return { target: 'paused', statusChange: 'paused', autoResume: false };
+  }
+  return { target: 'unchanged', statusChange: null, autoResume: false };
+}
+
+// Re-entrancy guard: a tick that runs longer than the 60s interval must not
+// overlap the next one (which could double-fire a not-yet-advanced condition).
+let ticking = false;
+
+/** Check for due schedule conditions and fire them (at most once per trigger per tick). */
+async function checkDue(): Promise<void> {
+  if (!triggersEnabled() || ticking) return;
+  ticking = true;
+  try {
+    const now = new Date();
+    for (const trigger of [...enabledTriggers.values()]) {
+      try {
+        await tickTrigger(trigger, now);
+      } catch (err) {
+        // Isolate failures so one trigger's error (e.g. a disk write) doesn't
+        // skip the rest of this tick.
+        logger.error('trigger-scheduler', `Failed to tick trigger ${trigger.id}`, err);
+      }
+    }
+  } finally {
+    ticking = false;
+  }
+}
+
+/** Fire a single trigger once if any of its schedule conditions are due, then
+ * advance/expire those conditions and (de)persist. */
+async function tickTrigger(trigger: Trigger, now: Date): Promise<void> {
+  const plan = planTick(trigger, now);
+  if (plan.dueCount === 0) return;
+
+  // Fire ONCE for the trigger this tick, even when several conditions coincide
+  // (M2: "any match fires the trigger" — not one task per condition).
+  await fireTrigger(trigger, { kind: 'schedule' });
+
+  // fireTrigger may have paused + deindexed the trigger (daily cap, unreachable
+  // channel). If so, leave its conditions alone.
+  if (!enabledTriggers.has(trigger.id)) return;
+
+  trigger.conditions = plan.nextConditions;
+  if (plan.stillActive) {
+    await saveTrigger(trigger);
+    enabledTriggers.set(trigger.id, trigger);
+  } else {
+    trigger.status = 'paused';
+    await saveTrigger(trigger);
+    deindexTrigger(trigger.id);
+    emitEvent('trigger:paused', trigger.id, { reason: 'all schedule conditions fired' });
+  }
+}
+
+/**
+ * Fire a trigger: spawn a fresh read-only task, wire its delivery channel, and
+ * seed the PM with the action prompt. Shared by the scheduler (schedule context)
+ * and the Slack dispatch hook (message context).
+ *
+ * Firing posts no preamble — the spawned PM does the work and posts the result
+ * itself, so the first message the channel sees is the actual output.
+ */
+export async function fireTrigger(trigger: Trigger, context: FireContext): Promise<void> {
+  if (!triggersEnabled()) return;
+
+  // Pre-flight for a channel-bound schedule fire: if the bound channel was
+  // deleted or archived (or the bot removed and it archived), pause the trigger
+  // and DM the creator instead of spawning a task that would post into the void.
+  // Message-context fires skip this — we just received a message there, so it's
+  // live — and DMs can't be deleted. Checked BEFORE the daily cap so a bail here
+  // doesn't consume a cap slot (L2).
+  if (context.kind !== 'message' && trigger.binding.type === 'channel') {
+    if (!(await isChannelReachable(trigger.binding.channel_id))) {
+      logger.warn('trigger-scheduler', `Trigger ${trigger.id} bound channel ${trigger.binding.channel_id} unreachable — pausing`);
+      trigger.status = 'paused';
+      await saveTrigger(trigger);
+      deindexTrigger(trigger.id);
+      emitEvent('trigger:paused', trigger.id, { reason: 'bound channel unreachable' });
+      await notifyCreator(trigger, `⚠️ A trigger you set up was paused — its channel (#${trigger.binding.channel_name}) is gone or archived. Recreate it elsewhere if you still need it.`);
+      return;
+    }
+  }
+
+  if (!withinDailyCap()) {
+    logger.warn('trigger-scheduler', `Daily fire cap (${DAILY_FIRE_CAP}) reached — dropping trigger ${trigger.id}`);
+    await notifyCreator(trigger, `⚠️ A trigger you set up couldn't run — Archie hit its daily limit of automated runs. It will resume tomorrow.`);
+    return;
+  }
+
+  const task = await Task.create();
+  task.metadata.triggered_by = trigger.id;
+
+  // Wire delivery. message context → reply in the triggering thread (linked as
+  // default, no post). schedule context → the PM opens the destination itself.
+  let delivery: string;
+  if (context.kind === 'message' && context.channelId && context.threadId) {
+    task.linkSlackThread(context.channelId, context.threadId, context.channelName ?? context.channelId);
+    delivery = 'Post your reply in your default channel — the thread where the triggering message was posted.';
+  } else if (trigger.binding.type === 'user') {
+    delivery = `Deliver the result to the user as a direct message (Slack user ID ${trigger.binding.user_id}).`;
+  } else {
+    delivery = `Deliver the result by posting it to the channel #${trigger.binding.channel_name} (Slack channel ID ${trigger.binding.channel_id}).`;
+  }
+  task.debouncedSave();
+
+  const reason = context.kind === 'message'
+    ? `a new message in #${context.channelName ?? context.channelId ?? 'a channel'} matched your filter`
+    : 'a scheduled run';
+  const seed = `${trigger.action.prompt}\n\n${delivery}`;
+
+  logger.system(`Trigger ${trigger.id} fired (${context.kind}) → task ${task.taskId}`);
+  await task.sendMessage(AGENT_PROMPTS.triggered(seed, reason), 'pm-agent');
+
+  trigger.last_fired_at = new Date().toISOString();
+  await saveTrigger(trigger);
+  emitEvent('trigger:fired', task.taskId, { trigger_id: trigger.id });
+}
+
+// ---- Announcements (config changes only — never firing) ----
+
+type TriggerChange = 'enabled' | 'edited' | 'paused' | 'resumed' | 'deleted';
+
+/**
+ * Post a one-line notice to the channel a trigger is bound to whenever its
+ * configuration changes. This is the transparency guarantee: a trigger can be
+ * managed from a DM, but its bound channel always sees the change. Best-effort —
+ * a failed post is logged, not thrown.
+ */
+export async function announceTriggerChange(trigger: Trigger, change: TriggerChange): Promise<void> {
+  // The notice is posted IN the bound channel, so naming the channel again would
+  // be redundant — omit "where" here (the approval card, posted in the task
+  // thread, still shows it).
+  const what = triggerWhat(trigger);
+  const when = triggerWhen(trigger);
+  let text: string;
+  switch (change) {
+    case 'enabled':
+      text = `🔔 New automation added — *${what}* · ${when}`;
+      break;
+    case 'edited':
+      text = `✏️ Automation updated — *${what}* · now ${when}`;
+      break;
+    case 'paused':
+      text = `⏸️ Automation paused — *${what}* won't run until it's resumed.`;
+      break;
+    case 'resumed':
+      text = `▶️ Automation resumed — *${what}* · ${when}`;
+      break;
+    case 'deleted':
+      text = `🗑️ Automation removed — *${what}*`;
+      break;
+  }
+  try {
+    await postToBinding(trigger.binding, text);
+  } catch (err) {
+    logger.warn('trigger-scheduler', `Failed to announce ${change} for ${trigger.id}`, err);
+  }
+}
+
+// ---- Human-readable rendering ----
+//
+// User-facing trigger text is built from three plain-English facets — WHAT it
+// does (the PM's short summary, never the verbose internal prompt), WHEN it
+// runs (cron humanized to prose, never a raw expression), and WHERE it posts.
+
+const DOW_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/** 24h hour+minute → "9:00 AM" / "3:15 PM" / "12:00 AM". */
+function formatClock(hour: number, minute: number): string {
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  const ampm = hour < 12 ? 'AM' : 'PM';
+  return `${h12}:${String(minute).padStart(2, '0')} ${ampm}`;
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] || s[v] || s[0]}`;
+}
+
+/** Friendly timezone label: "Europe/London" → "London time", "UTC" → "UTC". */
+export function friendlyTz(tz: string): string {
+  if (!tz || tz === 'UTC') return 'UTC';
+  const city = tz.split('/').pop()?.replace(/_/g, ' ');
+  return city ? `${city} time` : tz;
+}
+
+/**
+ * Turn a cron expression into plain English for the shapes the PM generates
+ * (hourly, daily/weekday/weekend/weekly/monthly at a time). Falls back to a
+ * generic phrase for anything unusual — the raw cron is never shown to users.
+ */
+export function describeSchedule(cron: string, tz: string): string {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return 'on a custom schedule';
+  const [min, hour, dom, mon, dow] = parts;
+  const isNum = (s: string) => /^\d+$/.test(s);
+  const tzSuffix = ` (${friendlyTz(tz)})`;
+
+  // Sub-daily cadences (no specific clock time → no timezone suffix).
+  const hourStep = hour.match(/^\*\/(\d+)$/);
+  if (hourStep) return `every ${hourStep[1]} hours`;
+  if (hour === '*') {
+    const minStep = min.match(/^\*\/(\d+)$/);
+    if (minStep) return `every ${minStep[1]} minutes`;
+    if (isNum(min)) return min === '0' ? 'every hour' : `every hour at :${min.padStart(2, '0')}`;
+    return 'on a custom schedule';
+  }
+
+  if (!isNum(hour) || !isNum(min)) return 'on a custom schedule';
+  const time = formatClock(Number(hour), Number(min));
+
+  if (dow !== '*') {
+    if (dow === '1-5') return `every weekday at ${time}${tzSuffix}`;
+    if (['0,6', '6,0', '6,7', '0,7'].includes(dow)) return `every weekend at ${time}${tzSuffix}`;
+    const nums = dow.split(',').map((d) => (d === '7' ? 0 : Number(d)));
+    if (nums.every((n) => Number.isInteger(n) && n >= 0 && n <= 6)) {
+      return `every ${nums.map((n) => DOW_NAMES[n]).join(', ')} at ${time}${tzSuffix}`;
+    }
+    return 'on a custom schedule';
+  }
+
+  if (dom !== '*' && isNum(dom)) {
+    const scope = mon === '*' ? 'each month' : 'certain months';
+    return `on the ${ordinal(Number(dom))} of ${scope} at ${time}${tzSuffix}`;
+  }
+
+  if (dom === '*' && mon === '*') return `every day at ${time}${tzSuffix}`;
+  return 'on a custom schedule';
+}
+
+/** Render a one-off instant in a timezone: "once on Jun 26 at 9:00 AM (London time)". */
+function describeOneOff(iso: string, tz: string): string {
+  try {
+    const d = new Date(iso);
+    const date = d.toLocaleDateString('en-US', { timeZone: tz, month: 'short', day: 'numeric' });
+    const time = d.toLocaleTimeString('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit' });
+    return `once on ${date} at ${time} (${friendlyTz(tz)})`;
+  } catch {
+    return `once at ${iso}`;
+  }
+}
+
+/** Plain-English "when" clause for a single condition. */
+function describeCondition(c: TriggerCondition): string {
+  if (c.type === 'schedule') {
+    return c.cron ? describeSchedule(c.cron, c.tz) : describeOneOff(c.next_run_at, c.tz);
+  }
+  const filters: string[] = [];
+  if (c.match?.contains) filters.push(`mentioning "${c.match.contains}"`);
+  if (c.match?.from_user) filters.push('from a specific person');
+  return `on a new message${filters.length ? ' ' + filters.join(' ') : ''}`;
+}
+
+/** First sentence / clipped form of the internal prompt — fallback when no summary was set. */
+function shortenPrompt(prompt: string): string {
+  const s = (prompt.split(/(?<=[.!?])\s/)[0] ?? prompt).trim();
+  return s.length > 90 ? `${s.slice(0, 87)}…` : s;
+}
+
+/** WHAT the trigger does — the PM's short summary, else a clipped internal prompt.
+ * Trailing punctuation is stripped so it reads as a label inside a larger sentence. */
+export function triggerWhat(trigger: Trigger): string {
+  const raw = trigger.summary?.trim() || shortenPrompt(trigger.action.prompt);
+  return raw.replace(/[.\s]+$/, '');
+}
+
+/** WHEN it runs, across all conditions ("every day at 9:00 AM" / "on a new message …"). */
+export function triggerWhen(trigger: Trigger): string {
+  return trigger.conditions.map(describeCondition).join(' or ');
+}
+
+/** WHERE results are delivered ("#general" / "a DM"). */
+export function triggerWhere(trigger: Trigger): string {
+  return trigger.binding.type === 'channel' ? `#${trigger.binding.channel_name}` : 'a DM';
+}
+
+/** Human-readable one-liner: "<when> → <what>". Used by CLI/API listings. */
+export function describeTrigger(trigger: Trigger): string {
+  return `${triggerWhen(trigger)} → ${triggerWhat(trigger)}`;
+}
+
+/**
+ * Post a plain message to a trigger's binding (channel or user DM). Slack's
+ * chat.postMessage resolves a user id directly to that user's DM, so no
+ * separate conversations.open is needed.
+ */
+async function postToBinding(binding: TriggerBinding, text: string): Promise<void> {
+  const channel = binding.type === 'user' ? binding.user_id : binding.channel_id;
+  await postSlackMessage({ channel, text });
+}
+
+/** Best-effort DM to a trigger's creator (used for cap/failure notices). */
+async function notifyCreator(trigger: Trigger, text: string): Promise<void> {
+  if (!trigger.created_by || trigger.created_by === 'unknown') return; // no known human to DM
+  try {
+    await postSlackMessage({ channel: trigger.created_by, text });
+  } catch (err) {
+    logger.warn('trigger-scheduler', `Failed to notify creator of ${trigger.id}`, err);
+  }
+}

--- a/src/system/trigger-store.ts
+++ b/src/system/trigger-store.ts
@@ -1,0 +1,159 @@
+/**
+ * Trigger Store
+ *
+ * File-based persistence for triggers — one JSON file per trigger under
+ * TRIGGERS_DIR. Mirrors the task persistence helpers (src/tasks/persistence.ts)
+ * in spirit: simple load/save/list/delete over a flat directory.
+ *
+ * The trigger scheduler (trigger-scheduler.ts) holds the in-memory index; this
+ * module is the durable source of truth.
+ */
+
+import { mkdir, readFile, writeFile, readdir, unlink } from 'fs/promises';
+import { existsSync } from 'fs';
+import { resolve, sep } from 'path';
+import type { Trigger } from '../types/trigger.js';
+import { TRIGGERS_DIR } from './workdir.js';
+import { logger } from './logger.js';
+
+/**
+ * Generate a unique trigger ID.
+ * Format: trg-YYYYMMDD-HHMM-xxxxxx (mirrors generateTaskId).
+ */
+export function generateTriggerId(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  const random = Math.random().toString(36).substring(2, 8);
+  return `trg-${year}${month}${day}-${hours}${minutes}-${random}`;
+}
+
+/**
+ * Trigger ids are always minted by `generateTriggerId` as
+ * `trg-<digits>-<digits>-<alnum>`. Validate any caller-supplied id — a PM tool
+ * arg, the `/triggers/:id` route param, an approval `ref`, a Slack button value
+ * — against that shape before it reaches a filesystem path. The allowed charset
+ * excludes `.` and the path separators, so a validated id cannot express path
+ * traversal (`../…`). This is the single sanitiser guarding every store path.
+ */
+const TRIGGER_ID_RE = /^trg-[A-Za-z0-9-]+$/;
+
+export function isValidTriggerId(id: string): boolean {
+  return typeof id === 'string' && TRIGGER_ID_RE.test(id);
+}
+
+/**
+ * Return the id ONLY if it matches the trigger-id shape, as the value read from
+ * the regex match (not the raw input). Building a path from the matched value —
+ * rather than the caller's string — is what breaks the path-injection taint
+ * flow: the result is provably constrained to `[A-Za-z0-9-]`, so it can carry
+ * no `.` or separator and cannot express traversal. Returns null on no match.
+ */
+function matchedTriggerId(id: string): string | null {
+  if (typeof id !== 'string') return null;
+  const m = TRIGGER_ID_RE.exec(id);
+  return m ? m[0] : null;
+}
+
+/**
+ * Path to a trigger's JSON file. Throws on any id that would escape
+ * TRIGGERS_DIR. Two guards: the id-shape check above, and — the canonical
+ * path-injection remediation — resolving the candidate path and requiring it to
+ * stay within the resolved base directory (`startsWith(base + sep)`), so the
+ * returned path handed to `readFile`/`unlink`/`writeFile` is provably contained.
+ */
+export function getTriggerPath(id: string): string {
+  const safeId = matchedTriggerId(id);
+  if (safeId === null) {
+    throw new Error(`Invalid trigger id: ${JSON.stringify(id)}`);
+  }
+  // Build from `safeId` (the regex-matched value), and additionally require the
+  // resolved path to sit directly inside TRIGGERS_DIR — belt-and-suspenders
+  // containment on top of the shape barrier.
+  const base = resolve(TRIGGERS_DIR);
+  const full = resolve(base, `${safeId}.json`);
+  if (!full.startsWith(base + sep)) {
+    throw new Error(`Invalid trigger id: ${JSON.stringify(id)}`);
+  }
+  return full;
+}
+
+/** Ensure the triggers directory exists. */
+async function ensureTriggersDir(): Promise<void> {
+  if (!existsSync(TRIGGERS_DIR)) {
+    await mkdir(TRIGGERS_DIR, { recursive: true });
+  }
+}
+
+/** Persist a trigger (create or overwrite). */
+export async function saveTrigger(trigger: Trigger): Promise<void> {
+  await ensureTriggersDir();
+  await writeFile(getTriggerPath(trigger.id), JSON.stringify(trigger, null, 2));
+}
+
+/** Load a trigger by ID. Returns null if missing or unparseable. */
+export async function loadTrigger(id: string): Promise<Trigger | null> {
+  if (!isValidTriggerId(id)) return null; // malformed id → treat as "not found"
+  const path = getTriggerPath(id);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as Trigger;
+  } catch (err) {
+    logger.warn('trigger-store', `Failed to parse trigger ${id}: ${err}`);
+    return null;
+  }
+}
+
+/** List all triggers on disk (any status). */
+export async function listTriggers(): Promise<Trigger[]> {
+  await ensureTriggersDir();
+  const entries = await readdir(TRIGGERS_DIR, { withFileTypes: true });
+  const triggers: Trigger[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const trigger = await loadTrigger(entry.name.replace(/\.json$/, ''));
+    if (trigger) triggers.push(trigger);
+  }
+  return triggers;
+}
+
+/** Delete a trigger's file. No-op if already gone. */
+export async function deleteTrigger(id: string): Promise<void> {
+  if (!isValidTriggerId(id)) return; // malformed id → nothing to delete
+  const path = getTriggerPath(id);
+  if (existsSync(path)) {
+    await unlink(path);
+  }
+}
+
+/**
+ * Count active (enabled) triggers, optionally filtered by a predicate.
+ * Used to enforce per-user / per-channel caps at creation time.
+ */
+export async function countActiveTriggers(
+  predicate?: (t: Trigger) => boolean,
+): Promise<number> {
+  const all = await listTriggers();
+  return all.filter((t) => t.status === 'enabled' && (!predicate || predicate(t))).length;
+}
+
+/**
+ * Flip a proposed (`pending`) trigger to `enabled` and record the approver.
+ * Returns the updated trigger, or null when it doesn't exist or isn't pending.
+ * The caller is responsible for indexing it into the scheduler (which computes
+ * the first `next_run_at` for schedule conditions).
+ */
+export async function enableProposedTrigger(
+  id: string,
+  approverId: string,
+): Promise<Trigger | null> {
+  const trigger = await loadTrigger(id);
+  if (!trigger || trigger.status !== 'pending') return null;
+  trigger.status = 'enabled';
+  trigger.approved_by = approverId;
+  await saveTrigger(trigger);
+  return trigger;
+}

--- a/src/system/trigger-visibility.ts
+++ b/src/system/trigger-visibility.ts
@@ -1,0 +1,44 @@
+/**
+ * Trigger visibility — pure decision logic for which triggers are visible from
+ * a given Slack context. Kept dependency-free (no Slack client) so it can be
+ * unit-tested directly; the live channel-privacy lookup is injected as
+ * `resolvePrivacy`.
+ *
+ * Rules (the "tier of the space the request comes from"):
+ *  - Public-channel triggers are visible from every tier.
+ *  - Private-channel triggers are visible only from that exact channel.
+ *  - DM triggers are visible only from that user's DM.
+ *  - Operator context (the CLI) sees everything.
+ */
+
+import type { Trigger } from '../types/trigger.js';
+
+export interface TriggerOrigin {
+  kind: 'channel' | 'dm' | 'operator';
+  /** For channel origin: the originating Slack channel ID. */
+  channelId?: string;
+  /** For dm origin: the DM partner's Slack user ID. */
+  userId?: string;
+}
+
+/**
+ * Is `trigger` visible from `origin`? `resolvePrivacy(channelId)` must return
+ * the channel's CURRENT public/private state (true = private) — resolving it
+ * live is what makes a public→private conversion immediately drop the trigger
+ * from public/DM listings.
+ */
+export async function triggerVisibleFrom(
+  trigger: Trigger,
+  origin: TriggerOrigin,
+  resolvePrivacy: (channelId: string) => Promise<boolean>,
+): Promise<boolean> {
+  if (origin.kind === 'operator') return true;
+
+  if (trigger.binding.type === 'user') {
+    return origin.kind === 'dm' && origin.userId === trigger.binding.user_id;
+  }
+
+  const isPrivate = await resolvePrivacy(trigger.binding.channel_id);
+  if (!isPrivate) return true; // public-channel trigger — visible from any tier
+  return origin.kind === 'channel' && origin.channelId === trigger.binding.channel_id;
+}

--- a/src/system/workdir.ts
+++ b/src/system/workdir.ts
@@ -35,6 +35,9 @@ export const REPOS_DIR = join(WORKDIR, 'repos');
 /** Sessions directory (task runtime data) */
 export const SESSIONS_DIR = join(WORKDIR, 'sessions');
 
+/** Triggers directory (one JSON file per persistent trigger) */
+export const TRIGGERS_DIR = join(WORKDIR, 'triggers');
+
 /** Persistent per-plugin data directory */
 export const PLUGINS_DATA_DIR = join(WORKDIR, 'plugins-data');
 
@@ -72,6 +75,7 @@ export async function bootstrapWorkdir(): Promise<void> {
   await mkdir(WORKDIR, { recursive: true });
   await mkdir(REPOS_DIR, { recursive: true });
   await mkdir(SESSIONS_DIR, { recursive: true });
+  await mkdir(TRIGGERS_DIR, { recursive: true });
   await mkdir(PLUGINS_DATA_DIR, { recursive: true });
   await mkdir(OAUTH_DIR, { recursive: true, mode: 0o700 });
   await mkdir(OAUTH_PENDING_DIR, { recursive: true, mode: 0o700 });

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -546,17 +546,21 @@ export class Task {
   async postInteractiveToUser(
     text: string,
     blocks: unknown[],
-    approvalType: 'edit_mode' | 'research_budget' | 'merge',
+    approvalType: 'edit_mode' | 'research_budget' | 'merge' | 'trigger',
     channelKey?: string,
     context?: { github: string; pr_number: number },
+    ref?: string,
   ): Promise<void> {
     // Merge approvals carry the PR identity so CLI/SSE consumers can echo it
     // back on resolution (the API route requires github+pr_number for
-    // type:'merge'); other approval types omit it (backward compatible).
+    // type:'merge'). `ref` is an opaque id the approval applies to (e.g. a
+    // trigger id), echoed so the CLI can resolve the exact item when several
+    // approvals of the same type are outstanding. Other types omit both.
     emitEvent('approval:requested', this.taskId, {
       text,
       approvalType,
       ...(context ? { github: context.github, pr_number: context.pr_number } : {}),
+      ...(ref ? { ref } : {}),
     });
 
     const ch = this.resolveSlackChannel(channelKey);
@@ -870,6 +874,30 @@ export class Task {
       return null;
     }
     return getMessageReactions(ch.channel_id, messageTs);
+  }
+
+  /**
+   * Link an existing Slack thread to this task and promote it to the default
+   * channel. Posts nothing — used by `fireTrigger` for channel-message triggers
+   * so the spawned PM replies in the triggering thread rather than opening a new
+   * one. Idempotent; mirrors the channel-registration shape used by `append`.
+   * Returns the channel key.
+   */
+  linkSlackThread(channelId: string, threadTs: string, channelName: string): string {
+    const key = `slack:${channelId}:${threadTs}`;
+    if (!this.metadata.channels[key]) {
+      this.metadata.channels[key] = {
+        type: 'slack',
+        thread_id: threadTs,
+        channel_id: channelId,
+        channel_name: channelName,
+        last_processed_ts: threadTs,
+        url: buildThreadUrl(channelId, threadTs) ?? undefined,
+      };
+    }
+    this.metadata.default_channel ??= key;
+    this.debouncedSave();
+    return key;
   }
 
   /**
@@ -1379,6 +1407,65 @@ export class Task {
   async handleResearchBudgetDenial(): Promise<void> {
     await appendAgentFinding(this.taskId, 'system', 'Additional research denied by user', 'decision');
     await this.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
+  }
+
+  /**
+   * Approve the trigger this task proposed (read from `metadata.pending_trigger_id`).
+   * Flips it to `enabled`, indexes the scheduler, and announces to the bound
+   * channel. Shared by the Slack `approve_trigger` button and the CLI
+   * `/tasks/:id/approve` endpoint. Returns the enabled trigger (or null if the
+   * pending proposal is gone). Dynamic imports avoid a static task↔scheduler cycle.
+   */
+  async handleTriggerApproval(approverId: string, triggerId?: string): Promise<import('../types/trigger.js').Trigger | null> {
+    const id = triggerId ?? this.metadata.pending_trigger_id;
+    if (!id) {
+      logger.warn('task', `handleTriggerApproval on ${this.taskId} with no trigger id`);
+      return null;
+    }
+    const { loadTrigger, enableProposedTrigger, deleteTrigger, countActiveTriggers } = await import('../system/trigger-store.js');
+    const { indexTrigger, announceTriggerChange, MAX_TRIGGERS_PER_USER, MAX_TRIGGERS_PER_CHANNEL } = await import('../system/trigger-scheduler.js');
+
+    // Re-check caps at approval: pending proposals don't count toward the caps,
+    // so approving several proposed while under the limit could otherwise blow
+    // past it. Refuse (delete the pending file) if enabling would exceed a cap.
+    const pending = await loadTrigger(id);
+    if (pending && pending.status === 'pending') {
+      const overChannel = pending.binding.type === 'channel'
+        && (await countActiveTriggers((t) => t.binding.type === 'channel' && t.binding.channel_id === (pending.binding as { channel_id: string }).channel_id)) >= MAX_TRIGGERS_PER_CHANNEL;
+      const overUser = pending.created_by && pending.created_by !== 'unknown'
+        && (await countActiveTriggers((t) => t.created_by === pending.created_by)) >= MAX_TRIGGERS_PER_USER;
+      if (overChannel || overUser) {
+        await deleteTrigger(id);
+        if (this.metadata.pending_trigger_id === id) this.metadata.pending_trigger_id = undefined;
+        this.debouncedSave();
+        await appendAgentFinding(this.taskId, 'system', `Trigger ${id} not enabled — active-trigger cap reached`, 'decision');
+        return null;
+      }
+    }
+
+    const trigger = await enableProposedTrigger(id, approverId);
+    if (this.metadata.pending_trigger_id === id) this.metadata.pending_trigger_id = undefined;
+    this.debouncedSave();
+    if (!trigger) return null;
+    indexTrigger(trigger);
+    await appendAgentFinding(this.taskId, 'system', `Trigger ${id} approved by user`, 'decision');
+    emitEvent('trigger:created', this.taskId, { trigger_id: id });
+    await announceTriggerChange(trigger, 'enabled');
+    return trigger;
+  }
+
+  /**
+   * Deny the trigger this task proposed — delete the pending file. Shared by the
+   * Slack `deny_trigger` button and the CLI `/approve` endpoint.
+   */
+  async handleTriggerDenial(triggerId?: string): Promise<void> {
+    const id = triggerId ?? this.metadata.pending_trigger_id;
+    if (this.metadata.pending_trigger_id === id) this.metadata.pending_trigger_id = undefined;
+    this.debouncedSave();
+    if (!id) return;
+    const { deleteTrigger } = await import('../system/trigger-store.js');
+    await deleteTrigger(id);
+    await appendAgentFinding(this.taskId, 'system', `Trigger ${id} denied by user`, 'decision');
   }
 
   // ---- Internal methods ----

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@
 
 export * from './task.js';
 export * from './agent.js';
+export * from './trigger.js';

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -327,6 +327,8 @@ export interface TaskMetadata {
     trigger_at: string;              // ISO 8601 datetime when the task should be reactivated
     reason: string;                  // Why — shown to agent when woken
   };
+  triggered_by?: string;             // Trigger ID that spawned this task (set by fireTrigger). Blocks the task from creating triggers.
+  pending_trigger_id?: string;       // Trigger ID proposed by this task, awaiting approve/deny (read by handleTriggerApproval/Denial)
   created_at: string;
   updated_at: string;
 }

--- a/src/types/trigger.ts
+++ b/src/types/trigger.ts
@@ -1,0 +1,63 @@
+/**
+ * Trigger type definitions
+ *
+ * A Trigger is a persistent "do Y when X happens" rule that spawns a fresh task
+ * when its condition fires. Two condition types ship in v1:
+ *   - `schedule` — fires on a recurring cron cadence or once at a future time
+ *   - `channel_message` — fires on a new top-level message in a bound channel
+ *
+ * Triggers are stored one JSON file per trigger under TRIGGERS_DIR (see
+ * trigger-store.ts) and indexed in-memory by the trigger scheduler.
+ */
+
+export type TriggerStatus = 'pending' | 'enabled' | 'paused';
+
+/**
+ * Where a fired trigger delivers its work.
+ *  - `channel` — posts a thread in the bound Slack channel
+ *  - `user` — delivers by DM to the user
+ *
+ * Channel privacy (public/private) is deliberately NOT stored here — it is
+ * resolved live at list time (see list_triggers), because a channel can be
+ * converted public↔private after the trigger was created and a stale cached
+ * value would leak a now-private channel's triggers into public contexts.
+ */
+export type TriggerBinding =
+  | { type: 'channel'; channel_id: string; channel_name: string }
+  | { type: 'user'; user_id: string };
+
+/**
+ * A condition that fires the trigger.
+ *  - `schedule` — recurring when `cron` is set (next_run_at recomputed after each
+ *    fire), one-off when `cron` is absent (auto-pauses after firing once).
+ *  - `channel_message` — a new top-level message in `channel_id` matching the
+ *    optional `match` filter.
+ */
+export type TriggerCondition =
+  | { type: 'schedule'; tz: string; next_run_at: string; cron?: string }
+  | { type: 'channel_message'; channel_id: string; match?: { contains?: string; from_user?: string } };
+
+export interface Trigger {
+  /** "trg-YYYYMMDD-HHMM-random6" */
+  id: string;
+  /** pending = proposed, awaiting approval; enabled = live; paused = inactive */
+  status: TriggerStatus;
+  /** Slack user ID who requested it */
+  created_by: string;
+  created_at: string;
+  /** Slack user ID who approved it (set when status flips pending → enabled) */
+  approved_by?: string;
+  binding: TriggerBinding;
+  /** N conditions — any match fires the trigger */
+  conditions: TriggerCondition[];
+  /** PM instruction seeded into the spawned task when fired (internal — not shown to users). */
+  action: { prompt: string };
+  /**
+   * Short, user-facing one-liner describing what the trigger does (e.g. "Daily
+   * summary of #bot-test"). Shown in approval prompts, announcements, and
+   * listings instead of the verbose internal `action.prompt`. Set by the PM at
+   * creation; falls back to a shortened `action.prompt` when absent.
+   */
+  summary?: string;
+  last_fired_at?: string;
+}


### PR DESCRIPTION
## What & why

Archie was purely reactive — it only acted on an inbound Slack message or a GitHub webhook. The one bit of proactivity (the reminder scheduler) could re-wake an existing task but never start work on its own. This PR adds **triggers**: persistent, user-approved "do Y when X happens" rules that spawn a fresh task when a condition fires. It's the one sanctioned form of self-initiated work, and every trigger is created behind an explicit Approve/Deny gate.

Two condition types ship in v1: **schedule** (a recurring cron cadence or a one-off future time) and **channel-message** (a new top-level message in a watched channel, with an optional substring / author filter). Each trigger is bound to a delivery target — a channel or a user DM. GitHub-event triggers are a deliberate follow-up.

## How it works

The design reuses existing machinery rather than adding a new engine. The firing loop is a near-clone of the reminder scheduler's index-and-tick pattern (`trigger-scheduler.ts`): an in-memory index of enabled triggers, a 60s tick, and an immediate catch-up check on boot. Recurrence math is offloaded to `croner` (DST-correct, zero-dep) and kept **entirely internal** — the PM translates natural language → a cron expression at creation, the system validates a ≥1h floor for recurring schedules, and listings render cron back to prose. One-off schedules store a single `next_run_at` and auto-pause after firing. Triggers persist one JSON file each under `$ARCHIE_WORKDIR/triggers/` (`trigger-store.ts`).

Creation reuses the edit-mode approval mechanism, which is already channel-agnostic: `propose_trigger` posts an Approve/Deny prompt that renders as buttons in Slack and as `[y]/[n]` in the CLI, and both converge on the same task-level handlers (`handleTriggerApproval`/`handleTriggerDenial`) — the Slack button and the CLI `/tasks/:id/approve` endpoint. There is no operator bypass. The proposed trigger id is threaded through the approval event so concurrent proposals resolve to the right one.

Fired tasks are ordinary read-only tasks: `fireTrigger` spawns a task, wires the delivery destination, sets `triggered_by`, and seeds the PM with the action prompt. Firing posts no preamble — the spawned PM does the work and posts the result itself. A provenance gate blocks a trigger-spawned task from creating more triggers (no amplification loops). Visibility is scoped by the tier of the space the request comes from (public / private / DM), with channel privacy resolved from the workspace channel cache (`listWorkspaceChannels`) plus a live fail-closed fallback on a miss, so a public→private conversion is reflected promptly and a private trigger is never leaked into a public listing. Config changes (create/edit/pause/resume/delete) are announced to the bound channel; firing is not.

The PM gets four tools (`propose_trigger` / `list_triggers` / `update_trigger` / `delete_trigger`), an engine-owned skill (`skills/triggers`) plus a short always-present blurb in the PM base prompt so it knows triggers exist before loading the skill, and the operator surface gets `/api/triggers` endpoints and a CLI trigger-list view (press `t`). Protections: the ≥1h recurring floor, per-user and per-channel active-trigger caps (re-checked on resume), a per-account daily fire cap, a dead/archived-channel pre-flight that pauses and notifies, stale-pending GC on boot, and an `ARCHIE_TRIGGERS_ENABLED` kill switch.

Out of scope on purpose: GitHub-event triggers, and any user-facing cron surface.

## Verification

Static checks all pass on the rebased tip: `npm run typecheck`, `npm run build`, and `npm test` (**782 tests, 59 files**), including new unit tests for cron next-run (with a DST boundary), the ≥1h-floor validator, and the visibility-scoping decision.

I did **not** boot the live app / run the E2E harness in this environment, so the end-to-end Slack and CLI paths (button approval, `[y]/[n]` approval, a real fire posting into a channel/DM) have not been exercised against a running instance — worth a live check before relying on it.

One thing to look at closely in review: this branch was written before `main`'s `postToUser` refactor and rebased onto it. That refactor narrowed `PostTarget` to `channel` only (removed `new_dm`/`new_thread`) and deleted `openDMChannel`, routing cross-channel posting through the new task-decoupled `post_to_channel` explore tool. I adapted trigger delivery to the new model — system-level announcements/notices post directly via `postSlackMessage` (a Slack user id resolves straight to that user's DM, so no `conversations.open` is needed), and `fireTrigger`'s delivery instruction to the PM is now tool-agnostic plain language ("post the result to #channel" / "as a DM to the user"). The PM-driven delivery of a fired result therefore leans on whatever posting tools the PM currently has under the new model; that's the specific path I'd validate live.

## Deployment & follow-ups

- No migration. Triggers live in a new `$ARCHIE_WORKDIR/triggers/` directory created on boot.
- New dependency: `croner`.
- `ARCHIE_TRIGGERS_ENABLED=false` disables all firing and creation globally (kill switch); default is enabled.
- Follow-up: GitHub-event triggers (webhook plumbing already exists); and a live E2E pass over the approval + fire paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzcVLThyuwSpo8p6RTE2wT)_