### PR TITLE
feat(auth): Claude subscription auth for CLI-only interactive use

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
-# Anthropic API
+# Claude authentication (auto-detected in priority order):
+#   1. ANTHROPIC_API_KEY — standard API key.
+#   2. CLAUDE_CODE_OAUTH_TOKEN — subscription token from `claude setup-token`.
+# At least one must be available or startup fails.
+#
+# Subscription auth (CLAUDE_CODE_OAUTH_TOKEN) is for CLI-only interactive use
+# (`npm run cli`); use ANTHROPIC_API_KEY for Slack-connected deployments and the
+# E2E harness. See docs/guides/local-development.md.
 ANTHROPIC_API_KEY=sk-ant-...
+# CLAUDE_CODE_OAUTH_TOKEN=
 
 # Claude Code CLI path - point directly to cli.js
 CLAUDE_PATH=/path/to/claude

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -27,7 +27,7 @@ Monitoring: container logs + /health endpoint
 Secrets are injected via the container's environment file plus the mounted
 `/app/secrets` volume. See `.env.example` for the full list. Required at runtime:
 
-- `ANTHROPIC_API_KEY` — Claude API access (required; startup fails without it)
+- `ANTHROPIC_API_KEY` — Claude API access. A deployment must use an API key (subscription auth via `CLAUDE_CODE_OAUTH_TOKEN` is CLI-only). Startup fails if no Claude credential is present.
 - `SLACK_BOT_TOKEN` / `SLACK_SIGNING_SECRET` — Slack integration in HTTP webhook mode (optional; CLI-only mode if both omitted)
 - `SLACK_APP_TOKEN` — `xapp-...` app-level token; set this *instead of* `SLACK_SIGNING_SECRET` to use Socket Mode and deploy without an inbound webhook URL
 - `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, `GITHUB_INSTALLATION_ID` — GitHub App identifiers

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -2,12 +2,14 @@
 
 ## Quick Start
 
-The only required env var is `ANTHROPIC_API_KEY`. Slack and GitHub App credentials are optional.
+Archie needs a Claude credential, auto-detected in priority order: `ANTHROPIC_API_KEY`, then `CLAUDE_CODE_OAUTH_TOKEN` (a subscription token from `claude setup-token`). At least one must be set or startup fails. Slack and GitHub App credentials are optional.
+
+**Subscription auth is for CLI-only interactive use.** Running Archie in CLI-only mode (no Slack credentials) and driving it from `npm run cli`, you can authenticate with your Claude subscription via `CLAUDE_CODE_OAUTH_TOKEN` instead of a metered API key — turns are human-initiated, the same shape as using Claude Code directly. Slack-connected deployments and the E2E harness are automated access and should use `ANTHROPIC_API_KEY`.
 
 ```bash
 # 1. Setup environment
 cp .env.example .env
-# Set ANTHROPIC_API_KEY in .env
+# Set ANTHROPIC_API_KEY in .env (or CLAUDE_CODE_OAUTH_TOKEN for CLI-only subscription use)
 
 # 2. Ensure your SSH key is loaded (used for git inside Docker)
 ssh-add
