### PR TITLE
fix(changelog): let changelog commits trigger CI and the image build

### DIFF
--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -23,7 +23,10 @@
 #   4. publish: scripts/changelog-insert.mjs splices each entry into its
 #      reverse-chronological slot below the intro header, leaving structure and
 #      the bottom snapshot alone.
-#   5. publish: commit straight to main with [skip ci] so it doesn't trigger a rebuild.
+#   5. publish: commit straight to main. The commit deliberately does NOT carry
+#      [skip ci]: deployments take the latest main commit, so every commit on
+#      main — including a changelog entry — must have its own CI run and
+#      published image.
 #
 # Security:
 #   The gather step feeds attacker-influenceable text (PR/issue/commit bodies) to
@@ -310,9 +313,9 @@ jobs:
           FIRST_DATE="${TARGET_DATES%% *}"
           LAST_DATE="${TARGET_DATES##* }"
           if [ "$FIRST_DATE" = "$LAST_DATE" ]; then
-            MESSAGE="docs(changelog): add entry for ${FIRST_DATE} [skip ci]"
+            MESSAGE="docs(changelog): add entry for ${FIRST_DATE}"
           else
-            MESSAGE="docs(changelog): add entries for ${FIRST_DATE}..${LAST_DATE} [skip ci]"
+            MESSAGE="docs(changelog): add entries for ${FIRST_DATE}..${LAST_DATE}"
           fi
           git commit -m "$MESSAGE"
 


### PR DESCRIPTION
## What & why

The daily changelog automation commits its entries to `main` with a `skip ci` marker in the message, so neither CI nor the Docker image build runs for that commit. Deployments take the latest commit on `main` — after a changelog push, the tip of `main` has no corresponding build/image, which makes deploying harder. Follow-up to #217.

This drops the marker so a changelog commit gets its own CI run and published image like any other commit on `main`.

(The PR title and this description deliberately avoid spelling the bracketed marker: GitHub honors it anywhere in a head commit message, so a commit message merely *mentioning* it verbatim would skip CI on this PR too — the first push of this branch did exactly that and had to be reworded.)

## How it works

Message-only change in the publish step of `.github/workflows/daily-changelog.yml` (both the single-day and multi-day backfill forms), plus the header comment updated to document why the commit deliberately does **not** skip CI. The `SKIP_OWN` quiet-day filter in `changelog-gather.sh` matches on the `docs(changelog): add entr` prefix, not the suffix, so it is unaffected.

Note the trigger mechanics actually allow this to work: `ci.yml` and `docker-publish.yml` both run on `push` to `main`, and the publish job pushes over SSH with the changelog deploy key — not `GITHUB_TOKEN` — so its pushes do trigger workflows once the marker is gone.

## Verification

Workflow YAML parses (PyYAML). Confirmed `ci.yml` and `docker-publish.yml` trigger on push to `main`, and that the changelog push uses the deploy key rather than `GITHUB_TOKEN` (whose pushes would never trigger workflows regardless of the marker). Not run live: the next scheduled changelog run after merge will demonstrate the CI/image build firing on its commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVfkd1zx53Z2zA2yG7sBUV