### PR TITLE
fix(docker): ship the core skills directory in the images

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -31,6 +31,11 @@ RUN npm ci
 COPY tsconfig.json tsconfig.scripts.json ./
 COPY src/ ./src/
 COPY prompts/ ./prompts/
+# Core skills the PM loads by name (thread-conduct, triggers, channel-canvas,
+# self-awareness). registry.ts resolves CORE_SKILLS_DIR to /app/skills and sets
+# coreSkillsPath only if it exists — without this COPY it never does, and every
+# `Skill` call for a core skill fails with "Unknown skill".
+COPY skills/ ./skills/
 COPY scripts/ ./scripts/
 
 # Build TypeScript (main app, then the standalone git-askpass token helper)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,10 @@ services:
       # Mount source code for hot reload
       - ./src:/app/src
       - ./prompts:/app/prompts
+      # Core skills the PM loads by name. registry.ts only sets coreSkillsPath if
+      # /app/skills exists, so without this every core-skill `Skill` call fails
+      # with "Unknown skill" (Dockerfile.dev never copies them either).
+      - ./skills:/app/skills
 
       # SSH agent forwarding (macOS Docker Desktop)
       - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock


### PR DESCRIPTION
## The bug

`skills/` reaches neither image:

- `Dockerfile.prod` copies `src/`, `prompts/`, `scripts/` — **not** `skills/`
- `Dockerfile.dev` copies none of them, and `docker-compose.yml` mounts only `./src` and `./prompts`

`registry.ts` resolves `CORE_SKILLS_DIR` to `/app/skills` and sets `coreSkillsPath` only `if (existsSync(...))`. The directory never exists, so the value is always `undefined` and no core skill is ever mounted into an agent's `.claude/skills`. Every `Skill` call for one fails with `Unknown skill: <name>`.

## How long

Since the directory was created. `git log -S CORE_SKILLS_DIR` returns exactly one commit — `c1a082a` (2026-05-26), which added `skills/` **and** the `/app/skills` lookup together — and no image config has mentioned it since.

| skill | added | unloadable in a container since |
|---|---|---|
| `self-awareness` | 2026-05-26 | day one |
| `channel-canvas` | 2026-06-28 | day one |
| `triggers` | 2026-07-10 | day one |
| `thread-conduct` | 2026-08-05 | day one |

Only a bare `npm run dev` from the repo root ever resolved them — presumably how they were written and why nobody noticed.

## Why it matters

`pm-agent.md` tells the PM to load `triggers` before setting up any automation, and `thread-conduct` before posting outside its own thread. Neither has ever been loadable in a deployed instance.

Observed live while testing something unrelated: the PM called `Skill: thread-conduct` **twice** in one turn, got `Unknown skill` both times, and went on to post into another channel without any of that guidance.

## The fix

`COPY skills/ ./skills/` in `Dockerfile.prod`, `- ./skills:/app/skills` in `docker-compose.yml` — mirroring how `prompts/` is already handled in both.

## Verification

Before, in a running dev container: `ls /app/skills` → `No such file or directory`.

After recreating with the mount: `channel-canvas  self-awareness  thread-conduct  triggers`, and the same PM turn that previously errored now logs `Launching skill: thread-conduct` and `Launching skill: channel-canvas` with real content.

Prod is inferred from the Dockerfile, not from inspecting the host — but the omission is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