@@ -139,8 +141,9 @@ If `ARCHIE_PLUGINS` is set to a git URL, the app auto-clones the plugins repo on
 ## Environment Variables
 
 ```bash
-# Required
-ANTHROPIC_API_KEY=sk-ant-...           # Claude API key
+# Required — a Claude credential (at least one):
+ANTHROPIC_API_KEY=sk-ant-...           # Claude API key (use this for Slack deployments + E2E)
+# CLAUDE_CODE_OAUTH_TOKEN=...          # subscription token, CLI-only interactive use (`claude setup-token`)
 
 # Optional - Slack (omit for CLI-only mode)
 # SLACK_BOT_TOKEN=xoxb-...

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -11,6 +11,7 @@
  */
 
 import { join } from 'path';
+import { claudeCredentialEnv } from '../system/claude-credential.js';
 import { mkdir, symlink, readdir, writeFile, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { randomUUID } from 'node:crypto';
@@ -613,7 +614,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
     // resolving to a literal `~` directory instead of the real home.
     env: {
       NODE_ENV: process.env.NODE_ENV || 'development',
-      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      ...claudeCredentialEnv(),
       // CA-trust config for the spawned CLI. The SDK REPLACES env (see note
       // above), so without forwarding these an operator-provided CA (e.g. a
       // TLS-intercepting egress proxy) never reaches the child and its

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ import { initEventPersistence } from './tasks/persistence.js';
 import { initReminderScheduler } from './system/reminder-scheduler.js';
 import { initTriggerScheduler } from './system/trigger-scheduler.js';
 import { initMemory } from './memory/index.js';
+import { assertClaudeCredentialAvailable } from './system/claude-credential.js';
+import { StartupError } from './system/startup-error.js';
 
 /**
  * Application configuration
@@ -65,9 +67,7 @@ function loadConfig(): AppConfig {
   const port = parseInt(process.env.PORT || '3000', 10);
   const githubWebhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
 
-  if (!process.env.ANTHROPIC_API_KEY) {
-    throw new Error('ANTHROPIC_API_KEY environment variable is required');
-  }
+  assertClaudeCredentialAvailable();
 
   return {
     slackBotToken,
@@ -287,6 +287,18 @@ async function main(): Promise<void> {
     process.on('SIGINT', () => shutdown('SIGINT'));
     process.on('SIGTERM', () => shutdown('SIGTERM'));
   } catch (error) {
+    if (error instanceof StartupError) {
+      // Known, operator-fixable misconfiguration — show a clean, actionable
+      // message with no JS stack trace (the stack is noise here).
+      logger.error('startup', error.message);
+      // Details to stderr (not logger.plain, which is stdout) so the fix lands
+      // on the same stream as the headline under `npm run dev 2>startup.log`.
+      for (const line of error.details) {
+        logger.plainErr(`  ${line}`);
+      }
+      logger.plainErr('');
+      process.exit(1);
+    }
     logger.error('index', 'Failed to start server', error);
     process.exit(1);
   }

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -12,6 +12,7 @@
  */
 
 import crypto from 'node:crypto';
+import { claudeCredentialEnv } from '../system/claude-credential.js';
 import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { query, tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
@@ -81,7 +82,7 @@ Respond with JSON only.`;
         executable: 'node',
         env: {
           NODE_ENV: process.env.NODE_ENV || 'development',
-          ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+          ...claudeCredentialEnv(),
           // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
           ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
           ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),

--- a/src/memory/extractor.ts
+++ b/src/memory/extractor.ts
@@ -6,6 +6,7 @@
  */
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
+import { claudeCredentialEnv } from '../system/claude-credential.js';
 import { loadPrompt } from '../utils/prompt-loader.js';
 import { logger } from '../system/logger.js';
 import type { ExtractionResult, MemoryUpdate, EntityUpdate } from './types.js';
