### PR TITLE
Restore sandbox egress enforcement, make package installs work, and add a live boundary check

### DIFF
--- a/.claude/skills/archie-e2e/SKILL.md
+++ b/.claude/skills/archie-e2e/SKILL.md
@@ -129,6 +129,18 @@ cat payload.json | npx tsx tools/e2e/evidence.ts --out-dir <dir>
 
 The markdown companion is rendered mechanically from the JSON in the same invocation (metadata header, assertion table, fenced excerpts, verdict); the JSON is canonical if they ever seem to diverge.
 
+## 3b. Egress check (run on any branch that touches the sandbox or bumps the SDK)
+
+```bash
+npx tsx tools/e2e/egress-check.ts        # requires a booted instance
+```
+
+Asserts the documented network boundary on the live instance: it copies `tools/e2e/egress-probe.mts` into the container, spawns one throwaway sandboxed agent (Haiku, two Bash calls) using the real `src/agents/sandbox.ts`, and requires **both** directions — a host off the allowlist must be blocked, and a host on it must be reachable. Exits non-zero naming which direction failed, with the probe transcript.
+
+Why it exists: the allowlist is enforced by the Claude CLI, not by our code, and it silently stopped being enforced between CLI 2.1.156 and 2.1.157 while our configuration was unchanged. Archie picked that up transitively in a lockfile refresh and ran with unrestricted agent egress for six weeks. No unit test can catch that class of regression — only a live assertion can. Run this after any SDK bump, any `src/agents/sandbox.ts` or `spawn.ts` change, and before shipping anything that relies on the isolation claims in `SECURITY.md`.
+
+A failure here is a release blocker, not a flake. If the non-allowlisted host is reachable, agent egress is open.
+
 ## 4. Teardown
 
 ```bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -51,6 +51,14 @@ RUN chmod +x /app/scripts/git-askpass.sh && \
     npx tsc -p tsconfig.scripts.json
 ENV GIT_ASKPASS=/app/scripts/git-askpass.sh
 
+# Sourced by every non-interactive bash an agent runs. Bridges the sandbox's
+# per-session proxy to tools that ignore the standard *_PROXY vars (Yarn Berry).
+# Lives OUTSIDE /app on purpose: the sandbox denyRead includes /app, so a script
+# there is unreadable from agent Bash and silently never sourced.
+# spawn.ts must forward BASH_ENV explicitly — the SDK replaces the child env.
+RUN mkdir -p /etc/archie && cp /app/scripts/sandbox-shell-env.sh /etc/archie/sandbox-shell-env.sh && chmod 0444 /etc/archie/sandbox-shell-env.sh
+ENV BASH_ENV=/etc/archie/sandbox-shell-env.sh
+
 # Create non-root user (required: bypassPermissions refuses to run as root)
 RUN groupadd -g 1001 archie && \
     useradd -u 1001 -g archie -m archie

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -52,6 +52,14 @@ RUN mkdir -p /workdir /app/secrets && \
 RUN chmod +x /app/scripts/git-askpass.sh
 ENV GIT_ASKPASS=/app/scripts/git-askpass.sh
 
+# Sourced by every non-interactive bash an agent runs. Bridges the sandbox's
+# per-session proxy to tools that ignore the standard *_PROXY vars (Yarn Berry).
+# Lives OUTSIDE /app on purpose: the sandbox denyRead includes /app, so a script
+# there is unreadable from agent Bash and silently never sourced.
+# spawn.ts must forward BASH_ENV explicitly — the SDK replaces the child env.
+RUN mkdir -p /etc/archie && cp /app/scripts/sandbox-shell-env.sh /etc/archie/sandbox-shell-env.sh && chmod 0444 /etc/archie/sandbox-shell-env.sh
+ENV BASH_ENV=/etc/archie/sandbox-shell-env.sh
+
 ENV HOME=/home/archie
 
 # Entrypoint drops to non-root user (shared with dev)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Archie HQ is early-stage software. Security fixes target the **latest `main`**. 
 Archie runs autonomous AI agents that read code, reason, and — once approved — make changes. The engine is built around defense-in-depth so that an agent (or a prompt-injected one) is constrained even if it behaves unexpectedly. Reporters should understand these boundaries when assessing impact:
 
 - **Per-agent filesystem isolation** — each agent runs in a sandbox (bubblewrap on Linux) that restricts which paths it can read and write.
-- **Network deny-all from agent Bash** — agents cannot make arbitrary outbound network calls from their shell. Web access is available only through a controlled research pipeline.
+- **Network deny-all from agent Bash** — agents cannot make arbitrary outbound network calls from their shell. Web access is available only through a controlled research pipeline. Two narrow exceptions: repo agents in edit mode may reach the trusted package registries (for `npm`/`yarn`), and a plugin agent may declare specific hosts it needs. This boundary is enforced by the Claude CLI and is version-coupled — it regressed once across a CLI update with our configuration unchanged, so `tools/e2e/egress-check.ts` asserts it against a live instance.
 - **Tool denylists** — agents are restricted to an allowed set of tools; dangerous operations are blocked.
 - **Human approval gate for edit mode** — agents are read-only by default. Making code changes (edit mode) requires explicit human approval.
 - **Git safety** — force pushes are disallowed, and pushing is blocked from agent Bash.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -61,7 +61,11 @@ PreToolUse hooks (Read, Write, Edit, Glob, Grep):
 
 **Writes:** Deny-all by default. Workspace paths added to `allowWrite` per track. `/tmp` is always writable (tools need scratch space). Protected files (`.claude/settings.json`, `.claude/skills`, `.claude/hooks`, `CLAUDE.md`) are in `denyWrite` — agents cannot modify their own configuration at runtime.
 
-**Network:** All outbound network access from Bash is denied by default (`allowedDomains: []`). Agents cannot `curl`, `wget`, or otherwise reach the internet from shell commands. Web access is only available through the controlled research pipeline (MCP tools).
+**Network:** Outbound access from Bash is deny-all by default. Agents cannot `curl`, `wget`, or otherwise reach the internet from shell commands; web access is only available through the controlled research pipeline (MCP tools). Two narrow exceptions widen the allowlist: repo agents in **edit mode** may reach the trusted package registries (`registry.npmjs.org`, `registry.yarnpkg.com`) so `npm`/`yarn` installs and lockfile regeneration work, and a plugin agent may declare `allowedNetworkDomains` in its frontmatter (e.g. the `ops` plugin reaching `sheets.googleapis.com`). Read-only repo agents and the PM stay fully denied.
+
+The allowlist is enforced from the **policy tier** (`managedSettings`), not from the `sandbox` option — see `buildManagedNetworkPolicy` in `src/agents/sandbox.ts`. This matters: `sandbox.network.allowedDomains` is silently ignored under `permissionMode: 'bypassPermissions'`, which every agent runs under, so the policy tier is what actually holds the boundary. Because that enforcement lives in the Claude CLI rather than in our code, it is version-coupled and has regressed before (CLI 2.1.156 → 2.1.157) with our config unchanged. `tools/e2e/egress-check.ts` asserts the boundary against a live instance for exactly this reason — treat an SDK bump as a security-relevant change and re-run it.
+
+Two deployment caveats. A host-level IT managed-settings tier (e.g. `/etc/claude-code/managed-settings.json`) causes the SDK to **drop** our policy tier unless that admin sets `parentSettingsBehavior: 'merge'`, which would reopen egress with no error. And DNS inside the sandbox namespace is unavailable by design — all egress is forced through the sandbox's local proxy, so tools that ignore proxy environment variables fail to resolve hosts even when those hosts are allowlisted.
 
 ### Repo Isolation: Shared Clones
 
@@ -235,7 +239,14 @@ Every task maintains a `knowledge.log` file (`sessions/{task-id}/shared/knowledg
 Layer 1: OS-level sandbox (Bash only)
   ├── denyRead [/app, ~/.claude] + allowRead [shared, base .git/objects, plugin dirs]
   ├── allowWrite [/tmp, workspace] + denyWrite [.claude/settings.json, .claude/skills, .claude/hooks, CLAUDE.md]
