### PR TITLE
fix(slack): inject a canvas shared across channels only once

### DIFF
--- a/src/connectors/slack/__tests__/channel-canvas.test.ts
+++ b/src/connectors/slack/__tests__/channel-canvas.test.ts
@@ -187,6 +187,38 @@ describe('buildChannelCanvasPromptSection — containment', () => {
     expect(section.trimEnd().endsWith('</canvas>\n</channel_project_context>')).toBe(true);
   });
 
+  // A single canvas pinned as a tab in several channels is the intended way to keep
+  // one team-wide brief. Each channel's store adopts it independently, so a task
+  // linked to threads in both would otherwise get the same brief twice.
+  it('injects a canvas shared across channels only once', async () => {
+    const shared = { ...adoptedEntry('F_SHARED'), title: 'Archie — team' };
+    storesByChannel['C1'] = { canvases: [shared], announced: {}, checkedAt: 0 };
+    storesByChannel['C2'] = { canvases: [shared], announced: {}, checkedAt: 0 };
+
+    const section = await buildChannelCanvasPromptSection({
+      channels: {
+        a: { type: 'slack', channel_id: 'C1' },
+        b: { type: 'slack', channel_id: 'C2' },
+      },
+    } as unknown as TaskMetadata);
+
+    expect(section.match(/<canvas /g)).toHaveLength(1);
+  });
+
+  it('still injects distinct canvases from different channels', async () => {
+    storesByChannel['C1'] = { canvases: [{ ...adoptedEntry('F1'), title: 'Archie — one' }], announced: {}, checkedAt: 0 };
+    storesByChannel['C2'] = { canvases: [{ ...adoptedEntry('F2'), title: 'Archie — two' }], announced: {}, checkedAt: 0 };
+
+    const section = await buildChannelCanvasPromptSection({
+      channels: {
+        a: { type: 'slack', channel_id: 'C1' },
+        b: { type: 'slack', channel_id: 'C2' },
+      },
+    } as unknown as TaskMetadata);
+
+    expect(section.match(/<canvas /g)).toHaveLength(2);
+  });
+
   it('keeps the canvas title quoted and escaped in the attribute', async () => {
     const entry = { ...adoptedEntry('F1'), title: 'Archie "quoted" > brief' };
     storesByChannel['C1'] = { canvases: [entry], announced: {}, checkedAt: 0 };

--- a/src/connectors/slack/channel-canvas.ts
+++ b/src/connectors/slack/channel-canvas.ts
@@ -258,11 +258,17 @@ export async function buildChannelCanvasPromptSection(metadata: TaskMetadata): P
   if (channelIds.size === 0) return '';
 
   const blocks: string[] = [];
+  // One canvas can be pinned as a tab in several channels — the intended way to
+  // keep a single team-wide brief — and a task can be linked to threads in more
+  // than one of them. Each channel's store adopts it independently, so dedupe by
+  // file id or the same brief is injected twice.
+  const seen = new Set<string>();
   for (const channelId of channelIds) {
     const store = await loadChannelStore(channelId);
     if (!store) continue;
     for (const c of store.canvases) {
-      if (c.external || !c.markdown) continue;
+      if (c.external || !c.markdown || seen.has(c.file_id)) continue;
+      seen.add(c.file_id);
       // JSON.stringify gives a safely-quoted/escaped attribute value.
       blocks.push(`<canvas title=${JSON.stringify(c.title)}>\n${stripContainerTags(c.markdown)}\n</canvas>`);
     }


### PR DESCRIPTION
## Why

Pinning one canvas as a tab in several channels is the intended way to keep a single team-wide brief — an escalation list maintained in one place rather than copied per channel (see archie-plugins#129, which now recommends exactly this).

Each channel's store adopts that canvas independently, and a task can be linked to threads in more than one channel: `metadata.channels` is keyed `slack:<channelId>:<threadTs>`, and `Task.append()` adds an entry for every thread not already linked. So `buildChannelCanvasPromptSection` appended the same brief once per channel.

Effect was wasted context and a prompt containing the same brief twice — no wrong behaviour. Harmless while two channels sharing a canvas was unusual; now it's the shape teams are being told to use.

## What changed

A `Set` on `file_id` around the block loop. Multiple *threads* in one channel were already fine — `channelIds` is a `Set` — this covers the cross-channel case.

## Tests

Two added: a canvas present in two channels' stores yields one `<canvas>` element; two distinct canvases still yield two. 961 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
