### PR TITLE
fix(changelog): stop the daily automation writing empty day records

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -256,6 +256,10 @@ jobs:
           git config user.name "archie-changelog[bot]"
           git config user.email "archie-changelog@users.noreply.github.com"
           git add CHANGELOG.md
+          # Keep this message prefix in sync with SKIP_OWN in
+          # scripts/changelog-gather.sh: it excludes the automation's own
+          # changelog commits so a quiet day (whose only commit is the previous
+          # day's entry) isn't mistaken for an active one and summarized empty.
           git commit -m "docs(changelog): add entry for ${TARGET_DATE} [skip ci]"
 
           # Retry the push a few times to ride out transient failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 Archie ships continuously, so changes are grouped by the **date they landed** on `main` rather than by version. Each entry leads with the **value** it delivers, then adds **technical detail**; pure plumbing stays technical. The [starting-point snapshot](#before-this-log--the-starting-point) at the bottom is where Archie stood before the first entry.
 
+<!-- This file is generated automatically — do NOT edit it by hand. The `.github/workflows/daily-changelog.yml` workflow summarizes each day's merged PRs into a dated entry and commits it to `main` on its own. To shape how a change reads here, write a clear PR description — that is the source the automation reads. Quiet days with nothing merged are intentionally skipped (no entry), so gaps between dates are expected. Hand edits drift from the automation and may be overwritten; the only reason to touch this file directly is to repair a mistake the automation made. -->
+
 ## [Unreleased]
 
 _Changes on `main` that haven't been summarized into a dated entry yet._
-
-## 2026-07-09
-
-_No changes landed on `main` this day._
 
 ## 2026-07-08
 