-  └── network: allowedDomains [] (deny all)
+  ├── failIfUnavailable: true (refuse to start rather than run unsandboxed)
+  └── network namespace: no DNS, no direct route — all egress via the sandbox proxy
+
+Layer 1b: Policy tier (managedSettings) — enforces the egress allowlist
+  ├── allowedDomains [] for PM + read-only repo agents (deny all)
+  ├── + trusted package registries for repo agents in edit mode
+  ├── + plugin-declared allowedNetworkDomains
+  └── allowManagedDomainsOnly: true — user/project/local/flag domain rules ignored
 
 Layer 2: PreToolUse hooks (Read, Write, Edit, Glob, Grep)
   ├── Resolves paths to absolute before checking
@@ -302,8 +313,8 @@ Production requires these persistent mounts:
 |-----------|-----------|-----------|------|----------------|-------|-----------|-------------|
 | PM Agent | Workspace + shared | Yes (workspace) | Yes (sandboxed) | No | Yes | No | Yes |
 | Repo Agent (readonly) | Clone + shared | No | Yes (RO sandbox) | No | No | Read only | Yes |
-| Repo Agent (edit mode) | Clone + shared | Yes (clone) | Yes (RW sandbox) | No | No | Full | Yes |
-| Plugin Agent | Workspace + shared + plugin dirs | Yes (workspace) | Yes (sandboxed) | No | No | No | Yes |
+| Repo Agent (edit mode) | Clone + shared | Yes (clone) | Yes (RW sandbox) | Package registries only | No | Full | Yes |
+| Plugin Agent | Workspace + shared + plugin dirs | Yes (workspace) | Yes (sandboxed) | Declared domains only | No | No | Yes |
 | Preset Classifier (inner) | No | No | No | N/A | No | No | No (no tools at all; Haiku JSON output only) |
 
 Web research is performed by the host process via Perplexity Agent API — there is no Claude-driven researcher or report-writer subagent inside the pipeline.
@@ -316,7 +327,7 @@ These are tracked issues with workarounds in place. Remove workarounds when upst
 
 **Issue:** bwrap's mount ordering emits `allowWrite --bind` before `denyRead --tmpfs`. The tmpfs on the parent destroys the child's writable bind mount. `allowRead` then restores read-only access but write access is permanently lost.
 
-**Workaround:** Don't `denyRead` any directory that contains writable child paths. Currently `/workdir/sessions` is left open to Bash (not denied). PreToolUse hooks enforce read boundaries on in-process tools (Read/Glob/Grep). This means Bash can technically browse other tasks' session directories, but cannot exfiltrate data (network is blocked).
+**Workaround:** Don't `denyRead` any directory that contains writable child paths. Currently `/workdir/sessions` is left open to Bash (not denied). PreToolUse hooks enforce read boundaries on in-process tools (Read/Glob/Grep). This means Bash can technically browse other tasks' session directories. Exfiltrating what it finds is bounded by the egress allowlist rather than impossible — a read-only agent is denied all egress, but an edit-mode agent can reach the package registries, so this control depends on the network boundary actually holding (see **Network** above).
 
 **When to remove:** When `sandbox-runtime` fixes mount ordering (tmpfs before bind) or provides a `denyRead` mode that doesn't use tmpfs. Track: `anthropic-experimental/sandbox-runtime` issues.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+        "@anthropic-ai/claude-agent-sdk": "0.3.220",
         "@anthropic-ai/sdk": "^0.115.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1096.0",
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "npm": ">=11.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+    "@anthropic-ai/claude-agent-sdk": "0.3.220",
     "@anthropic-ai/sdk": "^0.115.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1096.0",
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/scripts/sandbox-shell-env.sh
+++ b/scripts/sandbox-shell-env.sh
@@ -1,0 +1,24 @@
+# Sourced by every non-interactive bash the agent runs, via BASH_ENV.
+#
+# Purpose: bridge the sandbox's proxy to tools that ignore the standard *_PROXY
+# variables. All agent egress is forced through a local authenticated proxy whose
+# URL carries a per-session token, so it is only knowable at runtime inside the
+# sandbox — it cannot be baked into the spawn environment.
+#
+# Yarn Berry (yarn 2+) is the case that forced this: it reads only its own config
+# keys (`httpProxy`/`httpsProxy`, env-mapped as YARN_HTTP_PROXY/YARN_HTTPS_PROXY)
+# and ignores HTTPS_PROXY entirely, so `yarn install` fails DNS resolution inside
+# the sandbox even with the registry allowlisted and the proxy exported.
+#
+# Keep this cheap and idempotent — it runs on EVERY bash invocation, including
+# nested ones. Never fail: a non-zero exit here would break every agent command.
+
+if [ -n "${HTTPS_PROXY:-}${ALL_PROXY:-}" ]; then
+  _archie_proxy="${HTTPS_PROXY:-${ALL_PROXY}}"
+  # Respect an explicit override; otherwise inherit the sandbox's proxy.
+  export YARN_HTTPS_PROXY="${YARN_HTTPS_PROXY:-$_archie_proxy}"
+  export YARN_HTTP_PROXY="${YARN_HTTP_PROXY:-${HTTP_PROXY:-$_archie_proxy}}"
+  unset _archie_proxy
+fi
+
+: # always succeed

--- a/src/agents/__tests__/sandbox.test.ts
+++ b/src/agents/__tests__/sandbox.test.ts
@@ -66,6 +66,16 @@ describe('buildPackageManagerCacheEnv', () => {
     expect(env.YARN_CACHE_FOLDER).toBe(`${WORKSPACE}/.cache/yarn`);
   });
 