@@ -240,7 +241,7 @@ export async function runExtraction(
         executable: 'node',
         env: {
           NODE_ENV: process.env.NODE_ENV || 'development',
-          ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+          ...claudeCredentialEnv(),
           // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
           // Adds TLS trust only — not tools/permissions — so the minimal-env invariant holds.
           ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),

--- a/src/memory/housekeeping.ts
+++ b/src/memory/housekeeping.ts
@@ -14,6 +14,7 @@
  */
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
+import { claudeCredentialEnv } from '../system/claude-credential.js';
 import { readFile, writeFile, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
@@ -269,7 +270,7 @@ async function runHousekeeperAgent(fileContent: string): Promise<string> {
       executable: 'node',
       env: {
         NODE_ENV: process.env.NODE_ENV || 'development',
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+        ...claudeCredentialEnv(),
         // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
         // Adds TLS trust only — not tools/permissions — so the minimal-env invariant holds.
         ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),

--- a/src/system/__tests__/claude-credential.test.ts
+++ b/src/system/__tests__/claude-credential.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const systemMock = vi.fn();
+vi.mock('../logger.js', () => ({ logger: { system: (m: string) => systemMock(m) } }));
+
+import {
+  resolveClaudeCredential,
+  claudeCredentialEnv,
+  assertClaudeCredentialAvailable,
+} from '../claude-credential.js';
+import { StartupError } from '../startup-error.js';
+
+const savedApiKey = process.env.ANTHROPIC_API_KEY;
+const savedToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+
+beforeEach(() => {
+  systemMock.mockReset();
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+});
+
+afterEach(() => {
+  if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+  else process.env.ANTHROPIC_API_KEY = savedApiKey;
+  if (savedToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  else process.env.CLAUDE_CODE_OAUTH_TOKEN = savedToken;
+});
+
+describe('resolveClaudeCredential', () => {
+  it('resolves api_key from ANTHROPIC_API_KEY', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    const r = resolveClaudeCredential();
+    expect(r.kind).toBe('api_key');
+    expect(r.env).toEqual({ ANTHROPIC_API_KEY: 'sk-test' });
+  });
+
+  it('resolves oauth_token_env from CLAUDE_CODE_OAUTH_TOKEN when no api key', () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-env';
+    const r = resolveClaudeCredential();
+    expect(r.kind).toBe('oauth_token_env');
+    expect(r.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: 'oauth-env' });
+  });
+
+  it('prefers api key over env token', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-env';
+    expect(resolveClaudeCredential().kind).toBe('api_key');
+  });
+
+  it('resolves none when no credential is set', () => {
+    expect(resolveClaudeCredential().kind).toBe('none');
+  });
+
+  it('treats a whitespace-only value as absent', () => {
+    process.env.ANTHROPIC_API_KEY = '   ';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-env';
+    expect(resolveClaudeCredential().kind).toBe('oauth_token_env');
+  });
+});
+
+describe('claudeCredentialEnv', () => {
+  it('returns the env fragment', () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-env';
+    expect(claudeCredentialEnv()).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: 'oauth-env' });
+  });
+
+  it('returns {} when nothing resolves', () => {
+    expect(claudeCredentialEnv()).toEqual({});
+  });
+});
+
+describe('assertClaudeCredentialAvailable', () => {
+  it('throws when no credential is available', () => {
+    expect(() => assertClaudeCredentialAvailable()).toThrow(/No Claude credential/);
+  });
+
+  it('logs the resolved kind and does not throw when available', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    assertClaudeCredentialAvailable();
+    expect(systemMock).toHaveBeenCalledWith('Claude auth: api_key');
+  });
+
+  it('logs the "oauth_token (env)" label for a subscription token', () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-env';
+    assertClaudeCredentialAvailable();
+    expect(systemMock).toHaveBeenCalledWith('Claude auth: oauth_token (env)');
+  });
+
+  it('throws a StartupError whose details name both credential env vars', () => {
+    let err: unknown;
+    try {
+      assertClaudeCredentialAvailable();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(StartupError);
+    const details = (err as StartupError).details.join('\n');
+    expect(details).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(details).toContain('ANTHROPIC_API_KEY');
+  });
+});