@@ -44,14 +42,6 @@ _No changes landed on `main` this day._
 ## 2026-07-04
 
 - **Operators now have a repeatable, adversarially-verified loop — Forge — for taking any idea, GitHub issue, or existing PR to a tested, verified pull request.** The `/forge` command walks through inception (testable acceptance criteria with named verification methods: `unit`/`integration`/`live-e2e`/`manual`/`deploy-only`), fact-checked research, critic-hardened planning, adversarial implementation review, and black-box QA against a live instance via the `archie-debug` MCP; `live-e2e` ACs that need infrastructure not yet built are waived with a named post-merge step rather than silently skipped. Operation is local and operator-driven — one run at a time, two human gates (inception sign-off and merge decision), no Archie runtime change. _Technical: ships as `.claude/skills/forge/` (orchestrator `SKILL.md` + six self-contained stage files carrying verbatim role prompts) and `.claude/commands/forge.md`; run state in `forge.yaml` on a `forge/*` branch; entry points: idea, issue, pr (finish-mode), resume, abandon; `docs/proposals/forge.md` contains the full design rationale; Stage 1 machinery dry-run verified on a real target (30 cited claims, 29 confirmed, 0 wrong); a consistency review caught 3 blocking gaps — all fixed before merge (PR #174)._
-
-## 2026-07-03
-
-_No changes landed on `main` this day._
-
-## 2026-07-02
-
-_No changes landed on `main` this day._
 
 ## 2026-07-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ Use the unified logger (`src/system/logger.ts`) for all console output. Never us
 
 **Never hard-wrap prose.** In Markdown and other prose (docs, `CHANGELOG.md`, PR descriptions, comments), write each paragraph or bullet as a single line and let it soft-wrap. Do not insert manual line breaks to hit a column width — they make edits and diffs noisy. Only code (fenced blocks, indented samples) may span fixed-width lines.
 
+## Changelog
+
+`CHANGELOG.md` is generated automatically — **do not maintain it by hand.** A scheduled GitHub Actions workflow (`.github/workflows/daily-changelog.yml`) summarizes each day's merged PRs into a dated entry and commits it to `main` on its own. Do not add, edit, or remove `CHANGELOG.md` entries as part of your work — not on a feature branch, not in a PR, not "while you're in there." The way to shape what appears is to write a clear PR description: that is the source the automation reads. Quiet days with nothing merged are skipped on purpose, so gaps between dates are expected and not something to fill in. The only legitimate reason to touch `CHANGELOG.md` or its workflow directly is to fix the automation itself.
+
 ## Git Workflow
 
 **IMPORTANT**: Only create commits when explicitly requested by the user. Never commit code automatically.

--- a/scripts/changelog-gather.sh
+++ b/scripts/changelog-gather.sh
@@ -21,12 +21,20 @@ OUT="${3:?missing out-file}"
 
 SINCE="$DATE 00:00:00 +0000"
 UNTIL="$DATE 23:59:59 +0000"
+# The automation's own changelog commits are excluded everywhere. They must not
+# count as a day's "changes": on a quiet day the only commit on main is often the
+# previous day's `docs(changelog): add entry for …` push, and if that counted as
+# activity the day would slip past the bail-out below and reach the model with
+# empty context — which then drafts a bogus "_No changes landed_" entry.
 SKIP_OWN='^docs(changelog): add entry for'
 
-# Bail early if nothing landed at all (no PRs, no direct commits).
+# Bail early if nothing worth documenting landed. `commits` uses the SAME
+# `SKIP_OWN` filter as the backstop context below, so this check is exactly
+# "would the context be empty?" — PRs merged that day plus non-automation commits.
 prs="$(gh pr list --repo "$REPO" --search "is:merged base:main merged:$DATE" \
         --json number --jq '.[].number' --limit 100 || true)"
-commits="$(git log --no-merges --since="$SINCE" --until="$UNTIL" --pretty=format:'%h')"
+commits="$(git log --no-merges --since="$SINCE" --until="$UNTIL" \
+            --invert-grep --grep="$SKIP_OWN" --pretty=format:'%h')"
 if [ -z "$prs" ] && [ -z "$commits" ]; then
   exit 10
 fi

--- a/scripts/changelog-insert.mjs
+++ b/scripts/changelog-insert.mjs
@@ -50,8 +50,14 @@ const date = entry.match(DATE_HEADING)[1];
 // nothing to report (changelog-gather.sh bails before the model runs), so a
 // bulletless entry arriving here means something upstream misfired — never
 // commit a hollow "_No changes landed_" section. Fail loudly instead.
+//
+// The test is "does the body have a markdown list item?": every real entry —
+// including a pure-plumbing day, written as `- _Technical: …_` — leads its
+// content with a bullet, while the empty-day draft is a bare italic line.
+// Match only list markers (`-`, `*`, `+`), NEVER a leading `_`: accepting `_`
+// would let the empty "_No changes landed_" sentinel pass straight through.
 const body = entry.slice(entry.indexOf('\n') + 1);
-if (!/^\s*[-*] /m.test(body)) {
+if (!/^\s*[-*+] /m.test(body)) {
   console.error(
     `Refusing to insert: entry for ${date} has a heading but no changelog bullets ` +
       `(an empty "no changes" record). A quiet day should be skipped upstream, not committed.\n` +

--- a/scripts/changelog-insert.mjs
+++ b/scripts/changelog-insert.mjs
@@ -13,6 +13,7 @@
 //   1  the entry file has no "## YYYY-MM-DD" heading (refuse to insert)
 //   2  bad arguments
 //   3  an entry for that date is already present (no-op; safe to ignore)
+//   4  the entry has a heading but no bullets (an empty "no changes" record; refuse)
 
 import { readFileSync, writeFileSync } from 'node:fs';
 
@@ -44,6 +45,20 @@ let entry = (nextSection === -1
 ).replace(/```[a-z]*\s*$/i, '').trim();
 
 const date = entry.match(DATE_HEADING)[1];
+
+// Refuse an empty day record. The automation is supposed to skip a day with
+// nothing to report (changelog-gather.sh bails before the model runs), so a
+// bulletless entry arriving here means something upstream misfired — never
+// commit a hollow "_No changes landed_" section. Fail loudly instead.
+const body = entry.slice(entry.indexOf('\n') + 1);
+if (!/^\s*[-*] /m.test(body)) {
+  console.error(
+    `Refusing to insert: entry for ${date} has a heading but no changelog bullets ` +
+      `(an empty "no changes" record). A quiet day should be skipped upstream, not committed.\n` +
+      'Got:\n' + entry.slice(0, 200),
+  );
+  process.exit(4);
+}
 
 // Idempotency: never add a second section for the same date.
 if (new RegExp(`^## ${date}\\b`, 'm').test(changelog)) {


### PR DESCRIPTION
## What & why

The daily-changelog automation has been committing empty `_No changes landed on `main` this day._` entries on quiet days. Three such records exist in `CHANGELOG.md` (2026-07-02, 2026-07-03, 2026-07-09), and all three were created by `archie-changelog[bot]`, not by hand.

Root cause is a self-referential inconsistency in `scripts/changelog-gather.sh`. The script decides whether to skip a day by checking if any PRs merged or any commits landed. But the early bail-out counted *all* non-merge commits, while the context it actually feeds the model filters out the automation's own `docs(changelog): add entry for …` commits (the `SKIP_OWN` filter). On a quiet day the only commit on `main` in that day's window is often the *previous* day's changelog push — so the bail-out saw "a commit landed" and proceeded, but the model then received a context file with no PRs and no commits (the one commit having been filtered out). Given empty context, the model dutifully wrote an empty entry, and `changelog-insert.mjs` committed it to `main`.

This also explains a confusing detail: a real commit dated 2026-07-09 does exist (`244b644`), but it belonged to PR #130 which didn't merge until ~8 hours after the 07-09 job ran, so it wasn't on `main` at gather time — `git log --since/--until` keys off commit date, but a commit only becomes reachable once its PR merges.

## How it works

- `scripts/changelog-gather.sh` — the bail-out now applies the same `SKIP_OWN` filter to its commit check that the backstop context already uses. The check becomes exactly "would the context be empty?" (PRs merged that day plus non-automation commits), so a day whose only commit is the automation's own changelog push is correctly detected as empty and skipped (exit 10). This is the root-cause fix.
- `scripts/changelog-insert.mjs` — defense-in-depth in the trusted, deterministic step: it now refuses (new exit code 4) to insert an entry that has a `## YYYY-MM-DD` heading but no bullets. A quiet day is meant to be skipped upstream before the model ever runs, so a bulletless entry reaching the insert step means something misfired — it fails loudly instead of committing a hollow record. This makes "automation never writes an empty day record" a structural guarantee even if a future change reintroduces an empty-context path.
- `CHANGELOG.md` — removed the three empty entries this bug produced, and added a header comment stating the file is generated and must not be hand-edited. Quiet days are now simply absent, so gaps between dates are expected.
- `CLAUDE.md` — added a "Changelog" section telling agents not to maintain the file by hand; the way to shape an entry is a clear PR description, which is the source the automation reads.

Out of scope: the PR-merges-on-a-later-day-than-its-commits quirk noted above is left as-is — the merged-PR path (`merged:<date>`) attributes those changes to the day the PR actually merged, which is correct; this PR only stops the empty-entry bug.

## Verification

- `bash -n scripts/changelog-gather.sh` passes.
- Reproduced the bug against real history: reconstructed `main` as it stood when the 2026-07-09 job ran and confirmed the old bail-check saw the bot's own commit (so it did *not* skip), while the new filtered check returns empty — so with no PRs merged that day the day now correctly bails.
- Exercised `changelog-insert.mjs` across all paths: empty "no changes" entry → exit 4, not inserted; real entry with a bullet → exit 0, inserted in the right place; technical-only bullet → exit 0; duplicate date → exit 3; missing heading → exit 1. Also confirmed insertion still works against the actual `CHANGELOG.md` with the new header comment present (entry lands above the newest dated entry, comment preserved).
- Did not run the full `vitest` suite: these are standalone scripts not imported by `src/`, and there are no existing changelog tests, so the TypeScript suite doesn't cover them. The GitHub API steps (`gh pr list`) were not run live here (no token in this environment); the change to that path is a filter addition verified by the shell parse and the git-log reproduction above.

## Deployment & follow-ups

None required — no runtime or workflow-permission changes. The next scheduled run picks up the fixed scripts automatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EVm99AL5DHGY3L4AGbyYjd)_