+  it('redirects yarn 4 global folder and Corepack home, not just the cache', () => {
+    // Yarn Berry creates $HOME/.yarn at startup before touching the project, so a
+    // redirected cache alone leaves it dying on ENOENT (observed with the mobile
+    // repo's pinned yarn 4.12.0). Corepack fetches pinned releases into
+    // COREPACK_HOME, which is unwritable for the same reason.
+    const env = buildPackageManagerCacheEnv(WORKSPACE);
+    expect(env.YARN_GLOBAL_FOLDER).toBe(`${WORKSPACE}/.cache/yarn-global`);
+    expect(env.COREPACK_HOME).toBe(`${WORKSPACE}/.cache/corepack`);
+  });
+
   it('scopes caches per workspace so agents cannot share a cache', () => {
     // A shared cache (e.g. under /tmp) would let one agent stage content another
     // agent later installs from.

--- a/src/agents/__tests__/sandbox.test.ts
+++ b/src/agents/__tests__/sandbox.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Sandbox config + policy-tier tests.
+ *
+ * These pin the SHAPE of what we hand the SDK. They cannot prove the CLI
+ * actually enforces it — that regressed once with the config unchanged (CLI
+ * 2.1.156 → 2.1.157) and no unit test could have caught it. The live boundary
+ * assertion lives in tools/e2e/egress-check.ts; this file guards the wiring
+ * those live checks depend on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildSandboxConfig,
+  buildManagedNetworkPolicy,
+  buildPackageManagerCacheEnv,
+  TRUSTED_PACKAGE_REGISTRY_DOMAINS,
+  type SandboxOptions,
+} from '../sandbox.js';
+
+const base: SandboxOptions = {
+  cwd: '/workdir/sessions/task-1/workspace',
+  allowReadPaths: ['/workdir/sessions/task-1/workspace'],
+  allowWritePaths: ['/workdir/sessions/task-1/workspace'],
+};
+
+describe('buildManagedNetworkPolicy', () => {
+  it('denies all egress when no domains are allowed', () => {
+    expect(buildManagedNetworkPolicy(base).sandbox.network.allowedDomains).toEqual([]);
+  });
+
+  it('carries the allowlist it was given', () => {
+    const policy = buildManagedNetworkPolicy({
+      ...base,
+      allowedNetworkDomains: [...TRUSTED_PACKAGE_REGISTRY_DOMAINS],
+    });
+    expect(policy.sandbox.network.allowedDomains).toEqual([
+      'registry.npmjs.org',
+      'registry.yarnpkg.com',
+    ]);
+  });
+
+  it('always sets allowManagedDomainsOnly — the allowlist is not enforced without it', () => {
+    // Verified empirically: with this flag absent the policy tier has no effect
+    // and Bash reaches any host, even under an explicit allowlist.
+    expect(buildManagedNetworkPolicy(base).sandbox.network.allowManagedDomainsOnly).toBe(true);
+    expect(
+      buildManagedNetworkPolicy({ ...base, allowedNetworkDomains: ['example.invalid'] }).sandbox
+        .network.allowManagedDomainsOnly,
+    ).toBe(true);
+  });
+
+  it('agrees with buildSandboxConfig on the domain list, so the two tiers cannot drift', () => {
+    const opts: SandboxOptions = { ...base, allowedNetworkDomains: ['sheets.googleapis.com'] };
+    expect(buildManagedNetworkPolicy(opts).sandbox.network.allowedDomains).toEqual(
+      buildSandboxConfig(opts).network.allowedDomains,
+    );
+  });
+});
+
+describe('buildPackageManagerCacheEnv', () => {
+  const WORKSPACE = '/workdir/sessions/task-1/workspace';
+
+  it('moves npm and yarn caches off the read-only $HOME', () => {
+    const env = buildPackageManagerCacheEnv(WORKSPACE);
+    expect(env.npm_config_cache).toBe(`${WORKSPACE}/.cache/npm`);
+    expect(env.YARN_CACHE_FOLDER).toBe(`${WORKSPACE}/.cache/yarn`);
+  });
+
+  it('scopes caches per workspace so agents cannot share a cache', () => {
+    // A shared cache (e.g. under /tmp) would let one agent stage content another
+    // agent later installs from.
+    const a = buildPackageManagerCacheEnv('/workdir/sessions/task-a/workspace');
+    const b = buildPackageManagerCacheEnv('/workdir/sessions/task-b/workspace');
+    expect(a.npm_config_cache).not.toBe(b.npm_config_cache);
+    expect(a.YARN_CACHE_FOLDER).not.toBe(b.YARN_CACHE_FOLDER);
+  });
+
+  it('keeps every cache path inside the workspace, which is the writable region', () => {
+    // If a cache escaped the workspace it would land somewhere denied and the
+    // EROFS failure would come straight back.
+    for (const value of Object.values(buildPackageManagerCacheEnv(WORKSPACE))) {
+      expect(value.startsWith(`${WORKSPACE}/`)).toBe(true);
+    }
+  });
+});
+
+describe('buildSandboxConfig', () => {
+  it('fails closed when the sandbox is unavailable instead of running unsandboxed', () => {
+    expect(buildSandboxConfig(base).failIfUnavailable).toBe(true);
+  });
+
+  it('keeps the sandbox enabled and refuses unsandboxed escapes', () => {
+    const cfg = buildSandboxConfig(base);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.allowUnsandboxedCommands).toBe(false);
+  });
+
+  it('defaults to network deny-all', () => {
+    expect(buildSandboxConfig(base).network.allowedDomains).toEqual([]);
+  });
+});

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -4,9 +4,13 @@
  * Builds OS-level sandbox config (Bash tool) and PreToolUse hooks
  * (in-process tools) to enforce filesystem and network boundaries.
  *
- * Two enforcement layers from the same SandboxOptions:
+ * Three enforcement layers from the same SandboxOptions:
  * 1. buildSandboxConfig()         → SDK sandbox (bubblewrap/sandbox-exec for Bash)
- * 2. createFilesystemGuardHooks() → PreToolUse hooks (Read, Write, Edit, Glob, Grep)
+ * 2. buildManagedNetworkPolicy()  → policy tier that actually enforces the egress allowlist
+ * 3. createFilesystemGuardHooks() → PreToolUse hooks (Read, Write, Edit, Glob, Grep)
+ *
+ * Layers 1 and 2 both carry the network allowlist, and BOTH are required — see
+ * buildManagedNetworkPolicy for why the sandbox config alone does not enforce it.
  */
 
 import { resolve, normalize } from 'path';
