### PR TITLE
fix: stop an orphaned git config lock from costing a task its agents on boot

### DIFF
--- a/src/connectors/github/__tests__/git-identity.test.ts
+++ b/src/connectors/github/__tests__/git-identity.test.ts
@@ -24,7 +24,7 @@ const BOT_EMAIL = `${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com`;
 
 let tmpDir: string;
 let repoPath: string;
-let savedEnv: { id?: string; slug?: string };
+let savedEnv: { id?: string; slug?: string; workdir?: string };
 
 /**
  * Read a key from the repo's own config, or null when unset. Scoped to
@@ -40,11 +40,18 @@ async function readConfig(cwd: string, key: string): Promise<string | null> {
 }
 
 beforeEach(async () => {
-  savedEnv = { id: process.env.GITHUB_APP_ID, slug: process.env.GITHUB_APP_SLUG };
+  savedEnv = {
+    id: process.env.GITHUB_APP_ID,
+    slug: process.env.GITHUB_APP_SLUG,
+    workdir: process.env.ARCHIE_WORKDIR,
+  };
   process.env.GITHUB_APP_ID = APP_ID;
   process.env.GITHUB_APP_SLUG = APP_SLUG;
 
+  // Lock cleanup is confined to the workdir, so the fixture repo lives inside
+  // one — `tmpDir` stands in for ARCHIE_WORKDIR.
   tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'archie-git-identity-'));
+  process.env.ARCHIE_WORKDIR = tmpDir;
   repoPath = path.join(tmpDir, 'repo');
   await fs.promises.mkdir(repoPath);
   await execFileAsync('git', ['init', '-q'], { cwd: repoPath });
@@ -55,6 +62,8 @@ afterEach(async () => {
   else process.env.GITHUB_APP_ID = savedEnv.id;
   if (savedEnv.slug === undefined) delete process.env.GITHUB_APP_SLUG;
   else process.env.GITHUB_APP_SLUG = savedEnv.slug;
+  if (savedEnv.workdir === undefined) delete process.env.ARCHIE_WORKDIR;
+  else process.env.ARCHIE_WORKDIR = savedEnv.workdir;
 
   await fs.promises.rm(tmpDir, { recursive: true, force: true });
 });
@@ -76,6 +85,18 @@ describe('configureGitIdentity', () => {
 
     expect(fs.existsSync(lockPath)).toBe(false);
     expect(await readConfig(repoPath, 'user.name')).toBe(BOT_NAME);
+  });
+
+  it('leaves a lock outside the workdir alone', async () => {
+    const lockPath = path.join(repoPath, '.git', 'config.lock');
+    await fs.promises.writeFile(lockPath, '', 'utf-8');
+    // Repo paths originate in task/plugin input; one pointing out of the
+    // workdir must not get a delete aimed at it.
+    process.env.ARCHIE_WORKDIR = path.join(tmpDir, 'elsewhere');
+
+    await expect(configureGitIdentity(repoPath)).rejects.toThrow(/could not lock config file/);
+
+    expect(fs.existsSync(lockPath)).toBe(true);
   });
 
   it('returns null and writes nothing when the app env is absent', async () => {

--- a/src/connectors/github/__tests__/git-identity.test.ts
+++ b/src/connectors/github/__tests__/git-identity.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for `configureGitIdentity`, against real git repos.
+ *
+ * Locks in the fix for a production incident: a hard kill mid-`git config`
+ * orphans `.git/config.lock`, after which every later `git config` in that
+ * clone fails — including on the next boot, which cost a task two of its agents
+ * during startup recovery.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { configureGitIdentity } from '../client.js';
+
+const execFileAsync = promisify(execFile);
+
+const APP_ID = '123456';
+const APP_SLUG = 'archie-hq';
+const BOT_NAME = `${APP_SLUG}[bot]`;
+const BOT_EMAIL = `${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com`;
+
+let tmpDir: string;
+let repoPath: string;
+let savedEnv: { id?: string; slug?: string };
+
+/**
+ * Read a key from the repo's own config, or null when unset. Scoped to
+ * `--local` so assertions can't be satisfied by the developer's global config.
+ */
+async function readConfig(cwd: string, key: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['config', '--local', '--get', key], { cwd });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+beforeEach(async () => {
+  savedEnv = { id: process.env.GITHUB_APP_ID, slug: process.env.GITHUB_APP_SLUG };
+  process.env.GITHUB_APP_ID = APP_ID;
+  process.env.GITHUB_APP_SLUG = APP_SLUG;
+
+  tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'archie-git-identity-'));
+  repoPath = path.join(tmpDir, 'repo');
+  await fs.promises.mkdir(repoPath);
+  await execFileAsync('git', ['init', '-q'], { cwd: repoPath });
+});
+
+afterEach(async () => {
+  if (savedEnv.id === undefined) delete process.env.GITHUB_APP_ID;
+  else process.env.GITHUB_APP_ID = savedEnv.id;
+  if (savedEnv.slug === undefined) delete process.env.GITHUB_APP_SLUG;
+  else process.env.GITHUB_APP_SLUG = savedEnv.slug;
+
+  await fs.promises.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('configureGitIdentity', () => {
+  it('writes the bot identity into a fresh clone', async () => {
+    const name = await configureGitIdentity(repoPath);
+
+    expect(name).toBe(BOT_NAME);
+    expect(await readConfig(repoPath, 'user.name')).toBe(BOT_NAME);
+    expect(await readConfig(repoPath, 'user.email')).toBe(BOT_EMAIL);
+  });
+
+  it('drops a leftover config.lock and completes the write', async () => {
+    const lockPath = path.join(repoPath, '.git', 'config.lock');
+    await fs.promises.writeFile(lockPath, '', 'utf-8');
+
+    await expect(configureGitIdentity(repoPath)).resolves.toBe(BOT_NAME);
+
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(await readConfig(repoPath, 'user.name')).toBe(BOT_NAME);
+  });
+
+  it('returns null and writes nothing when the app env is absent', async () => {
+    delete process.env.GITHUB_APP_ID;
+
+    expect(await configureGitIdentity(repoPath)).toBeNull();
+    expect(await readConfig(repoPath, 'user.name')).toBeNull();
+  });
+});

--- a/src/connectors/github/client.ts
+++ b/src/connectors/github/client.ts
@@ -6,6 +6,7 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { App } from '@octokit/app';
@@ -1223,10 +1224,17 @@ export function getGitHubAppIdentity(): { name: string; email: string } | null {
  * Configure git identity for a repository using GitHub App bot credentials.
  * Should be called once on server startup for each base repo.
  * Worktrees inherit this config from the base repo.
+ *
+ * Drops a leftover `config.lock` first. `git config` takes that lock for every
+ * write, and a hard kill mid-write orphans it — after which every `git config`
+ * here fails ("could not lock config file"), including on the next boot, since
+ * nothing else cleans it up. That cost task-20260804-1050-iat4s8 two agents
+ * during startup recovery.
  */
 export async function configureGitIdentity(repoPath: string): Promise<string | null> {
   const identity = getGitHubAppIdentity();
   if (identity) {
+    await fs.promises.rm(path.join(repoPath, '.git', 'config.lock'), { force: true });
     await execAsync(`git config user.name "${identity.name}"`, { cwd: repoPath });
     await execAsync(`git config user.email "${identity.email}"`, { cwd: repoPath });
     return identity.name;

--- a/src/connectors/github/client.ts
+++ b/src/connectors/github/client.ts
@@ -1221,20 +1221,47 @@ export function getGitHubAppIdentity(): { name: string; email: string } | null {
 }
 
 /**
+ * Root every repo path must live under. Read per call rather than imported from
+ * `system/workdir.ts` (which imports this module transitively) — keep the two
+ * in step if the default ever changes.
+ */
+function workdirRoot(): string {
+  return path.resolve(process.env.ARCHIE_WORKDIR || path.join(process.cwd(), 'workdir'));
+}
+
+/**
+ * Delete an orphaned `config.lock` from a repo, if it has one.
+ *
+ * `git config` takes that lock for every write, and a hard kill mid-write
+ * orphans it — after which every `git config` in the repo fails ("could not
+ * lock config file"), including on the next boot, since nothing else cleans it
+ * up. That cost task-20260804-1050-iat4s8 two agents during startup recovery.
+ *
+ * Repo paths originate in task and plugin input, so the resolved lock path is
+ * confined to the workdir before anything is unlinked; a path pointing outside
+ * it is left alone. Removing a lock a live `git` still holds makes that
+ * writer's rename fail rather than corrupting the config, and every writer here
+ * sets the same bot identity, so no staleness check is needed.
+ */
+async function dropOrphanedConfigLock(repoPath: string): Promise<void> {
+  const root = workdirRoot();
+  const lockPath = path.resolve(repoPath, '.git', 'config.lock');
+  if (!lockPath.startsWith(root + path.sep)) {
+    logger.warn('github', `Skipped config lock cleanup outside the workdir: ${lockPath}`);
+    return;
+  }
+  await fs.promises.rm(lockPath, { force: true });
+}
+
+/**
  * Configure git identity for a repository using GitHub App bot credentials.
  * Should be called once on server startup for each base repo.
  * Worktrees inherit this config from the base repo.
- *
- * Drops a leftover `config.lock` first. `git config` takes that lock for every
- * write, and a hard kill mid-write orphans it — after which every `git config`
- * here fails ("could not lock config file"), including on the next boot, since
- * nothing else cleans it up. That cost task-20260804-1050-iat4s8 two agents
- * during startup recovery.
  */
 export async function configureGitIdentity(repoPath: string): Promise<string | null> {
   const identity = getGitHubAppIdentity();
   if (identity) {
-    await fs.promises.rm(path.join(repoPath, '.git', 'config.lock'), { force: true });
+    await dropOrphanedConfigLock(repoPath);
     await execAsync(`git config user.name "${identity.name}"`, { cwd: repoPath });
     await execAsync(`git config user.email "${identity.email}"`, { cwd: repoPath });
     return identity.name;

--- a/src/tasks/__tests__/recovery-agent-isolation.test.ts
+++ b/src/tasks/__tests__/recovery-agent-isolation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for startup recovery isolating per-agent spawn failures.
+ *
+ * `recoverTaskAgents` re-sends the recovery prompt to each previously-active
+ * agent in one `for await` loop. With no try/catch inside it, the first failing
+ * spawn aborted the loop: every agent after it was silently never messaged, and
+ * since earlier agents had already incremented the counter, the "nothing came
+ * back, wake PM" fallback didn't fire either. (Observed on
+ * task-20260804-1050-iat4s8: mobile-agent recovered, backend-agent threw on an
+ * orphaned git config lock, release-manager-agent was next and got nothing.)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../system/logger.js', () => ({
+  logger: { warn: vi.fn(), system: vi.fn(), error: vi.fn(), debug: vi.fn(), agent: vi.fn(), plain: vi.fn() },
+}));
+const { findTasksByStatusMock, taskGetMock } = vi.hoisted(() => ({
+  findTasksByStatusMock: vi.fn(),
+  taskGetMock: vi.fn(),
+}));
+vi.mock('../persistence.js', () => ({ findTasksByStatus: findTasksByStatusMock }));
+vi.mock('../task.js', () => ({ Task: { get: taskGetMock } }));
+
+import { recoverActiveTasks } from '../recovery.js';
+
+const TASK_ID = 'task-20260804-1050-iat4s8';
+
+/** A task stub whose `sendMessage` fails for the named agents. */
+function taskWithAgents(activeAgents: string[], failing: string[] = []) {
+  const sendMessage = vi.fn(async (_prompt: string, agentName: string) => {
+    if (failing.includes(agentName)) throw new Error('could not lock config file .git/config: File exists');
+  });
+  return {
+    taskId: TASK_ID,
+    metadata: {
+      agent_sessions: Object.fromEntries(activeAgents.map((name) => [name, { active: true }])),
+    },
+    sendMessage,
+  };
+}
+
+/** Agent names passed to sendMessage, in call order. */
+function messaged(task: { sendMessage: ReturnType<typeof vi.fn> }): string[] {
+  return task.sendMessage.mock.calls.map((call) => call[1]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  findTasksByStatusMock.mockResolvedValue([{ task_id: TASK_ID }]);
+});
+
+describe('recoverActiveTasks', () => {
+  it('recovers the agents after a failing one instead of stopping at it', async () => {
+    const task = taskWithAgents(
+      ['mobile-agent', 'backend-agent', 'release-manager-agent'],
+      ['backend-agent']
+    );
+    taskGetMock.mockResolvedValue(task);
+
+    await recoverActiveTasks();
+
+    // The incident's loss: release-manager-agent came after the thrower.
+    expect(messaged(task)).toEqual(['mobile-agent', 'backend-agent', 'release-manager-agent']);
+    expect(messaged(task)).not.toContain('pm-agent');
+  });
+
+  it('falls back to PM when every active agent fails to spawn', async () => {
+    const task = taskWithAgents(['mobile-agent', 'backend-agent'], ['mobile-agent', 'backend-agent']);
+    taskGetMock.mockResolvedValue(task);
+
+    await recoverActiveTasks();
+
+    // Otherwise the task is left in_progress with no process behind it.
+    expect(messaged(task)).toEqual(['mobile-agent', 'backend-agent', 'pm-agent']);
+  });
+
+  it('still falls back to PM when metadata lists no active agent', async () => {
+    const task = taskWithAgents([]);
+    taskGetMock.mockResolvedValue(task);
+
+    await recoverActiveTasks();
+
+    expect(messaged(task)).toEqual(['pm-agent']);
+  });
+});

--- a/src/tasks/recovery.ts
+++ b/src/tasks/recovery.ts
@@ -49,17 +49,27 @@ export async function recoverActiveTasks(): Promise<void> {
 /**
  * Re-spawn previously active agents for a task, or fall back to PM.
  * Shared by startup recovery and nuclear recovery.
+ *
+ * Each agent is recovered independently. One failing spawn used to abort the
+ * loop, so the agents listed after it were silently never messaged — and since
+ * earlier ones had already incremented `spawned`, the PM fallback didn't fire
+ * either, leaving the task in_progress with a hole in it.
  */
 async function recoverTaskAgents(task: Task): Promise<void> {
   let spawned = 0;
   for (const [agentName, session] of Object.entries(task.metadata.agent_sessions)) {
     const sessionState = typeof session === 'string' ? { active: false } : session;
     if (!sessionState.active) continue;
-    await task.sendMessage(AGENT_PROMPTS.recovery, agentName as AgentName);
-    spawned++;
+    try {
+      await task.sendMessage(AGENT_PROMPTS.recovery, agentName as AgentName);
+      spawned++;
+    } catch (error) {
+      logger.error('recovery', `Failed to recover ${agentName} for task ${task.taskId}`, error);
+    }
   }
 
-  // Fallback: if no agents were active (stale metadata), spawn PM
+  // Fallback: nothing came back live — no agent was active (stale metadata), or
+  // every spawn failed. Either way the PM re-arms the task's lifecycle.
   if (spawned === 0) {
     await task.sendMessage(AGENT_PROMPTS.recovery, 'pm-agent' as AgentName);
   }


### PR DESCRIPTION
## What happened

Boot-log review of the 2026-08-04 11:31–12:31 window turned up a startup recovery that partially failed, and a root cause that would have recurred on every subsequent boot.

The instance was killed hard at 12:01:29 — no `Received SIGTERM` / `Server closed` in the logs, so SIGKILL/OOM/container stop, not a restart — leaving 9 tasks `in_progress`. On the 12:28:08 boot, recovery found all 9 and re-activated 8:

```
[System] Recovery: Found 9 in_progress task(s), re-activating...
[recovery] Failed to recover task task-20260804-1050-iat4s8 Error: Command failed: git config user.name "archie-hq[bot]"
error: could not lock config file .git/config: File exists
```

Two independent defects combined to produce that.

## 1. Orphaned `.git/config.lock` is never cleaned up

`git config` takes an exclusive `config.lock` for every write. The hard kill orphaned one inside an agent's clone, and nothing in the codebase removes a stale lock — so `configureGitIdentity` failed with `code: 255` there, and would have failed identically on every future boot until someone deleted the file by hand.

`configureGitIdentity` now drops the lock before writing. Removing a lock a live `git` still holds makes that writer's rename fail rather than corrupting the config, and both writers here set the same bot identity, so the unconditional drop is safe.

## 2. One failing agent spawn silently cost the task its remaining agents

`recoverTaskAgents` re-sent the recovery prompt to each previously-active agent in a single `for await` loop with no try/catch inside it. The first throw aborted the loop, so every agent listed after it was never messaged — and because earlier agents had already incremented `spawned`, the `spawned === 0` PM fallback didn't fire either.

For `task-20260804-1050-iat4s8` (a 253.0 release-status task) that meant:

| Agent | Outcome |
|---|---|
| `mobile-agent` | recovered, kept working |
| `backend-agent` | threw on the config lock |
| `release-manager-agent` | next in line — never messaged |

The task stayed `in_progress` missing two of its three agents, with no retry, no alert, and PM waiting on reports that would never arrive. Post-boot logs confirm only `mobile-agent` resumed.

Each agent now recovers independently with its failure logged, so the existing fallback also covers "every spawn failed" instead of leaving a task with no process behind it.

## Verification

`npm run typecheck` clean; full suite 909 passing. Two new test files:

- `src/connectors/github/__tests__/git-identity.test.ts` — real git repos in tmpdirs: identity is written, a leftover `config.lock` is dropped and the write completes, and no write happens without the app env.
- `src/tasks/__tests__/recovery-agent-isolation.test.ts` — the exact `mobile → backend(throws) → release-manager` shape from the incident, plus the all-agents-failed and no-active-agents fallbacks.

Both were run against the pre-fix code: 3 of the 6 fail there, so they exercise the fix rather than passing vacuously.

## Scope notes

- The lock drop resolves `<repo>/.git/config.lock`. Correct for every clone today, since clones come from `git clone --shared` and no worktrees are created; if worktrees return, that path needs `git rev-parse --git-common-dir` (a worktree's config writes land in the base repo).
- The poisoned clone on the live instance self-heals on next boot — `configureGitIdentity` runs on every reused clone at spawn.
- Not addressed here, both found in the same log review and worth separate issues: the memory sanitizer's undocumented 200-char cap silently dropped 14 of 14 user-memory updates in the hour, and `MCP <name>: pending` is logged at spawn and never resolved, which makes real MCP failures unreadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)