--- a/src/system/claude-credential.ts
+++ b/src/system/claude-credential.ts
@@ -1,0 +1,57 @@
+/**
+ * Claude credential resolution. Auto-detects, in priority order:
+ *   1. ANTHROPIC_API_KEY        — preserves legacy behavior exactly
+ *   2. CLAUDE_CODE_OAUTH_TOKEN  — subscription token (`claude setup-token`)
+ * Each branch normalizes to an env fragment the spawned Claude Code CLI honors,
+ * so the CLI's isolated CLAUDE_CONFIG_DIR is left untouched. Token values are
+ * never logged — only the resolved kind.
+ */
+import { logger } from './logger.js';
+import { StartupError } from './startup-error.js';
+
+export type ClaudeCredentialKind =
+  | 'api_key'
+  | 'oauth_token_env'
+  | 'none';
+
+export interface ResolvedClaudeCredential {
+  kind: ClaudeCredentialKind;
+  env: Record<string, string>;
+}
+
+export function resolveClaudeCredential(): ResolvedClaudeCredential {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (apiKey && apiKey.trim()) {
+    return { kind: 'api_key', env: { ANTHROPIC_API_KEY: apiKey } };
+  }
+  const envToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  if (envToken && envToken.trim()) {
+    return { kind: 'oauth_token_env', env: { CLAUDE_CODE_OAUTH_TOKEN: envToken } };
+  }
+  return { kind: 'none', env: {} };
+}
+
+export function claudeCredentialEnv(): Record<string, string> {
+  return resolveClaudeCredential().env;
+}
+
+const KIND_LABEL: Record<ClaudeCredentialKind, string> = {
+  api_key: 'api_key',
+  oauth_token_env: 'oauth_token (env)',
+  none: 'none',
+};
+
+export function assertClaudeCredentialAvailable(): void {
+  const { kind } = resolveClaudeCredential();
+  if (kind === 'none') {
+    throw new StartupError(
+      "No Claude credential found — Archie can't authenticate to Claude.",
+      [
+        'Set ONE of the following, then restart:',
+        '  • CLAUDE_CODE_OAUTH_TOKEN   subscription token — run: claude setup-token',
+        '  • ANTHROPIC_API_KEY         a standard Anthropic API key',
+      ],
+    );
+  }
+  logger.system(`Claude auth: ${KIND_LABEL[kind]}`);
+}