@@ -67,6 +71,11 @@ export const TRUSTED_PACKAGE_REGISTRY_DOMAINS = [
 export function buildSandboxConfig(opts: SandboxOptions) {
   return {
     enabled: true,
+    // Refuse to run rather than degrade: without this the SDK falls back to
+    // running commands UNSANDBOXED (with only a warning) when bwrap/sandbox-exec
+    // is missing. A silent downgrade of every boundary is not an acceptable
+    // failure mode for a deployment that documents these guarantees.
+    failIfUnavailable: true,
     allowUnsandboxedCommands: false,
     autoAllowBashIfSandboxed: true,
     filesystem: {
@@ -81,6 +90,78 @@ export function buildSandboxConfig(opts: SandboxOptions) {
     network: {
       allowedDomains: opts.allowedNetworkDomains ?? [],
     },
+  };
+}
+
+// ---- Managed policy tier (what actually enforces the egress allowlist) ----
+
+/**
+ * Build the policy-tier settings that enforce the outbound-network allowlist.
+ *
+ * Why this exists as a second layer: `sandbox.network.allowedDomains` passed via
+ * the SDK's `sandbox` option is NOT enforced under `permissionMode:
+ * 'bypassPermissions'` — which every agent runs under (see spawn.ts). From CLI
+ * 2.1.157 onward the domain filter is resolved through permission evaluation,
+ * and bypass mode short-circuits that to allow-all, so the allowlist is ignored
+ * and Bash reaches any host. CLI 2.1.156 and earlier did enforce it; the change
+ * arrived here transitively via a lockfile refresh, silently, which is why
+ * tools/e2e/egress-check.ts asserts the boundary on a live instance.
+ *
+ * The `managedSettings` tier is the SDK's documented channel for an embedding
+ * application to impose lockdown on the spawned CLI, and it is honored
+ * regardless of permission mode. `allowManagedDomainsOnly` is load-bearing:
+ * without it the policy tier has no effect at all (verified empirically). It
+ * also narrows the surface — domain rules from user, project, local, and flag
+ * settings are ignored, so a `.claude/settings.json` inside a task folder or a
+ * repo checkout cannot widen egress. Denied domains are still honored from
+ * every tier.
+ *
+ * IMPORTANT: because `allowManagedDomainsOnly` makes this tier authoritative,
+ * every domain an agent may legitimately reach must appear HERE. Feed it the
+ * same array as buildSandboxConfig (both derive from one SandboxOptions) or
+ * plugin-declared domains will be silently dropped.
+ *
+ * Deployment caveat: if the host has an IT-controlled managed-settings tier
+ * (e.g. /etc/claude-code/managed-settings.json), the SDK DROPS these parent
+ * settings unless that admin opts in with `parentSettingsBehavior: 'merge'` —
+ * and egress would reopen with no error. The live egress check is what catches
+ * that.
+ */
+export function buildManagedNetworkPolicy(opts: SandboxOptions) {
+  return {
+    sandbox: {
+      network: {
+        allowedDomains: opts.allowedNetworkDomains ?? [],
+        allowManagedDomainsOnly: true,
+      },
+    },
+  };
+}
+
+// ---- Package manager caches ----
+
+/**
+ * Environment that lets package managers actually run inside the sandbox.
+ *
+ * npm and yarn default their caches to `$HOME` (`~/.npm`, `~/.cache/yarn`), and
+ * `$HOME` is NOT in allowWrite — so `npm install` dies with
+ * `EROFS: read-only file system, open '/home/archie/.npm/_cacache/tmp/...'`
+ * *while fetching*, before the network allowlist is ever consulted. That EROFS
+ * is what actually blocked `npm install` in edit mode; the failure reads like a
+ * network problem (it names the registry URL) but is purely filesystem.
+ *
+ * Pointed at the agent's own workspace rather than a shared `/tmp`: a shared
+ * cache would let one agent stage content that another agent later installs
+ * from, which is a cross-task integrity problem we get to avoid for free.
+ *
+ * `npm_config_cache` is npm's env form of the `cache` config; yarn 1 reads
+ * `YARN_CACHE_FOLDER`. Neither needs a writable `$HOME` once its cache moves.
+ */
+export function buildPackageManagerCacheEnv(workspace: string): Record<string, string> {
+  const cacheRoot = resolve(workspace, '.cache');
+  return {
+    npm_config_cache: resolve(cacheRoot, 'npm'),
+    YARN_CACHE_FOLDER: resolve(cacheRoot, 'yarn'),
   };
 }
 

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -155,13 +155,24 @@ export function buildManagedNetworkPolicy(opts: SandboxOptions) {
  * from, which is a cross-task integrity problem we get to avoid for free.
  *
  * `npm_config_cache` is npm's env form of the `cache` config; yarn 1 reads
- * `YARN_CACHE_FOLDER`. Neither needs a writable `$HOME` once its cache moves.
+ * `YARN_CACHE_FOLDER`. Yarn 4 (Berry) needs more: it creates its *global folder*
+ * (`$HOME/.yarn`) at startup, before parsing the project, and dies with
+ * `Internal Error: ENOENT: no such file or directory, mkdir '/home/archie/.yarn'`
+ * regardless of where its cache points — so `YARN_GLOBAL_FOLDER` is required too.
+ * Repos that pin `packageManager` also let Corepack fetch the pinned release into
+ * `COREPACK_HOME` (`~/.cache/node/corepack`), which is likewise unwritable.
+ *
+ * Observed live: the mobile repo pins yarn 4.12.0, and `yarn install` failed
+ * instantly on the global-folder ENOENT while yarn 1 in the same sandbox worked
+ * fine — which is why this covers both generations rather than just the cache.
  */
 export function buildPackageManagerCacheEnv(workspace: string): Record<string, string> {
   const cacheRoot = resolve(workspace, '.cache');
   return {
     npm_config_cache: resolve(cacheRoot, 'npm'),
     YARN_CACHE_FOLDER: resolve(cacheRoot, 'yarn'),
+    YARN_GLOBAL_FOLDER: resolve(cacheRoot, 'yarn-global'),
+    COREPACK_HOME: resolve(cacheRoot, 'corepack'),
   };
 }
 

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -624,6 +624,10 @@ Shared folder: ${sharedPath} [READ-ONLY]
       // Redirect npm/yarn caches off the read-only $HOME, or installs fail with
       // EROFS before the network allowlist matters. See buildPackageManagerCacheEnv.
       ...buildPackageManagerCacheEnv(workspace),
+      // Sourced by every non-interactive bash the agent runs; maps the sandbox's
+      // per-session proxy onto tools that ignore the standard *_PROXY vars (Yarn
+      // Berry). Set by the Dockerfiles — forwarded because the SDK replaces env.
+      ...(process.env.BASH_ENV ? { BASH_ENV: process.env.BASH_ENV } : {}),
       // DEBUG: when the context-probe is enabled, route this agent's API traffic
       // through the in-process logging proxy so we can measure its real context
       // breakdown. No-op (key absent) when the probe is disabled or not listening.

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -47,7 +47,7 @@ import { loadPrompt } from '../utils/prompt-loader.js';
 import { processAgentEventForLogging, logger } from '../system/logger.js';
 import { emitEvent } from '../system/event-bus.js';
 import { getProbeBaseUrl } from '../system/context-probe.js';
-import { buildSandboxConfig, createFilesystemGuardHooks, TRUSTED_PACKAGE_REGISTRY_DOMAINS, type SandboxOptions } from './sandbox.js';
+import { buildSandboxConfig, buildManagedNetworkPolicy, buildPackageManagerCacheEnv, createFilesystemGuardHooks, TRUSTED_PACKAGE_REGISTRY_DOMAINS, type SandboxOptions } from './sandbox.js';
 import { applyOAuthBindings } from '../system/oauth/inject.js';
 import { enrichPromptWithMemory, isMemoryEnabled, isInjectionEnabled } from '../memory/index.js';
 
@@ -621,6 +621,9 @@ Shared folder: ${sharedPath} [READ-ONLY]
       PATH: process.env.PATH,
       HOME: process.env.HOME,
       CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+      // Redirect npm/yarn caches off the read-only $HOME, or installs fail with
+      // EROFS before the network allowlist matters. See buildPackageManagerCacheEnv.
+      ...buildPackageManagerCacheEnv(workspace),
       // DEBUG: when the context-probe is enabled, route this agent's API traffic
       // through the in-process logging proxy so we can measure its real context
       // breakdown. No-op (key absent) when the probe is disabled or not listening.
@@ -641,6 +644,10 @@ Shared folder: ${sharedPath} [READ-ONLY]
     permissionMode: 'bypassPermissions' as const,
     allowDangerouslySkipPermissions: true,
     sandbox: buildSandboxConfig(sandboxOpts),
+    // The egress allowlist is enforced from the policy tier, NOT from `sandbox`
+    // above — bypassPermissions makes the CLI ignore sandbox.network.allowedDomains.
+    // Both are fed from the same sandboxOpts so they cannot drift.
+    managedSettings: buildManagedNetworkPolicy(sandboxOpts),
     ...(tools ? { tools } : {}),
     hooks: {
       PreToolUse: createFilesystemGuardHooks(sandboxOpts),

--- a/tools/e2e/egress-check.test.ts
+++ b/tools/e2e/egress-check.test.ts
@@ -13,6 +13,7 @@ const PROBE_PASS = [
   'EGRESS_DENIED_HOST=blocked',
   'EGRESS_ALLOWED_HOST=reachable',
   'EGRESS_PKG_INSTALL=ok',
+  'EGRESS_YARN_PROXY=mapped',
 ].join('\n');
 
 function makeIo() {
@@ -38,6 +39,7 @@ describe('parseProbeOutput', () => {
       deniedHost: 'blocked',
       allowedHost: 'reachable',
       packageInstall: 'ok',
+      yarnProxy: 'mapped',
     });
   });
 
@@ -56,29 +58,37 @@ describe('parseProbeOutput', () => {
 
 describe('decideEgress', () => {
   it('passes only when the filter discriminates in both directions', () => {
-    expect(decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'reachable', packageInstall: 'ok' }).pass).toBe(true);
+    expect(decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'reachable', packageInstall: 'ok', yarnProxy: 'mapped' }).pass).toBe(true);
   });
 
   it('fails when a non-allowlisted host is reachable — the regression this guards', () => {
-    const d = decideEgress({ cliVersion: 'x', deniedHost: 'reachable', allowedHost: 'reachable', packageInstall: 'ok' });
+    const d = decideEgress({ cliVersion: 'x', deniedHost: 'reachable', allowedHost: 'reachable', packageInstall: 'ok', yarnProxy: 'mapped' });
     expect(d.pass).toBe(false);
     expect(d.reasons.join(' ')).toMatch(/NOT on the allowlist was reachable/);
   });
 
   it('fails when all egress is broken instead of filtered', () => {
-    const d = decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'blocked', packageInstall: 'failed' });
+    const d = decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'blocked', packageInstall: 'failed', yarnProxy: 'mapped' });
     expect(d.pass).toBe(false);
     expect(d.reasons.join(' ')).toMatch(/egress is broken rather than filtered/);
   });
 
   it('treats unknown as failure, never as a pass', () => {
-    expect(decideEgress({ cliVersion: 'x', deniedHost: 'unknown', allowedHost: 'unknown', packageInstall: 'unknown' }).pass).toBe(false);
+    expect(decideEgress({ cliVersion: 'x', deniedHost: 'unknown', allowedHost: 'unknown', packageInstall: 'unknown', yarnProxy: 'unset' }).pass).toBe(false);
+  });
+
+  it('fails when Yarn Berry never receives the sandbox proxy', () => {
+    // yarn 2+ ignores HTTPS_PROXY, so an unmapped YARN_HTTPS_PROXY means every
+    // Berry install dies on DNS even though the registry is allowlisted.
+    const d = decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'reachable', packageInstall: 'ok', yarnProxy: 'unset' });
+    expect(d.pass).toBe(false);
+    expect(d.reasons.join(' ')).toMatch(/Yarn Berry/);
   });
 
   it('fails when the boundary holds but npm install is broken', () => {
     // A correct allowlist that no package manager can use is not a pass — this is
     // the EROFS-on-read-only-$HOME failure the cache redirection fixes.
-    const d = decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'reachable', packageInstall: 'failed' });
+    const d = decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'reachable', packageInstall: 'failed', yarnProxy: 'mapped' });
     expect(d.pass).toBe(false);
     expect(d.reasons.join(' ')).toMatch(/npm install` failed inside the sandbox/);
   });
@@ -93,7 +103,7 @@ describe('runEgressCheck', () => {
 
   it('exits 1 and prints the probe output when egress is open', async () => {
     const { io, errors } = makeIo();
-    const open = 'CLI_VERSION=2.1.220\nEGRESS_DENIED_HOST=reachable\nEGRESS_ALLOWED_HOST=reachable\nEGRESS_PKG_INSTALL=ok';
+    const open = 'CLI_VERSION=2.1.220\nEGRESS_DENIED_HOST=reachable\nEGRESS_ALLOWED_HOST=reachable\nEGRESS_PKG_INSTALL=ok\nEGRESS_YARN_PROXY=mapped';
     expect(await runEgressCheck(fakeExec(open), io)).toBe(1);
     expect(errors.join('\n')).toMatch(/EGRESS CHECK FAILED/);
     expect(errors.join('\n')).toMatch(/EGRESS_DENIED_HOST=reachable/);

--- a/tools/e2e/egress-check.test.ts
+++ b/tools/e2e/egress-check.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { parseProbeOutput, decideEgress, runEgressCheck, type ProbeVerdicts } from './egress-check.js';
+import type { ExecFn, ExecResult } from './exec.js';
+
+const ok = (stdout: string): ExecResult => ({ code: 0, stdout, stderr: '' });
+
+const PS_RUNNING = JSON.stringify([
+  { Name: 'archie-hq-archie-1', Service: 'archie', State: 'running' },
+]);
+
+const PROBE_PASS = [
+  'CLI_VERSION=2.1.220',
+  'EGRESS_DENIED_HOST=blocked',
+  'EGRESS_ALLOWED_HOST=reachable',
+  'EGRESS_PKG_INSTALL=ok',
+].join('\n');
+
+function makeIo() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { io: { log: (l: string) => logs.push(l), error: (l: string) => errors.push(l) }, logs, errors };
+}
+
+/** Fake docker: compose ps → running, cp → ok, exec → the given probe output. */
+function fakeExec(probeOutput: string, overrides: Partial<Record<string, ExecResult>> = {}): ExecFn {
+  return async (_cmd, args) => {
+    if (args[0] === 'compose' && args[1] === 'ps') return overrides.ps ?? ok(PS_RUNNING);
+    if (args[0] === 'cp') return overrides.cp ?? ok('');
+    if (args[0] === 'exec') return overrides.exec ?? ok(probeOutput);
+    return ok('');
+  };
+}
+
+describe('parseProbeOutput', () => {
+  it('reads both verdicts and the CLI version', () => {
+    expect(parseProbeOutput(PROBE_PASS)).toEqual<ProbeVerdicts>({
+      cliVersion: '2.1.220',
+      deniedHost: 'blocked',
+      allowedHost: 'reachable',
+      packageInstall: 'ok',
+    });
+  });
+
+  it('reports unknown rather than guessing when a line is missing', () => {
+    const v = parseProbeOutput('CLI_VERSION=2.1.220\nEGRESS_DENIED_HOST=blocked');
+    expect(v.allowedHost).toBe('unknown');
+  });
+
+  it('does not match verdict lines embedded in other text', () => {
+    // The probe echoes the agent transcript after its verdicts; a curl command
+    // quoted there must not be mistaken for a verdict.
+    const v = parseProbeOutput('EGRESS_DENIED_HOST=blocked\n---- agent transcript ----\nEGRESS_ALLOWED_HOST=reachable is what we want');
+    expect(v.allowedHost).toBe('unknown');
+  });
+});
+
+describe('decideEgress', () => {
+  it('passes only when the filter discriminates in both directions', () => {
+    expect(decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'reachable', packageInstall: 'ok' }).pass).toBe(true);
+  });
+
+  it('fails when a non-allowlisted host is reachable — the regression this guards', () => {
+    const d = decideEgress({ cliVersion: 'x', deniedHost: 'reachable', allowedHost: 'reachable', packageInstall: 'ok' });
+    expect(d.pass).toBe(false);
+    expect(d.reasons.join(' ')).toMatch(/NOT on the allowlist was reachable/);
+  });
+
+  it('fails when all egress is broken instead of filtered', () => {
+    const d = decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'blocked', packageInstall: 'failed' });
+    expect(d.pass).toBe(false);
+    expect(d.reasons.join(' ')).toMatch(/egress is broken rather than filtered/);
+  });
+
+  it('treats unknown as failure, never as a pass', () => {
+    expect(decideEgress({ cliVersion: 'x', deniedHost: 'unknown', allowedHost: 'unknown', packageInstall: 'unknown' }).pass).toBe(false);
+  });
+
+  it('fails when the boundary holds but npm install is broken', () => {
+    // A correct allowlist that no package manager can use is not a pass — this is
+    // the EROFS-on-read-only-$HOME failure the cache redirection fixes.
+    const d = decideEgress({ cliVersion: 'x', deniedHost: 'blocked', allowedHost: 'reachable', packageInstall: 'failed' });
+    expect(d.pass).toBe(false);
+    expect(d.reasons.join(' ')).toMatch(/npm install` failed inside the sandbox/);
+  });
+});
+
+describe('runEgressCheck', () => {
+  it('exits 0 and says so when the boundary holds', async () => {
+    const { io, logs } = makeIo();
+    expect(await runEgressCheck(fakeExec(PROBE_PASS), io)).toBe(0);
+    expect(logs.join('\n')).toMatch(/Egress check passed/);
+  });
+
+  it('exits 1 and prints the probe output when egress is open', async () => {
+    const { io, errors } = makeIo();
+    const open = 'CLI_VERSION=2.1.220\nEGRESS_DENIED_HOST=reachable\nEGRESS_ALLOWED_HOST=reachable\nEGRESS_PKG_INSTALL=ok';
+    expect(await runEgressCheck(fakeExec(open), io)).toBe(1);
+    expect(errors.join('\n')).toMatch(/EGRESS CHECK FAILED/);
+    expect(errors.join('\n')).toMatch(/EGRESS_DENIED_HOST=reachable/);
+  });
+
+  it('fails clearly when no instance is running', async () => {
+    const { io, errors } = makeIo();
+    const code = await runEgressCheck(fakeExec(PROBE_PASS, { ps: ok('[]') }), io);
+    expect(code).toBe(1);
+    expect(errors.join('\n')).toMatch(/no running "archie" container/);
+  });
+
+  it('fails when the probe cannot be copied in', async () => {
+    const { io, errors } = makeIo();
+    const cpFail: ExecResult = { code: 1, stdout: '', stderr: 'no such container' };
+    expect(await runEgressCheck(fakeExec(PROBE_PASS, { cp: cpFail }), io)).toBe(1);
+    expect(errors.join('\n')).toMatch(/failed to copy the probe/);
+  });
+
+  it('does not pass a crashed probe just because it printed nothing', async () => {
+    const { io } = makeIo();
+    const crashed: ExecResult = { code: 1, stdout: '', stderr: 'SyntaxError' };
+    expect(await runEgressCheck(fakeExec('', { exec: crashed }), io)).toBe(1);
+  });
+});

--- a/tools/e2e/egress-check.ts
+++ b/tools/e2e/egress-check.ts
@@ -38,6 +38,8 @@ export interface ProbeVerdicts {
   allowedHost: Reachability;
   /** Whether `npm install` actually completes — the allowlist is useless if it doesn't. */
   packageInstall: 'ok' | 'failed' | 'unknown';
+  /** Whether the sandbox proxy reached Yarn Berry's own config keys (BASH_ENV wiring). */
+  yarnProxy: 'mapped' | 'unset';
 }
 
 function readReachability(output: string, key: string): Reachability {
@@ -57,6 +59,7 @@ export function parseProbeOutput(output: string): ProbeVerdicts {
     deniedHost: readReachability(output, 'EGRESS_DENIED_HOST'),
     allowedHost: readReachability(output, 'EGRESS_ALLOWED_HOST'),
     packageInstall: pkg ? (pkg[1] as ProbeVerdicts['packageInstall']) : 'unknown',
+    yarnProxy: /^EGRESS_YARN_PROXY=mapped$/m.test(output) ? 'mapped' : 'unset',
   };
 }
 
@@ -80,6 +83,11 @@ export function decideEgress(v: ProbeVerdicts): EgressDecision {
       v.allowedHost === 'blocked'
         ? 'a host ON the allowlist was blocked — egress is broken rather than filtered (this breaks npm/yarn in edit mode)'
         : 'could not determine whether an allowlisted host was reachable (probe output unreadable)',
+    );
+  }
+  if (v.yarnProxy !== 'mapped') {
+    reasons.push(
+      'the sandbox proxy did not reach Yarn Berry\'s config keys (YARN_HTTPS_PROXY unset) — check BASH_ENV and scripts/sandbox-shell-env.sh; yarn 2+ ignores HTTPS_PROXY and will fail DNS resolution',
     );
   }
   if (v.packageInstall !== 'ok') {
@@ -142,6 +150,7 @@ export async function runEgressCheck(exec: ExecFn, io: EgressCheckIo): Promise<n
   io.log(`  non-allowlisted host: ${verdicts.deniedHost} (expected blocked)`);
   io.log(`  allowlisted host:     ${verdicts.allowedHost} (expected reachable)`);
   io.log(`  npm install:          ${verdicts.packageInstall} (expected ok)`);
+  io.log(`  yarn berry proxy:     ${verdicts.yarnProxy} (expected mapped)`);
 
   if (!decision.pass) {
     io.error('EGRESS CHECK FAILED — the documented network boundary does not hold:');

--- a/tools/e2e/egress-check.ts
+++ b/tools/e2e/egress-check.ts
@@ -1,0 +1,172 @@
+/**
+ * archie-e2e egress check — assert the sandbox network boundary on a live instance.
+ *
+ * Usage: npx tsx tools/e2e/egress-check.ts        (requires a booted instance)
+ *
+ * Why this is a live check and not a unit test: the outbound allowlist is
+ * enforced by the Claude CLI, not by our code. It silently stopped being
+ * enforced between CLI 2.1.156 and 2.1.157 — our config never changed, so no
+ * assertion over config shape could have noticed. Archie picked the change up
+ * transitively in a lockfile refresh (commit 0c1383a, 2026-06-13) and ran with
+ * unrestricted agent egress for six weeks. This check is the tripwire: it drives
+ * a real sandboxed agent and asserts what it can and cannot reach.
+ *
+ * Both directions are asserted. A host off the allowlist must be blocked, and a
+ * host on it must be reachable — otherwise "all egress broken" would pass as
+ * secure and quietly break `npm install` in edit mode.
+ *
+ * Pure core: parseProbeOutput + decideEgress, unit-tested. The CLI main only
+ * does docker plumbing.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { makeExec, type ExecFn } from './exec.js';
+import { parseComposePs } from './teardown.js';
+
+const PROBE_LOCAL = 'tools/e2e/egress-probe.mts';
+const PROBE_REMOTE = '/tmp/egress-probe.mts';
+const SERVICE = 'archie';
+
+// ---- Probe output parsing (pure) ----
+
+export type Reachability = 'blocked' | 'reachable' | 'unknown';
+
+export interface ProbeVerdicts {
+  cliVersion: string;
+  deniedHost: Reachability;
+  allowedHost: Reachability;
+  /** Whether `npm install` actually completes — the allowlist is useless if it doesn't. */
+  packageInstall: 'ok' | 'failed' | 'unknown';
+}
+
+function readReachability(output: string, key: string): Reachability {
+  const m = output.match(new RegExp(`^${key}=(blocked|reachable|unknown)$`, 'm'));
+  return m ? (m[1] as Reachability) : 'unknown';
+}
+
+/**
+ * Extract the probe's verdict lines. A missing or unparseable line yields
+ * 'unknown', which decideEgress treats as a failure — never as a pass.
+ */
+export function parseProbeOutput(output: string): ProbeVerdicts {
+  const version = output.match(/^CLI_VERSION=(.+)$/m);
+  const pkg = output.match(/^EGRESS_PKG_INSTALL=(ok|failed|unknown)$/m);
+  return {
+    cliVersion: version ? version[1].trim() : 'unknown',
+    deniedHost: readReachability(output, 'EGRESS_DENIED_HOST'),
+    allowedHost: readReachability(output, 'EGRESS_ALLOWED_HOST'),
+    packageInstall: pkg ? (pkg[1] as ProbeVerdicts['packageInstall']) : 'unknown',
+  };
+}
+
+export interface EgressDecision {
+  pass: boolean;
+  reasons: string[];
+}
+
+/** The boundary holds only when the filter discriminates in both directions. */
+export function decideEgress(v: ProbeVerdicts): EgressDecision {
+  const reasons: string[] = [];
+  if (v.deniedHost !== 'blocked') {
+    reasons.push(
+      v.deniedHost === 'reachable'
+        ? 'a host that is NOT on the allowlist was reachable from sandboxed Bash — the egress allowlist is not being enforced'
+        : 'could not determine whether a non-allowlisted host was blocked (probe output unreadable)',
+    );
+  }
+  if (v.allowedHost !== 'reachable') {
+    reasons.push(
+      v.allowedHost === 'blocked'
+        ? 'a host ON the allowlist was blocked — egress is broken rather than filtered (this breaks npm/yarn in edit mode)'
+        : 'could not determine whether an allowlisted host was reachable (probe output unreadable)',
+    );
+  }
+  if (v.packageInstall !== 'ok') {
+    reasons.push(
+      v.packageInstall === 'failed'
+        ? '`npm install` failed inside the sandbox — check the package-manager cache redirection (a read-only $HOME makes installs fail with EROFS even when the registry is allowlisted)'
+        : 'could not determine whether `npm install` works inside the sandbox (probe output unreadable)',
+    );
+  }
+  return { pass: reasons.length === 0, reasons };
+}
+
+// ---- Orchestration (core over injected deps) ----
+
+export interface EgressCheckIo {
+  log: (line: string) => void;
+  error: (line: string) => void;
+}
+
+/** Resolve the running container name for the archie service. */
+async function resolveContainer(exec: ExecFn): Promise<{ name: string } | { error: string }> {
+  const ps = await exec('docker', ['compose', 'ps', '--format', 'json']);
+  if (ps.code !== 0) {
+    return { error: `docker compose ps failed with exit code ${ps.code}: ${ps.stderr.trim()}` };
+  }
+  const parsed = parseComposePs(ps.stdout);
+  if (!parsed.ok) return { error: `could not read compose ps output: ${parsed.error}` };
+  const container = parsed.containers.find((c) => c.service === SERVICE);
+  if (!container) {
+    return { error: `no running "${SERVICE}" container — boot an instance first (npx tsx tools/e2e/boot.ts)` };
+  }
+  return { name: container.name };
+}
+
+/** Copy the probe in, run it, assert both directions. Returns the process exit code. */
+export async function runEgressCheck(exec: ExecFn, io: EgressCheckIo): Promise<number> {
+  const container = await resolveContainer(exec);
+  if ('error' in container) {
+    io.error(`Egress check could not start: ${container.error}`);
+    return 1;
+  }
+
+  const cp = await exec('docker', ['cp', PROBE_LOCAL, `${container.name}:${PROBE_REMOTE}`]);
+  if (cp.code !== 0) {
+    io.error(`failed to copy the probe into ${container.name}: ${cp.stderr.trim()}`);
+    return 1;
+  }
+
+  io.log(`Running egress probe in ${container.name} (spawns one throwaway sandboxed agent) ...`);
+  const run = await exec('docker', [
+    'exec', '-u', 'archie', '-w', '/app', container.name,
+    'bash', '-lc', `mkdir -p /tmp/egress-check-ws && npx tsx ${PROBE_REMOTE}`,
+  ]);
+  const output = `${run.stdout}\n${run.stderr}`;
+
+  const verdicts = parseProbeOutput(output);
+  const decision = decideEgress(verdicts);
+
+  io.log(`CLI version in the instance: ${verdicts.cliVersion}`);
+  io.log(`  non-allowlisted host: ${verdicts.deniedHost} (expected blocked)`);
+  io.log(`  allowlisted host:     ${verdicts.allowedHost} (expected reachable)`);
+  io.log(`  npm install:          ${verdicts.packageInstall} (expected ok)`);
+
+  if (!decision.pass) {
+    io.error('EGRESS CHECK FAILED — the documented network boundary does not hold:');
+    for (const r of decision.reasons) io.error(`  - ${r}`);
+    io.error('Probe output follows:');
+    io.error(output.trim());
+    if (run.code !== 0) io.error(`(probe exited ${run.code})`);
+    return 1;
+  }
+
+  io.log('Egress check passed: sandboxed Bash reaches allowlisted hosts only.');
+  return 0;
+}
+
+// ---- CLI main ----
+
+async function main(): Promise<void> {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+  const code = await runEgressCheck(makeExec({ cwd: repoRoot }), {
+    log: (line) => console.log(line),
+    error: (line) => console.error(line),
+  });
+  process.exit(code);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/tools/e2e/egress-probe.mts
+++ b/tools/e2e/egress-probe.mts
@@ -1,0 +1,120 @@
+/**
+ * Live egress boundary probe — runs INSIDE the archie container.
+ *
+ * Copied in and executed by tools/e2e/egress-check.ts; not meant to be run by
+ * hand. It imports the real /app/src/agents/sandbox.ts (src is bind-mounted, so
+ * this exercises the code under test) and spawns one throwaway sandboxed agent
+ * with exactly the options spawn.ts uses, then reports two verdicts on stdout:
+ *
+ *   EGRESS_DENIED_HOST=<blocked|reachable>   a host NOT on the allowlist
+ *   EGRESS_ALLOWED_HOST=<blocked|reachable>  a host ON the allowlist
+ *
+ * Both directions matter. "denied blocked" alone can be achieved by breaking
+ * egress entirely; "allowed reachable" alone is the regression we shipped for
+ * six weeks. The check passes only when the filter discriminates.
+ *
+ * The agent shape is the edit-mode repo agent (the widest egress any agent
+ * gets), so a pass here bounds every other agent.
+ */
+
+import { query } from '/app/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs';
+import {
+  buildSandboxConfig,
+  buildManagedNetworkPolicy,
+  buildPackageManagerCacheEnv,
+  TRUSTED_PACKAGE_REGISTRY_DOMAINS,
+} from '/app/src/agents/sandbox.ts';
+
+/** Not on any allowlist. Chosen because it is stable, unrelated to our stack, and safe to hit. */
+const DENIED_HOST = 'https://example.com';
+/** On the edit-mode allowlist. Reachability proves the filter allows, not just denies. */
+const ALLOWED_HOST = `https://${TRUSTED_PACKAGE_REGISTRY_DOMAINS[0]}/npm`;
+
+const WORKSPACE = '/tmp/egress-check-ws';
+
+const sandboxOpts = {
+  cwd: WORKSPACE,
+  allowReadPaths: [WORKSPACE],
+  allowWritePaths: [WORKSPACE],
+  allowedNetworkDomains: [...TRUSTED_PACKAGE_REGISTRY_DOMAINS],
+};
+
+const prompt = `Run these commands with the Bash tool, one call each, and report their raw output verbatim. Run ALL of them even if an earlier one fails.
+1. curl -sS -m 10 -o /dev/null -w 'DENIED=%{http_code}\\n' ${DENIED_HOST} || echo 'DENIED=blocked'
+2. curl -sS -m 10 -o /dev/null -w 'ALLOWED=%{http_code}\\n' ${ALLOWED_HOST} || echo 'ALLOWED=blocked'
+3. rm -rf ${WORKSPACE}/pkg && mkdir -p ${WORKSPACE}/pkg && cd ${WORKSPACE}/pkg && npm init -y >/dev/null && (npm install left-pad --no-audit --no-fund >/dev/null 2>&1 && test -f node_modules/left-pad/package.json && echo 'PKG=ok' || echo 'PKG=failed')`;
+
+// Mirrors src/agents/spawn.ts buildQueryOptions for everything that bears on the
+// sandbox boundary: permissionMode, sandbox, managedSettings, settingSources.
+const it = query({
+  prompt,
+  options: {
+    model: 'claude-haiku-4-5-20251001',
+    cwd: WORKSPACE,
+    executable: 'node' as const,
+    settingSources: ['project'] as never,
+    env: {
+      NODE_ENV: 'development',
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      SHELL: '/bin/bash',
+      // Same cache redirection spawn.ts applies — without it npm dies on the
+      // read-only $HOME and step 3 fails for a reason unrelated to the network.
+      ...buildPackageManagerCacheEnv(WORKSPACE),
+      ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
+      ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
+    },
+    maxTurns: 8,
+    permissionMode: 'bypassPermissions' as const,
+    allowDangerouslySkipPermissions: true,
+    sandbox: buildSandboxConfig(sandboxOpts),
+    managedSettings: buildManagedNetworkPolicy(sandboxOpts),
+    disallowedTools: ['WebSearch', 'WebFetch'],
+  },
+});
+
+/**
+ * A host counts as reachable only on an explicit 2xx/3xx/4xx/5xx status line —
+ * an HTTP response came back, so the proxy let it through. Anything else (curl
+ * exit non-zero, our `|| echo blocked` fallback, a 000 status) is blocked.
+ * Deliberately conservative in the direction of reporting "reachable": a
+ * misparse must not turn an open boundary into a pass.
+ */
+function classify(transcript: string, label: string): 'blocked' | 'reachable' | 'unknown' {
+  const status = transcript.match(new RegExp(`${label}=(\\d{3})`));
+  if (status && status[1] !== '000') return 'reachable';
+  if (new RegExp(`${label}=(blocked|000)`).test(transcript)) return 'blocked';
+  return 'unknown';
+}
+
+let transcript = '';
+let cliVersion = 'unknown';
+
+for await (const m of it as AsyncIterable<Record<string, any>>) {
+  if (m.type === 'system' && m.subtype === 'init') {
+    cliVersion = String(m.claude_code_version ?? 'unknown');
+  } else if (m.type === 'user' && Array.isArray(m.message?.content)) {
+    for (const b of m.message.content) {
+      if (b.type === 'tool_result') {
+        transcript += (typeof b.content === 'string' ? b.content : JSON.stringify(b.content)) + '\n';
+      }
+    }
+  } else if (m.type === 'result') {
+    transcript += String(m.result ?? '') + '\n';
+  }
+}
+
+/** npm install counts as working only on an explicit PKG=ok from the agent's shell. */
+function packageInstall(t: string): 'ok' | 'failed' | 'unknown' {
+  if (/PKG=ok/.test(t)) return 'ok';
+  if (/PKG=failed/.test(t)) return 'failed';
+  return 'unknown';
+}
+
+console.log(`CLI_VERSION=${cliVersion}`);
+console.log(`EGRESS_DENIED_HOST=${classify(transcript, 'DENIED')}`);
+console.log(`EGRESS_ALLOWED_HOST=${classify(transcript, 'ALLOWED')}`);
+console.log(`EGRESS_PKG_INSTALL=${packageInstall(transcript)}`);
+console.log('---- agent transcript ----');
+console.log(transcript.trim());

--- a/tools/e2e/egress-probe.mts
+++ b/tools/e2e/egress-probe.mts
@@ -42,7 +42,8 @@ const sandboxOpts = {
 const prompt = `Run these commands with the Bash tool, one call each, and report their raw output verbatim. Run ALL of them even if an earlier one fails.
 1. curl -sS -m 10 -o /dev/null -w 'DENIED=%{http_code}\\n' ${DENIED_HOST} || echo 'DENIED=blocked'
 2. curl -sS -m 10 -o /dev/null -w 'ALLOWED=%{http_code}\\n' ${ALLOWED_HOST} || echo 'ALLOWED=blocked'
-3. rm -rf ${WORKSPACE}/pkg && mkdir -p ${WORKSPACE}/pkg && cd ${WORKSPACE}/pkg && npm init -y >/dev/null && (npm install left-pad --no-audit --no-fund >/dev/null 2>&1 && test -f node_modules/left-pad/package.json && echo 'PKG=ok' || echo 'PKG=failed')`;
+3. rm -rf ${WORKSPACE}/pkg && mkdir -p ${WORKSPACE}/pkg && cd ${WORKSPACE}/pkg && npm init -y >/dev/null && (npm install left-pad --no-audit --no-fund >/dev/null 2>&1 && test -f node_modules/left-pad/package.json && echo 'PKG=ok' || echo 'PKG=failed')
+4. test -n "$YARN_HTTPS_PROXY" && echo 'YARNPROXY=mapped' || echo 'YARNPROXY=unset'`;
 
 // Mirrors src/agents/spawn.ts buildQueryOptions for everything that bears on the
 // sandbox boundary: permissionMode, sandbox, managedSettings, settingSources.
@@ -62,6 +63,8 @@ const it = query({
       // Same cache redirection spawn.ts applies — without it npm dies on the
       // read-only $HOME and step 3 fails for a reason unrelated to the network.
       ...buildPackageManagerCacheEnv(WORKSPACE),
+      // Same as spawn.ts: maps the sandbox proxy onto Yarn Berry's own config keys.
+      ...(process.env.BASH_ENV ? { BASH_ENV: process.env.BASH_ENV } : {}),
       ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
       ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
     },
@@ -116,5 +119,6 @@ console.log(`CLI_VERSION=${cliVersion}`);
 console.log(`EGRESS_DENIED_HOST=${classify(transcript, 'DENIED')}`);
 console.log(`EGRESS_ALLOWED_HOST=${classify(transcript, 'ALLOWED')}`);
 console.log(`EGRESS_PKG_INSTALL=${packageInstall(transcript)}`);
+console.log(`EGRESS_YARN_PROXY=${/YARNPROXY=mapped/.test(transcript) ? 'mapped' : 'unset'}`);
 console.log('---- agent transcript ----');
 console.log(transcript.trim());


### PR DESCRIPTION
## Summary

Agent egress has been unrestricted since **2026-06-13**. `sandbox.network.allowedDomains` is not honored under `permissionMode: 'bypassPermissions'`, which every agent runs under, so sandboxed Bash could reach any host while `SECURITY.md` promised deny-all.

Confirmed on a live instance and bisected to an exact boundary: **CLI 2.1.156 blocks, 2.1.157 does not** (published a day apart). From 2.1.157 the domain filter resolves through permission evaluation, and bypass mode short-circuits that to allow-all.

It reached us transitively. Commit `0c1383a` — *"Multi-repo agents: declare and eager-mount multiple repos per agent"* — refreshed `package-lock.json` and floated the SDK 0.3.156 → 0.3.159 across the boundary. Nobody chose to upgrade, and nothing in the diff signalled a security change. The previous pin happened to land on 0.3.156, the last enforcing version, by luck.

Separately, **package installs could never have worked** in edit mode, for three stacked reasons that all look like network failures and none of which are:

1. npm/yarn default their caches to `$HOME`, which is unwritable in the sandbox → `EROFS: ... open '/home/archie/.npm/_cacache/tmp/...'` *while fetching*.
2. Yarn Berry creates its global folder `$HOME/.yarn` at startup, before parsing the project → `ENOENT` regardless of where the cache points.
3. Berry ignores `HTTPS_PROXY` and reads only its own `YARN_*` config keys → DNS failure even with the registry allowlisted.

So the registry allowlist added in `1749c5e` never unblocked anything.

## What changed

- **Egress enforced from the `managedSettings` policy tier**, honored regardless of permission mode. `allowManagedDomainsOnly: true` is load-bearing — without it the tier has no effect. Both tiers are fed from one `SandboxOptions` so they cannot drift.
- **`failIfUnavailable: true`** — was unset, so a host missing `bwrap` would have run every command unsandboxed with only a warning.
- **Package-manager environment redirected** into the agent's own workspace (`npm_config_cache`, `YARN_CACHE_FOLDER`, `YARN_GLOBAL_FOLDER`, `COREPACK_HOME`) — per-agent, not a shared `/tmp`, so one agent cannot stage content another later installs from.
- **A `BASH_ENV` script** (`scripts/sandbox-shell-env.sh`, installed to `/etc/archie`) maps the sandbox's per-session proxy onto Berry's config keys at runtime, since the token is unknowable at spawn time.
- **A live egress check** with four assertions, registered as step 3b in the archie-e2e skill.
- **Docs corrected** and the **SDK pinned exactly**.

## Why a live check, not a unit test

The enforcement lives in the CLI, not in our code. The regression shipped with our configuration byte-identical, so no assertion over config shape could have caught it. The check drives a real sandboxed agent and requires all four of: a non-allowlisted host is blocked, an allowlisted host is reachable, `npm install` completes, and the Berry proxy is mapped. Any subset is a false pass — "denied blocked" is satisfied by breaking egress entirely, and a correct allowlist no package manager can use is not a working sandbox.

It has already earned its keep twice: mutation-testing it (policy tier removed) fails correctly and names the open direction, and on its first real run it caught a `BASH_ENV` path inside `/app` that the sandbox's own `denyRead` made unreadable.

## Verification — full E2E from this branch

Fresh `--build` boot, attested from branch HEAD, driven through the documented harness lifecycle.

| Check | Result |
|---|---|
| Live egress check (CLI 2.1.220) | **pass** — blocked / reachable / npm ok / yarn proxy mapped |
| Mutation test: policy tier removed | fails correctly, exit 1 |
| `basic-nonce` scenario | completed, PM replied with agent roster |
| Edit-mode gate on the mobile repo | `approval:requested` → approved via API → proceeded |
| Real `yarn install` (mobile, yarn 4.12.0) | resolves from lockfile, **fetches 2,526 package zips (~397 MB) from the registry**, then fails *only* on 3 git-hosted deps — see below |
| Full suite + typecheck | 882 pass, clean |

The mobile run is the strongest evidence for both halves of this PR: the toolchain now works at real scale, and the remaining failures are the boundary correctly refusing hosts that are not allowlisted — `github.com:22` returning proxy `Error: Forbidden` and `https://github.com/...` returning `CONNECT tunnel failed, response 403`. No tracked file was modified, and nothing was committed, pushed, or opened as a PR.

## Bisect evidence

| SDK / CLI | Result |
|---|---|
| 0.2.85 (sandbox launch), 0.2.98, 0.3.142, 0.3.150–0.3.154 | blocked |
| **0.3.156** | **blocked — last good** |
| **0.3.157** | **open — first broken** |
| 0.3.159 (what `0c1383a` shipped) … 0.3.220 | open |

## Follow-ups this PR does not address

1. **Git-hosted dependencies are blocked** — `github.com` is not allowlisted, and three of mobile's deps (two private `sweatco/*` over SSH) need it. Allowlisting it is a real security trade, not a formality: `docs/architecture/security.md` relies on network deny-all to block `git push` from agent Bash, so opening `github.com` retires that control and creates an exfiltration path. Worth deciding deliberately; `codeload.github.com` covers npm tarballs without granting push, but bundler and yarn `git:` sources need `github.com` proper.
2. **Backend cannot install dependencies at all.** It is Ruby (`source "https://rubygems.org"`, ruby 3.4.9, bundler 4.0.14) and `ruby`/`gem`/`bundle` are **absent from the image**. Needs the toolchain added plus `rubygems.org` allowlisted — and it pulls three gems from `github.com`, so it hits (1) too.
3. **The check is not wired into CI** — it needs a booted instance, so where it runs is a deliberate decision.
4. **Worth reporting upstream** whether 0.3.157 dropped this deliberately, since that determines how durable the policy-tier approach is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