--- a/src/system/logger.ts
+++ b/src/system/logger.ts
@@ -302,6 +302,15 @@ export class Logger {
   }
 
   /**
+   * Like `plain`, but to stderr — for the detail lines of an operator-facing
+   * startup error, so they land on the same stream as the headline and are
+   * captured by `2>` redirection.
+   */
+  plainErr(message: string): void {
+    console.error(message);
+  }
+
+  /**
    * Log a debug message with an object (logged as-is for console inspection)
    */
   debug(prefix: string, message: string, data?: any): void {

--- a/src/system/secrets-vault.ts
+++ b/src/system/secrets-vault.ts
@@ -44,8 +44,11 @@ export function loadMasterKey(): Buffer {
     throw new Error('ARCHIE_SECRETS_KEY must be base64-encoded');
   }
   if (buf.length !== KEY_BYTES) {
+    // Deliberately no `got ${buf.length}` here: the message can end up in
+    // startup logs, and log text must never derive from the key material —
+    // not even its decoded length (CodeQL js/clear-text-logging).
     throw new Error(
-      `ARCHIE_SECRETS_KEY must decode to ${KEY_BYTES} bytes; got ${buf.length}. ` +
+      `ARCHIE_SECRETS_KEY must decode to exactly ${KEY_BYTES} bytes. ` +
       'Use 32 random bytes encoded as base64.'
     );
   }

--- a/src/system/startup-error.ts
+++ b/src/system/startup-error.ts
@@ -1,0 +1,18 @@
+/**
+ * A configuration/environment problem detected during startup that the operator
+ * can fix — as opposed to an unexpected crash. The entrypoint renders these as a
+ * clean, actionable message (no JS stack trace), since the stack is noise for a
+ * "you forgot to set X" error.
+ *
+ * `message` is the one-line headline. `details` are indented guidance lines shown
+ * beneath it (e.g. the options to choose from).
+ */
+export class StartupError extends Error {
+  readonly details: string[];
+
+  constructor(message: string, details: string[] = []) {
+    super(message);
+    this.name = 'StartupError';
+    this.details = details;
+  }
+}

--- a/src/system/triage.ts
+++ b/src/system/triage.ts
@@ -6,6 +6,7 @@
  */
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
+import { claudeCredentialEnv } from './claude-credential.js';
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import pc from "picocolors";
@@ -57,7 +58,7 @@ async function runTriage<T extends z.ZodType>(
       // pathToClaudeCodeExecutable: process.env.CLAUDE_PATH || "claude",
       env: {
         NODE_ENV: process.env.NODE_ENV || "development",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+        ...claudeCredentialEnv(),
         // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
         ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
         ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),

--- a/src/tasks/title-generator.ts
+++ b/src/tasks/title-generator.ts
@@ -8,6 +8,7 @@
  */
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
+import { claudeCredentialEnv } from '../system/claude-credential.js';
 import { z, toJSONSchema } from 'zod';
 import type { SlackThread } from '../types/index.js';
 import { renderMessageForContext } from './persistence.js';
@@ -102,7 +103,7 @@ Respond with JSON only.`;
         executable: 'node',
         env: {
           NODE_ENV: process.env.NODE_ENV || 'development',
-          ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+          ...claudeCredentialEnv(),
           // Forward CA-trust to the spawned CLI (TLS-intercepting proxy); no-op when unset.
           ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
           ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),

--- a/tools/e2e/boot.ts
+++ b/tools/e2e/boot.ts
@@ -44,7 +44,11 @@ const DEFAULT_POLL_INTERVAL_MS = 5000;
 
 // ---- Preflight (pure) ----
 
-/** Validate boot preconditions from already-read inputs. Returns human-readable errors, empty when OK. */
+/** Validate boot preconditions from already-read inputs. Returns human-readable errors, empty when OK.
+ *
+ * The E2E harness deliberately requires ANTHROPIC_API_KEY, not the
+ * CLAUDE_CODE_OAUTH_TOKEN subscription path: the harness is automated access, so
+ * it stays on an API key (subscription auth is for CLI-only interactive use). */
 export function preflight(dotenvText: string | undefined): string[] {
   if (dotenvText === undefined) {
     return ['.env not found at the repo root — copy .env.example and set ANTHROPIC_API_KEY'];


### PR DESCRIPTION
Lets an individual running Archie in **CLI-only mode** authenticate the spawned Claude Code CLI/SDK with their Claude subscription (`CLAUDE_CODE_OAUTH_TOKEN`, from `claude setup-token`) instead of a metered `ANTHROPIC_API_KEY` — the same subscription-auth path Claude Code itself supports for Pro/Max plans.

## What it does
- **`resolveClaudeCredential()`** (`src/system/claude-credential.ts`) auto-detects, in priority order: `ANTHROPIC_API_KEY` → `CLAUDE_CODE_OAUTH_TOKEN` → none, and normalizes the result to the env fragment the spawned CLI honors. Token values are never logged — only the resolved kind (`api_key` / `oauth_token_env`, logged as `Claude auth: api_key` / `Claude auth: oauth_token (env)`).
- **Boot gates on *any* Claude credential** (`assertClaudeCredentialAvailable()`), replacing the previous `ANTHROPIC_API_KEY`-only check, with a clean, actionable `StartupError` (`src/system/startup-error.ts`) — no JS stack trace — when none is present. Headline **and** details print to stderr, so `2>startup.log` captures both.
- **The resolved credential is threaded into every Claude SDK env allowlist** — agent spawn plus the one-shot calls (title generation, memory extractor/housekeeping, triage, research) — via `claudeCredentialEnv()`.

Default behavior is unchanged: an `ANTHROPIC_API_KEY`-configured deployment resolves exactly as before.

## Scope — CLI-only interactive use
Subscription auth is for **CLI-only interactive use** (`npm run cli`) — turns are human-initiated, the same shape as using Claude Code directly. **Slack-connected deployments and the E2E harness are automated access and use `ANTHROPIC_API_KEY`.** The E2E preflight (`tools/e2e/boot.ts`) requires the API key deliberately. Documented as a one-line scoping note in `.env.example` and `docs/guides/local-development.md` (no licensing prose in the config template); `docs/guides/deployment.md` corrected.

## Follow-ups (not this PR)
- #153 — this doesn't close it.
- The `npm run cli` self-bootstrap (auto-`claude setup-token` + auto-started dev server) — the natural home for this feature given the CLI-only lane.

## Verification
`npm run typecheck` ✓ · `npm run build` ✓ · `npx vitest run` → 914/914 ✓ (includes `claude-credential` unit tests pinning the label and the startup-error env-var names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149B53Y2e1THfaDsNbrqvQc
