### PR TITLE
Human-in-the-loop approval gate for critical MCP tools

### DIFF
--- a/.claude/skills/archie-e2e/SKILL.md
+++ b/.claude/skills/archie-e2e/SKILL.md
@@ -161,6 +161,16 @@ Why it exists: the allowlist is enforced by the Claude CLI, not by our code, and
 
 A failure here is a release blocker, not a flake. If the non-allowlisted host is reachable, agent egress is open.
 
+## 3c. Tool-approval-gate check (run on any branch that touches the gate, spawn hooks, or bumps the SDK)
+
+```bash
+npx tsx tools/e2e/tool-gate-check.ts     # requires a booted instance
+```
+
+Asserts the MCP tool approval gate end to end on the live instance, using the `gatecheck` example plugin (a stub MCP server whose one mutation appends to `workdir/e2e/gate-marker.log`, observable from the host; its policy, including the button title, is the `archie` block on the server in `examples/plugins/.mcp.json`): a gated call must produce a `tool_call` approval request **without executing**, approving via the API must let the agent's retry execute **exactly once**, and the fixture's `allow`-tier tool must pass ungated. Same rationale as the egress check: the interception lives in the Claude CLI (`PreToolUse` under `bypassPermissions`), is version-coupled, and no unit test can notice the CLI silently ceasing to deliver MCP calls to hooks. A failure is a release blocker for anything relying on the gate.
+
+Prerequisite: the booted workdir includes the `gatecheck` example plugin (`npm run example:setup` links `examples/plugins`, which ships it). The check is self-driving over the HTTP API — no MCP session needed — and takes one model round-trip per phase (~2-5 min total).
+
 ## 4. Teardown
 
 ```bash

--- a/docs/architecture/edit-mode.md
+++ b/docs/architecture/edit-mode.md
@@ -2,7 +2,7 @@
 
 Archie operates in two modes: **readonly** (the default) and **edit** (after human approval). This two-mode system implements a human-in-the-loop safety gate that prevents agents from modifying code without explicit user consent.
 
-> A sibling gate, [max mode](max-mode.md), reuses this same request → approve → respawn shape to upgrade the coding agents' model/effort for a task. The two are independent — a task can have either, both, or neither.
+> A sibling gate, [max mode](max-mode.md), reuses this same request → approve → respawn shape to upgrade the coding agents' model/effort for a task. A second sibling, [tool approvals](tool-approvals.md), gates individual MCP tool calls on per-call approval rather than a task-lifetime grant. All are independent.
 
 ## Two-Mode System
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -243,6 +243,7 @@ prompts/                         # Repo-root: layered system prompts
 - [GitHub Integration](github-integration.md) -- webhooks, PR management, merge orchestrator
 - [Edit Mode](edit-mode.md) -- approval flow, shared clones, and git workflow
 - [Max Mode](max-mode.md) -- per-task, human-approved model/effort upgrade for coding agents
+- [Tool Approvals](tool-approvals.md) -- per-call human approval for critical MCP tools
 - [Plugin System](plugin-system.md) -- plugin structure, loading, and agent registration
 - [Web Research](web-research.md) -- multi-agent research pipeline and defense layers
 - [Security](security.md) -- research budget, sandwich defense, prompt injection mitigations

--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -103,6 +103,11 @@ A plugin named `pm` is treated specially. Its `agents/pm.md` file provides:
 
 A single `.mcp.json` file at the plugins directory root (`$ARCHIE_WORKDIR/plugins/.mcp.json`) provides MCP server connection configs. Individual agents reference server names from this file via their frontmatter `mcpServers: [...]` field. Environment variables matching `${MCP_*}` are substituted at load time.
 
+A server entry may carry two Archie extensions, both parsed by `loadMcpJson` and **stripped before the config reaches the SDK** so a plugin authored for Archie stays a valid Claude plugin:
+
+- `description` — one human-readable line, surfaced in the PM's roster of what each teammate can reach.
+- `archie` — the tool approval policy for that server: `{ default, allow, ask, deny }`, each tier a list of bare tool names, plus an optional `titles` map giving the approver-facing button text for tools whose name is a bad button on its own. Because it lives with the server, every agent that mounts the server inherits it (the PM included), and `deny`-tier tools are appended to that agent's `disallowedTools`. A server without this block is unmanaged and behaves exactly as before the gate existed. A malformed block fails the load. See [Tool Approvals](tool-approvals.md).
+
 ## Plugin Loader
 
 The plugin loader (`src/system/plugin-loader.ts`) runs once at startup using synchronous filesystem reads. It scans every subdirectory of `PLUGINS_DIR` and produces a `LoadedPlugin[]` array consumed by downstream modules.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -201,6 +201,12 @@ In edit mode, repo agents manage their own PRs directly via the `repo-tools` MCP
 
 **Source:** `src/agents/spawn.ts`, `src/agents/tools.ts` (`createRequestEditModeTool`)
 
+### MCP Tool Approval Gate
+
+An MCP server can declare, per tool, that calls need per-call human approval — an `archie` block next to its connection config in the plugins repo's `.mcp.json` (see [Tool Approvals](tool-approvals.md)). A `PreToolUse` hook classifies each call against the policy of the servers that agent mounts: `allow` runs ungated, `deny` never runs (and is withheld through `disallowedTools` up front), `ask` is denied while a Slack Approve/Deny prompt — rendered by the engine from the policy's optional per-tool title and the call's sanitized arguments, never from the agent's summary — is posted and the task parks. Approval stores a single-use grant bound to `sha256(server, tool, canonicalized args)`; the agent's retry of that exact call spends it once. A server with no `archie` block is unmanaged and behaves exactly as before the gate existed. Because the policy travels with the server, every agent that mounts it is covered by the same rules, the PM included. Resolution follows the same trust model as the other gates (any workspace member; identity recorded for audit); the `/api` path is unauthenticated, as with every other approval type.
+
+**Source:** `src/agents/tool-approval-gate.ts`, `src/tasks/task.ts`, `src/connectors/slack/events.ts` (`registerToolApprovalHandlers`)
+
 ### PR Review Enforcement
 
 All code changes go through GitHub pull requests. Repo agents create PRs via the `create_pull_request` tool, and merge is gated on external PR review approval. The `merge_pull_request` tool checks that PRs are approved, CI is passing, and there are no conflicts before merging.

--- a/docs/architecture/tool-approvals.md
+++ b/docs/architecture/tool-approvals.md
@@ -1,0 +1,142 @@
+# MCP Tool Approvals
+
+Human-in-the-loop approval for critical MCP tools (issue #168). Today a tool is either allowed for an agent — and then invoked with no human check — or blocked outright. This gate adds the middle ground: a tool can be declared as needing **per-call human approval**, so genuinely useful but sensitive tools (retry a release build, publish an offer, send a campaign) can be enabled instead of withheld.
+
+> A sibling of [edit mode](edit-mode.md) in spirit, but not in shape. Edit mode is a one-way, task-lifetime grant over a *capability class* (repo writes). This gate is per-call, single-use, and bound to the call's arguments. The closest existing relative is the per-PR `merge` gate, and its two key properties — approval bound to a specific target, resolution by any workspace member with identity recorded — are borrowed directly.
+
+## The config
+
+One block per server, in the plugins repo's root `.mcp.json`, next to the connection config it governs:
+
+```json
+"tramline": {
+  "command": "node",
+  "args": ["${MCP_TRAMLINE_SERVER_PATH}"],
+  "description": "Tramline — mobile release management",
+  "archie": {
+    "default": "ask",
+    "allow": ["list_apps", "get_release", "get_release_analytics"],
+    "deny":  ["start_release", "stop_release"],
+    "titles": { "fully_release_rollout": "Release this rollout to 100% of users — irreversible" }
+  }
+}
+```
+
+Three tiers, deliberately the same three words Claude Code uses for permissions:
+
+| Tier | Meaning |
+|---|---|
+| `allow` | runs with no gate |
+| `ask` | a human approves this one call, arguments included |
+| `deny` | never runs — withheld from every agent that mounts the server |
+
+`titles` is optional and covered under [what the approver reads](#what-the-approver-reads).
+
+`default` covers every tool not listed and is `ask` when omitted, so a tool the server ships next quarter arrives gated rather than silently open. Invert `default` to suit the server: for a mostly-dangerous one list the safe reads under `allow`, for a mostly-safe one list the exceptions under `ask`/`deny`.
+
+The tiers name **who decides the call**, never what the tool claims to be. `allow` is typically reads, but a policy may deliberately put a cheap, repeatable mutation there (a retry button); the tier is not named `readonly` because the gate cannot verify read-ness — and in this project read-sounding tools have twice turned out to start builds.
+
+**The policy belongs to the server, not to the agent.** Which tools of Tramline are dangerous is a property of Tramline: every agent that mounts it gets the same policy, with no per-agent copy to keep in sync. Three consequences worth knowing:
+
+- The **PM is covered** like any other agent — its overlay's servers resolve through the same `resolveAgentMcpServers`.
+- `deny` replaces the hand-maintained `disallowedTools` blocks in agent frontmatter. Those blocks were identical across agents sharing a server (mobile's 23 entries were a strict subset of release-manager's 59), which is what one copy per server fixes. Frontmatter `disallowedTools` still works and is merged on top — an agent can still refuse a tool nobody else refuses.
+- Renaming a server key in `.mcp.json` moves its policy with it; there is no second place to update.
+
+Both Archie extensions to a server entry — `description` and `archie` — are parsed and **stripped by the loader**, so the Claude Agent SDK only ever receives valid connection config and a plugin authored for Archie stays a valid Claude plugin. (Verified against Claude Code 2.1.237: unknown keys in a server entry are ignored, while a genuinely invalid entry is reported and skipped.)
+
+### Default behaviour does not change
+
+**A server with no `archie` block is unmanaged: no hook is attached, and every one of its tools behaves exactly as it did before this feature.** Rollout is therefore incremental and opt-in per server — no existing plugin changes meaning, and an agent whose servers are all unmanaged runs on precisely the code path it ran on before. Nothing in the engine defaults to gating: the fail-safe `ask` default applies only *within* a server someone has already opted in.
+
+### What the approver reads
+
+The button's heading is the policy's **title** for the tool when one is written, followed by the call's actual arguments:
+
+```
+Release this rollout to 100% of users immediately — irreversible
+Tool: `tramline:fully_release_rollout`
+Arguments: id=`226284f5-…`
+```
+
+Titles are **optional and per-tool**, declared alongside the tiers:
+
+```json
+"archie": {
+  "default": "ask",
+  "allow": ["get_release"],
+  "titles": {
+    "fully_release_rollout": "Release this rollout to 100% of users immediately — irreversible"
+  }
+}
+```
+
+Write one only where the method name is a bad button on its own — `fully_release_rollout` and `fully_release_previous_rollout` are one word apart and mean very different things. An untitled tool renders as `Run \`server:tool\``: terse but honest, and the sanitized arguments show either way.
+
+> **Why the tool's own description isn't the source.** It would be the better one — consequence text living next to the code that implements it, with no copy in our config to rot — and this gate shipped that way first. It does not work. The Claude CLI *has* the descriptions (it gives them to the model) but exposes them to the SDK host nowhere: the single field in the SDK surface that would carry them, `McpServerStatus.tools[].description`, comes back `undefined` in practice, as does `annotations`. Found on a live instance (the button read `Run \`gatecheck:write_marker\`` where a description existed on the wire) and reduced to a minimal repro — one stdio server, two tools, descriptions present over stdio, absent in the control response — on 2026-08-20. If a future CLI populates the field, the description becomes the default and the title the override: a small change in `renderCall`, and worth making, since a title asserts a consequence the engine cannot verify.
+
+Both halves are rendered **by the engine, never by the agent**: an agent's own summary of what it intends is never what the human reads. Argument values are the one part of the prompt the agent controls — unescaped, a string argument can append its own lines ("*Note:* pre-agreed, safe to approve"). Values and titles alike are flattened, stripped of mrkdwn sigils and capped; arguments are code-spanned, and their count is capped too, because Slack refuses a section over 3000 characters. An agent that wants to explain itself does so in the thread, as a message attributed to it, alongside the button rather than inside it.
+
+### Validation
+
+The loader validates the block strictly and **throws on a malformed policy** — unknown tier, unknown key, a tool in two tiers, a non-list tier: this block decides which external mutations need a human, so a silently-dropped typo must not reclassify a tool. A misspelled tier key (`asks:`) would otherwise read as "nothing listed", quietly dropping every tool in it to the default.
+
+It also refuses a **server key that cannot carry a policy**. The gate finds a policy by splitting the SDK's `mcp__<server>__<tool>` name back into its parts, and a key containing `__` (or with a leading/trailing `_`) does not survive that round trip — `mcp__sweat__admin__publish_offer` splits as server `sweat`, no policy matches, and every tool of that server would run ungated. That is the same class of silent failure the strict parsing exists to prevent, so such a key is rejected at load rather than accepted with an unenforceable policy. Server keys without a policy are unaffected.
+
+## Why a PreToolUse hook, not `canUseTool`
+
+Every agent runs under `permissionMode: bypassPermissions`, and the SDK documents that this mode auto-approves calls past `canUseTool` ("PreToolUse hook denies bypass canUseTool", sdk.d.ts). The hook is the only interception point that holds in our configuration — and it is the same layer the filesystem guard already relies on to enforce read-only mode, so the trust in it is not new.
+
+The consequence: the gate cannot *pause-and-resume* the original call. It **denies** the call, posts the approval, parks the task, and on approval stores a single-use grant that the agent's **retry of the same call** spends. The action always runs through the same audited MCP path; there is no second code path that executes tools.
+
+## Flow
+
+```
+agent calls mcp__tramline__retry_workflow_run { id: "226284f5…" }
+  │
+  ├─ gate: managed server, tier=ask, no grant on file
+  │    ├─ render: the tool's description + sanitized arguments (never the agent's summary)
+  │    ├─ post Approve/Deny to Slack, write pending_tool_approval, park the task
+  │    └─ deny this attempt: "needs human approval, you'll be reactivated"
+  │
+  ├─ a human clicks Approve (any workspace member, as with edit mode / merge)
+  │    ├─ digest verified against the pending slot (mismatch/expired → stale no-op)
+  │    ├─ grant stored in approved_tool_calls (single-use, 30-min TTL)
+  │    └─ the requesting agent is woken
+  │
+  └─ agent retries the same call
+       └─ gate: digest matches → grant consumed (durable) → call proceeds
+```
+
+### The invariants, and why each exists
+
+- **Digest binding.** The grant is keyed on `sha256(server, tool, canonicalized arguments)` — approving one call cannot be spent on a different tool, different arguments, or twice. Canonicalization sorts keys at every depth and drops `undefined`, so argument order can't change identity.
+- **One pending request per task**, no supersede: superseding would let an agent swap the call out from under a human mid-read. The slot ages out after 1h; a click on an older prompt is a stale no-op that mints nothing. Only the agent that raised the request re-arms its park on a retry — a *different* agent reaching the same live slot is told to wait, because both resolution paths clear the requester's teardown alone and arming anyone else would leave a deferred stop nothing cancels.
+- **Anything that fails before the prompt lands clears the slot.** The slot's presence means "a prompt exists in Slack", and both the one-at-a-time refusal and the same-digest re-arm trust that. So the failure path covers the durable flush as well as the post itself: leaving the slot set would block every gated call for an hour and let a retry park the task against a button nobody can see.
+- **The spend is durable, the grant deduped.** The grant is removed from memory synchronously — two calls with the same digest in one turn cannot both find it — and the write is then *awaited* before the call proceeds, because a crash after the tool ran but before the write landed would leave the used token spendable again. A failed write is logged and the call still proceeds: refusing an action a human approved is worse than the replay risk. Losing the *grant* write, by contrast, only costs an extra prompt, so that one stays debounced.
+- **Fail closed.** Any error while evaluating a managed call — including agent-controlled input that overflows the canonicalizer — is a deny, not a throw. Unmanaged tools are classified before the try block and always proceed, even when the gate's own dependencies are broken.
+- **`deny` is enforced twice.** Listed tools are withheld through `disallowedTools`, so the model never sees a tool it cannot use; the gate still refuses the tier at call time, which is what covers a tool that only falls to a `deny` default.
+- **Findings at every step**: requested, approved by *name* / denied, expired unspent, and — as a `completion` finding — actually *spent*, so the audit trail can distinguish an approved call that never ran from one that ran.
+
+## Who may approve
+
+Anyone in the workspace — deliberately the same trust model as the edit-mode and merge gates. Identity is resolved for the audit trail; external/guest clickers resolve with identity omitted, mirroring the other gates. What keeps the button meaningful is what it says and its single-use binding, not who may press it.
+
+Resolution has the same surfaces as every other gate: Slack buttons, and the CLI/API path (`POST /tasks/:id/approve` with `type: 'tool_call'` and `ref` set to the call digest from the approval event). The `/api` router is unauthenticated — the same accepted trade every other approval type makes for dev convenience and e2e drivability; deployments exposing the port must restrict it at the ingress.
+
+## Drift to watch
+
+- **`PreToolUse` firing for MCP tools is version-coupled to the Claude CLI**, exactly like the egress allowlist (see [Security](security.md)) — which silently regressed across a CLI bump once. The live tripwire is `tools/e2e/tool-gate-check.ts` (with the `gatecheck` example plugin as its fixture): it drives a real agent at a real gated MCP tool on a booted instance and asserts interception, deny-blocks-execution, and single-use spend. Run it after any SDK bump and any change to this gate or `spawn.ts`, before trusting the gate with a write-scoped credential.
+- **Descriptions are the approver's only prose.** A server whose tool descriptions understate what a tool does produces a button that understates it too. That is deliberate — one place to fix, next to the code — but it means the descriptions of any `ask`-tier tool are part of the security surface and worth reviewing as such.
+- **A grant is not bound to the agent that requested it.** The digest covers the server, tool and arguments; another agent on the same task making the byte-identical call could spend it. Approving an *action* rather than an actor is the intended reading, but `requested_by` in the audit trail names the requester, not necessarily the executor. (The *pending slot* is requester-bound, so only the requester's retry re-arms the park.)
+- **Per-agent divergence has no expression yet.** If one agent should be allowed something its peers must ask for, that needs an agent-level override layered on the server policy — deliberately not built, because no current agent pair diverges. Until then the coarse tool is a second server entry with its own credential (`tramline` read-only, `tramline-rw` gated), which also gets the credential scoping right.
+
+## Relevant source files
+
+- `src/agents/tool-approval-gate.ts` — tiers, classification, digest, rendering/sanitization, hook factory
+- `src/system/plugin-loader.ts` — `loadMcpJson` / `parseServerPolicy` (strict validation, throws on a malformed policy)
+- `src/agents/registry.ts` — `resolveAgentMcpServers` (policy per mounted server, `deny` → `disallowedTools`)
+- `src/tasks/task.ts` — `requestToolApproval`, `consumeToolApproval`, `handleToolCallApproval` / `…Denial`
+- `src/types/task.ts` — `pending_tool_approval`, `approved_tool_calls`, `ApprovedToolCall`
+- `src/connectors/slack/events.ts` — `registerToolApprovalHandlers`
+- `src/agents/spawn.ts` — hook wiring (only for agents with a managed server) and the tool-description capture
+- Tests: `src/agents/__tests__/tool-approval-gate.test.ts`, `src/agents/__tests__/registry-mcp-policy.test.ts`, `src/tasks/__tests__/tool-approval.test.ts`, `src/system/__tests__/plugin-loader.test.ts`

--- a/examples/plugins/.mcp.json
+++ b/examples/plugins/.mcp.json
@@ -1,3 +1,16 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "gatecheck": {
+      "description": "Gate-check stub — one read tool and one gated mutation, used by the tool-approval-gate e2e check",
+      "command": "node",
+      "args": ["/workdir/plugins/gatecheck/server.mjs"],
+      "archie": {
+        "default": "ask",
+        "allow": ["get_status"],
+        "titles": {
+          "write_marker": "Append a marker line to the shared e2e marker file"
+        }
+      }
+    }
+  }
 }

--- a/examples/plugins/gatecheck/.claude-plugin/plugin.json
+++ b/examples/plugins/gatecheck/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "gatecheck",
+  "version": "1.0.0",
+  "description": "E2E fixture for the MCP tool approval gate — a stub MCP server with one read and one gated mutation, gated by the server's `archie` policy in .mcp.json. Used by tools/e2e/tool-gate-check.ts; harmless to leave installed."
+}

--- a/examples/plugins/gatecheck/agents/gatekeeper.md
+++ b/examples/plugins/gatecheck/agents/gatekeeper.md
@@ -1,0 +1,23 @@
+---
+role: Gate-check fixture agent. Exercises the MCP tool approval gate against the stub gatecheck server on request.
+expertise: Calling the gatecheck stub tools exactly as asked, reporting results verbatim
+mcpServers:
+  - gatecheck
+---
+
+# Gatekeeper Agent — E2E fixture
+
+You exist to exercise the MCP tool approval gate in end-to-end checks. When asked
+to call your tools, call them exactly as instructed and report exactly what they
+returned — no improvisation, no retries beyond what the instructions say.
+
+Two things matter:
+
+1. **`get_status` is ungated** — call it freely whenever asked.
+2. **`write_marker` is gated.** When you call it, the engine may deny it with a
+   message saying human approval was requested and the task is pausing. That is
+   the expected mechanism, not an error: report to the requester that approval
+   was requested, and when you are later reactivated, re-issue the SAME call
+   with the SAME arguments once — the approval is bound to that exact call.
+
+If a call is denied with any other message, report the denial text verbatim and stop.

--- a/examples/plugins/gatecheck/server.mjs
+++ b/examples/plugins/gatecheck/server.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Stub MCP server for the tool-approval-gate e2e check.
+ *
+ * Speaks just enough MCP over stdio (initialize / tools/list / tools/call) to
+ * serve two tools:
+ *
+ *   - get_status            read: reports how many markers have been written
+ *   - write_marker {value}  mutation: appends `value` to the marker file
+ *
+ * The marker file is the check's observable side effect: it lives under the
+ * bind-mounted workdir, so the host-side check script can assert that the
+ * mutation did NOT run before approval and ran EXACTLY ONCE after it.
+ * No dependencies on purpose — this runs wherever `node` runs.
+ */
+
+import { appendFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const MARKER_FILE = process.env.GATECHECK_MARKER_FILE || '/workdir/e2e/gate-marker.log';
+
+function markerLines() {
+  try {
+    return readFileSync(MARKER_FILE, 'utf8').split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+const TOOLS = [
+  {
+    name: 'get_status',
+    description: 'Read how many markers have been written so far. Safe read; changes nothing.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'write_marker',
+    description: 'Write a marker value to the shared marker file. This is a mutation.',
+    inputSchema: {
+      type: 'object',
+      properties: { value: { type: 'string', description: 'Marker value to record' } },
+      required: ['value'],
+      additionalProperties: false,
+    },
+  },
+];
+
+function handle(msg) {
+  const { id, method, params } = msg;
+  if (method === 'initialize') {
+    return {
+      id,
+      result: {
+        protocolVersion: params?.protocolVersion || '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'gatecheck', version: '1.0.0' },
+      },
+    };
+  }
+  if (method === 'tools/list') return { id, result: { tools: TOOLS } };
+  if (method === 'tools/call') {
+    const { name, arguments: args } = params ?? {};
+    if (name === 'get_status') {
+      return { id, result: { content: [{ type: 'text', text: `status ok; markers written: ${markerLines().length}` }] } };
+    }
+    if (name === 'write_marker') {
+      const value = String(args?.value ?? '');
+      mkdirSync(dirname(MARKER_FILE), { recursive: true });
+      appendFileSync(MARKER_FILE, `${value}\n`);
+      return { id, result: { content: [{ type: 'text', text: `marker written: ${value}` }] } };
+    }
+    return { id, error: { code: -32601, message: `unknown tool: ${name}` } };
+  }
+  if (id === undefined) return undefined; // notification — no response
+  return { id, error: { code: -32601, message: `unknown method: ${method}` } };
+}
+
+let buffer = '';
+process.stdin.on('data', (chunk) => {
+  buffer += chunk.toString();
+  let newline;
+  while ((newline = buffer.indexOf('\n')) >= 0) {
+    const line = buffer.slice(0, newline).trim();
+    buffer = buffer.slice(newline + 1);
+    if (!line) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const response = handle(msg);
+    if (response !== undefined) {
+      process.stdout.write(`${JSON.stringify({ jsonrpc: '2.0', ...response })}\n`);
+    }
+  }
+});
+console.error(`gatecheck: stub MCP server on stdio, marker file ${MARKER_FILE}`);

--- a/src/agents/__tests__/registry-mcp-policy.test.ts
+++ b/src/agents/__tests__/registry-mcp-policy.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Registry — MCP tool policy resolution.
+ *
+ * The policy travels with the *server* (its `archie` block in the plugins
+ * repo's .mcp.json), not with the agent, so:
+ *   - every agent that mounts the server gets the same policy, with no copy to
+ *     keep in sync per agent;
+ *   - the PM is covered by construction, since its overlay resolves servers
+ *     through the same function;
+ *   - `deny`-tier tools are withheld up front via disallowedTools, so the tool
+ *     is never offered to the model in the first place.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LoadedPlugin, LoadedMcpConfig, PluginAgentDef } from '../../system/plugin-loader.js';
+
+vi.mock('../../system/plugin-loader.js', () => ({
+  getPlugins: vi.fn(),
+  getRootMcpConfig: vi.fn(),
+  getPmOverlay: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../system/logger.js', () => ({
+  logger: { warn: vi.fn(), system: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+import { getPlugins, getRootMcpConfig, getPmOverlay } from '../../system/plugin-loader.js';
+import { scanAgentDefs } from '../registry.js';
+
+const ROOT_MCP: LoadedMcpConfig = {
+  servers: {
+    tramline: { command: 'node', args: ['tramline.js'] },
+    clickhouse: { command: 'uvx', args: ['mcp-clickhouse'] },
+    'sweatco-admin': { type: 'http', url: 'https://admin.example/mcp' },
+  },
+  descriptions: { tramline: 'Tramline — mobile releases' },
+  policies: {
+    tramline: {
+      default: 'ask',
+      tiers: { get_release: 'allow', start_release: 'deny', stop_release: 'deny' },
+      titles: { stop_release: 'Stop this release' },
+    },
+    'sweatco-admin': { default: 'allow', tiers: { publish_offer: 'ask' }, titles: {} },
+  },
+};
+
+function agent(key: string, extra: Partial<PluginAgentDef> = {}): PluginAgentDef {
+  return { key, role: `${key} role`, expertise: 'e', prompt: 'p', ...extra };
+}
+
+function plugin(name: string, agents: PluginAgentDef[]): LoadedPlugin {
+  return {
+    name,
+    dir: `/plugins/${name}`,
+    manifest: { name, version: '1.0.0', description: 'test' },
+    repoConfigs: null,
+    agents,
+    skillsPath: null,
+    hooks: null,
+  };
+}
+
+describe('scanAgentDefs — MCP tool policy', () => {
+  beforeEach(() => {
+    vi.mocked(getRootMcpConfig).mockReturnValue(ROOT_MCP);
+    vi.mocked(getPmOverlay).mockReturnValue(null);
+  });
+
+  it('attaches a server policy to every agent that mounts it', () => {
+    vi.mocked(getPlugins).mockReturnValue([
+      plugin('engineering', [agent('release-manager', { mcpServers: ['tramline', 'clickhouse'] })]),
+      plugin('mobile', [agent('mobile', { mcpServers: ['tramline'] })]),
+    ]);
+
+    const defs = scanAgentDefs();
+    for (const id of ['release-manager-agent', 'mobile-agent']) {
+      const def = defs.find((d) => d.id === id)!;
+      expect(def.mcpPolicy!.tramline.default).toBe('ask');
+      expect(def.mcpPolicy!.tramline.tiers.get_release).toBe('allow');
+    }
+  });
+
+  it('leaves mcpPolicy undefined when none of the agent\'s servers declare one', () => {
+    vi.mocked(getPlugins).mockReturnValue([
+      plugin('data', [agent('data-analyst', { mcpServers: ['clickhouse'] })]),
+    ]);
+
+    // Unmanaged: spawn attaches no gate hook at all, so behaviour is unchanged.
+    expect(scanAgentDefs().find((d) => d.id === 'data-analyst-agent')!.mcpPolicy).toBeUndefined();
+  });
+
+  it('does not leak the policy of a server the agent has not mounted', () => {
+    vi.mocked(getPlugins).mockReturnValue([
+      plugin('data', [agent('data-analyst', { mcpServers: ['clickhouse', 'tramline'] })]),
+    ]);
+
+    const policy = scanAgentDefs().find((d) => d.id === 'data-analyst-agent')!.mcpPolicy!;
+    expect(Object.keys(policy)).toEqual(['tramline']);
+  });
+
+  it('withholds deny-tier tools through disallowedTools, deduped with frontmatter', () => {
+    vi.mocked(getPlugins).mockReturnValue([
+      plugin('engineering', [agent('release-manager', {
+        mcpServers: ['tramline'],
+        // A plugin mid-migration may still list one of them by hand.
+        disallowedTools: ['WebSearch', 'mcp__tramline__start_release'],
+      })]),
+    ]);
+
+    const def = scanAgentDefs().find((d) => d.id === 'release-manager-agent')!;
+    expect(def.disallowedTools).toEqual([
+      'WebSearch',
+      'mcp__tramline__start_release',
+      'mcp__tramline__stop_release',
+    ]);
+  });
+
+  it('covers the PM through its overlay servers', () => {
+    vi.mocked(getPlugins).mockReturnValue([plugin('pm', [])]);
+    vi.mocked(getPmOverlay).mockReturnValue(agent('pm', { mcpServers: ['sweatco-admin'] }));
+
+    const pm = scanAgentDefs().find((d) => d.id === 'pm-agent')!;
+    expect(pm.mcpPolicy!['sweatco-admin'].tiers.publish_offer).toBe('ask');
+  });
+});

--- a/src/agents/__tests__/tool-approval-gate.test.ts
+++ b/src/agents/__tests__/tool-approval-gate.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseMcpToolName,
+  deniedToolNames,
+  classifyToolCall,
+  callDigest,
+  renderCall,
+  createToolApprovalHooks,
+  type McpToolPolicy,
+  type McpServerPolicy,
+  type ToolApprovalPort,
+} from '../tool-approval-gate.js';
+
+/**
+ * A realistic policy — the shape the Tramline server declares in the plugins
+ * repo's .mcp.json: reads run ungated, release-lifecycle mutations are disabled
+ * outright, everything else needs a human.
+ */
+const TRAMLINE: McpServerPolicy = {
+  default: 'ask',
+  tiers: {
+    list_apps: 'allow',
+    get_release: 'allow',
+    get_release_analytics: 'allow',
+    start_release: 'deny',
+  },
+  // Titles only where the method name is a bad button on its own.
+  titles: {
+    retry_workflow_run: 'Re-run the failed CI build for this release',
+    fully_release_rollout: 'Release this rollout to 100% of users immediately — irreversible',
+  },
+};
+
+const POLICY: McpToolPolicy = { tramline: TRAMLINE };
+
+const tool = (action: string) => `mcp__tramline__${action}`;
+
+async function runGate(port: Partial<ToolApprovalPort>, tool_name: string, tool_input: unknown, policy = POLICY) {
+  const fullPort: ToolApprovalPort = {
+    consumeApproval: () => false,
+    requestApproval: async () => 'posted',
+    ...port,
+  };
+  const [matcher] = createToolApprovalHooks(policy, fullPort);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (await matcher.hooks[0]({ tool_name, tool_input } as any, undefined as any, {} as any)) as any;
+}
+
+const denialReason = (r: { hookSpecificOutput?: { permissionDecisionReason?: string } }) =>
+  r.hookSpecificOutput?.permissionDecisionReason ?? '';
+const isDeny = (r: { hookSpecificOutput?: { permissionDecision?: string } }) =>
+  r.hookSpecificOutput?.permissionDecision === 'deny';
+
+describe('parseMcpToolName', () => {
+  it('splits server and tool', () => {
+    expect(parseMcpToolName('mcp__tramline__retry_workflow_run'))
+      .toEqual({ server: 'tramline', tool: 'retry_workflow_run' });
+  });
+
+  it('handles dashed and underscored server keys', () => {
+    expect(parseMcpToolName('mcp__atlassian-rovo-mcp__getJiraIssue'))
+      .toEqual({ server: 'atlassian-rovo-mcp', tool: 'getJiraIssue' });
+    expect(parseMcpToolName('mcp__aws_billing__get_cost'))
+      .toEqual({ server: 'aws_billing', tool: 'get_cost' });
+  });
+
+  it('rejects non-MCP tools', () => {
+    expect(parseMcpToolName('Read')).toBeUndefined();
+    expect(parseMcpToolName('mcp__no_tool_part')).toBeUndefined();
+  });
+});
+
+// A deny-tier tool is withheld from the agent up front, so it never plans
+// around a tool it cannot use. The gate is the backstop, not the only stop.
+describe('deniedToolNames', () => {
+  it('lists every deny-tier tool as its qualified SDK name', () => {
+    expect(deniedToolNames(POLICY)).toEqual(['mcp__tramline__start_release']);
+  });
+
+
+  it('does not withhold tools that only fall to a deny default', () => {
+    // Their names aren't knowable at load time — the gate refuses them at call time.
+    expect(deniedToolNames({ x: { default: 'deny', tiers: {}, titles: {} } })).toEqual([]);
+  });
+});
+
+describe('classifyToolCall', () => {
+  it('leaves non-MCP tools and unmanaged servers alone', () => {
+    expect(classifyToolCall(POLICY, 'Read')).toBeUndefined();
+    expect(classifyToolCall(POLICY, 'mcp__teamcity__trigger_build')).toBeUndefined();
+    expect(classifyToolCall(undefined, tool('get_release'))).toBeUndefined();
+  });
+
+  it('classifies listed tools by their tier', () => {
+    expect(classifyToolCall(POLICY, tool('get_release'))?.tier).toBe('allow');
+    expect(classifyToolCall(POLICY, tool('start_release'))?.tier).toBe('deny');
+    expect(classifyToolCall(POLICY, tool('retry_workflow_run'))?.tier).toBe('ask');
+  });
+
+  // A tool the server ships next quarter arrives gated, not silently open.
+  it('falls back to the server default for unlisted tools', () => {
+    expect(classifyToolCall(POLICY, tool('some_tool_shipped_next_quarter'))?.tier).toBe('ask');
+  });
+});
+
+describe('callDigest', () => {
+  it('is stable across argument order', () => {
+    expect(callDigest('s', 't', { a: 1, b: 2 })).toBe(callDigest('s', 't', { b: 2, a: 1 }));
+  });
+
+  it('binds to server, tool, and every argument', () => {
+    const base = callDigest('s', 't', { a: 1 });
+    expect(callDigest('other', 't', { a: 1 })).not.toBe(base);
+    expect(callDigest('s', 'other', { a: 1 })).not.toBe(base);
+    expect(callDigest('s', 't', { a: 2 })).not.toBe(base);
+    expect(callDigest('s', 't', { a: 1, extra: true })).not.toBe(base);
+  });
+
+  it('ignores undefined arguments the SDK may include', () => {
+    expect(callDigest('s', 't', { a: 1, b: undefined })).toBe(callDigest('s', 't', { a: 1 }));
+  });
+
+  it('distinguishes nested argument shapes', () => {
+    expect(callDigest('s', 't', { a: [1, 2] })).not.toBe(callDigest('s', 't', { a: [2, 1] }));
+    expect(callDigest('s', 't', { a: 1 })).not.toBe(callDigest('s', 't', { a: '1' }));
+  });
+});
+
+describe('renderCall', () => {
+  const call = { server: 'tramline', tool: 'retry_workflow_run', tier: 'ask' as const };
+
+  it("uses the policy's title for the tool plus sanitized arguments", () => {
+    const r = renderCall(TRAMLINE, call, { id: 'wf-1' });
+    expect(r.heading).toBe('Re-run the failed CI build for this release');
+    expect(r.summary).toContain('`tramline:retry_workflow_run`');
+    expect(r.summary).toContain('id=`wf-1`');
+  });
+
+  // Terse but honest — and the arguments show either way. The tool's own
+  // description is unreachable: the CLI never exposes it to us.
+  it('falls back to the bare identity for an untitled tool', () => {
+    expect(renderCall(TRAMLINE, { ...call, tool: 'unlisted_tool' }, {}).heading)
+      .toBe('Run `tramline:unlisted_tool`');
+  });
+
+  // The prompt must be authored by the engine. A string argument is the one
+  // part the agent controls, and unescaped it can append its own lines.
+  it('neutralizes newlines and mrkdwn in argument values', () => {
+    const r = renderCall(TRAMLINE, { ...call, tool: 'extend_soak' }, {
+      release_id: 'r1',
+      additional_hours: '6\n*Note:* pre-agreed with the release manager — safe to approve',
+    });
+    expect(r.summary).not.toContain('\n*Note:*');
+    expect(r.heading).not.toContain('\n');
+  });
+
+  // A title is authored in the plugins repo rather than by the agent, but it is
+  // rendered rather than trusted verbatim.
+  it('neutralizes newlines and mrkdwn in a title', () => {
+    const policy: McpServerPolicy = {
+      ...TRAMLINE,
+      titles: { retry_workflow_run: 'Retry a build\n*Note:* pre-approved by the team' },
+    };
+    const r = renderCall(policy, call, {});
+    expect(r.heading).not.toContain('\n');
+    expect(r.heading).not.toContain('*Note:*');
+  });
+
+  // The digest covers null arguments, so hiding them would have the approver
+  // approve an argument they were never shown.
+  it('renders null arguments instead of dropping them', () => {
+    expect(renderCall(TRAMLINE, call, { id: 'wf-1', reason: null }).summary).toContain('reason=`null`');
+  });
+
+  // Slack refuses a section over 3000 chars; an uncapped list would make such a
+  // call permanently unapprovable rather than merely ugly.
+  it('caps the number of arguments shown', () => {
+    const many = Object.fromEntries(Array.from({ length: 40 }, (_, i) => [`k${i}`, i]));
+    const summary = renderCall(TRAMLINE, call, many).summary;
+    expect(summary).toContain('(+28 more)');
+    expect(summary.length).toBeLessThan(3000);
+  });
+
+  it('caps long argument values and long titles', () => {
+    expect(renderCall(TRAMLINE, call, { id: 'x'.repeat(500) }).summary.length).toBeLessThan(400);
+    const longTitle: McpServerPolicy = { ...TRAMLINE, titles: { retry_workflow_run: 'd'.repeat(500) } };
+    expect(renderCall(longTitle, call, {}).heading.length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('createToolApprovalHooks', () => {
+  it('lets unmanaged tools and allow-tier tools straight through', async () => {
+    const requestApproval = vi.fn(async () => 'posted' as const);
+    for (const name of ['Read', 'mcp__teamcity__list_builds', tool('get_release'), tool('list_apps')]) {
+      expect(await runGate({ requestApproval }, name, {})).toEqual({ continue: true });
+    }
+    expect(requestApproval).not.toHaveBeenCalled();
+  });
+
+  // Belt to the disallowedTools braces: a deny-tier call that somehow reaches
+  // the gate is refused without bothering a human.
+  it('refuses a deny-tier call without posting an approval', async () => {
+    const requestApproval = vi.fn(async () => 'posted' as const);
+    const result = await runGate({ requestApproval }, tool('start_release'), {});
+    expect(isDeny(result)).toBe(true);
+    expect(denialReason(result)).toContain('disabled by the `tramline` tool policy');
+    expect(requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unlisted call under a deny default', async () => {
+    const policy: McpToolPolicy = { locked: { default: 'deny', tiers: {}, titles: {} } };
+    const result = await runGate({}, 'mcp__locked__anything', {}, policy);
+    expect(isDeny(result)).toBe(true);
+    expect(denialReason(result)).toContain('cannot be run by any agent');
+  });
+
+  it('requests approval for an ask-tier call and denies this attempt', async () => {
+    const requestApproval = vi.fn(
+      async (_r: { digest: string; server: string; tool: string; summary: string; heading: string }) =>
+        'posted' as const,
+    );
+    const result = await runGate({ requestApproval }, tool('retry_workflow_run'), { id: 'wf-1' });
+
+    expect(isDeny(result)).toBe(true);
+    expect(denialReason(result)).toContain('needs human approval');
+    expect(requestApproval).toHaveBeenCalledTimes(1);
+    const request = requestApproval.mock.calls[0][0];
+    expect(request.digest).toBe(callDigest('tramline', 'retry_workflow_run', { id: 'wf-1' }));
+    expect(request.heading).toBe('Re-run the failed CI build for this release');
+  });
+
+
+  it('raises a prompt for an untitled tool using its bare identity', async () => {
+    const requestApproval = vi.fn(async (r: { heading: string }) => { void r; return 'posted' as const; });
+    await runGate({ requestApproval }, tool('some_untitled_tool'), { id: 'x' });
+    expect(requestApproval.mock.calls[0][0].heading).toBe('Run `tramline:some_untitled_tool`');
+  });
+
+  it('proceeds exactly once a grant for that call is spendable', async () => {
+    const consumeApproval = vi.fn(() => true);
+    const requestApproval = vi.fn(async () => 'posted' as const);
+    const result = await runGate({ consumeApproval, requestApproval }, tool('retry_workflow_run'), { id: 'wf-1' });
+
+    expect(result).toEqual({ continue: true });
+    expect(consumeApproval).toHaveBeenCalledWith(callDigest('tramline', 'retry_workflow_run', { id: 'wf-1' }));
+    expect(requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('refuses a second gated call while one is pending', async () => {
+    const result = await runGate({ requestApproval: async () => 'already-pending' }, tool('retry_workflow_run'), {});
+    expect(isDeny(result)).toBe(true);
+    expect(denialReason(result)).toContain('already waiting for approval');
+  });
+
+  // Server and tool names reach the gate as model-supplied strings, so a
+  // prototype hit must not be mistaken for a policy.
+  it('does not treat inherited properties as policy', async () => {
+    const requestApproval = vi.fn(async () => 'posted' as const);
+    expect(await runGate({ requestApproval }, 'mcp__constructor__x', {})).toEqual({ continue: true });
+    expect(await runGate({ requestApproval }, tool('constructor'), {})).not.toEqual({ continue: true });
+    expect(requestApproval).toHaveBeenCalledTimes(1); // the tramline one is gated, not crashed
+  });
+
+  it('waits for the spend to be durable before letting the call through', async () => {
+    const order: string[] = [];
+    const consumeApproval = vi.fn(() => {
+      order.push('spend');
+      return Promise.resolve(true).then((v) => { order.push('flushed'); return v; });
+    });
+    const result = await runGate({ consumeApproval }, tool('retry_workflow_run'), { id: 'wf-1' });
+    expect(result).toEqual({ continue: true });
+    expect(order).toEqual(['spend', 'flushed']);
+  });
+
+  describe('fails closed', () => {
+    it('denies instead of throwing when an argument overflows the canonicalizer', async () => {
+      let deep: unknown = 'leaf';
+      for (let i = 0; i < 60_000; i++) deep = [deep];
+      const result = await runGate({}, tool('retry_workflow_run'), { id: 'wf-1', junk: deep });
+      expect(isDeny(result)).toBe(true);
+      expect(denialReason(result)).toContain('errored while evaluating');
+    });
+
+    it('denies when the port throws', async () => {
+      const result = await runGate(
+        { requestApproval: async () => { throw new Error('slack down'); } },
+        tool('retry_workflow_run'),
+        { id: 'wf-1' },
+      );
+      expect(isDeny(result)).toBe(true);
+      expect(denialReason(result)).toContain('slack down');
+    });
+
+    it('still lets unmanaged tools through when the port is broken', async () => {
+      const broken = { consumeApproval: () => { throw new Error('boom'); } };
+      expect(await runGate(broken, 'Read', { file_path: '/x' })).toEqual({ continue: true });
+      expect(await runGate(broken, tool('get_release'), {})).toEqual({ continue: true });
+    });
+  });
+});

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -15,6 +15,7 @@ import { PLUGINS_DATA_DIR } from '../system/workdir.js';
 import { join } from 'path';
 import { logger } from '../system/logger.js';
 import { resolveSkillPaths } from './core-skills.js';
+import { deniedToolNames, type McpToolPolicy } from './tool-approval-gate.js';
 
 // ---- Module state ----
 
@@ -306,25 +307,33 @@ function checkCollision(agentId: string, pluginName: string, seen: Map<string, s
 /**
  * Resolve agent's mcpServers references against the root .mcp.json.
  *
- * Tool permission rules (all from agent frontmatter):
+ * Tool permission rules:
  * - No `tools` defined → wildcard for every MCP server (`mcp__<name>__*`)
  * - `tools` defined → use exactly what's listed (user adds wildcards explicitly if needed)
- * - `disallowedTools` → always applied on top
+ * - `disallowedTools` → always applied on top, and the servers' own `deny`-tier
+ *   tools are appended to it, so a tool disabled once in .mcp.json is withheld
+ *   from every agent that mounts the server rather than re-listed per agent
+ *
+ * The tool approval policy travels with the server, not the agent: whichever
+ * agents mount `tramline` all get its `archie` block. That is what makes the
+ * PM — whose servers resolve through this same function — covered by default.
  */
 function resolveAgentMcpServers(
   agent: PluginAgentDef,
   rootMcp: LoadedMcpConfig,
-): Pick<AgentDef, 'mcpServers' | 'mcpDescriptions' | 'tools' | 'disallowedTools'> {
-  const result: Pick<AgentDef, 'mcpServers' | 'mcpDescriptions' | 'tools' | 'disallowedTools'> = {};
+): Pick<AgentDef, 'mcpServers' | 'mcpDescriptions' | 'mcpPolicy' | 'tools' | 'disallowedTools'> {
+  const result: Pick<AgentDef, 'mcpServers' | 'mcpDescriptions' | 'mcpPolicy' | 'tools' | 'disallowedTools'> = {};
 
   if (agent.mcpServers && agent.mcpServers.length > 0) {
     const resolved: Record<string, any> = {};
     const descriptions: Record<string, string> = {};
+    const policy: McpToolPolicy = {};
     for (const name of agent.mcpServers) {
       const config = rootMcp.servers[name];
       if (config) {
         resolved[name] = config;
         if (rootMcp.descriptions[name]) descriptions[name] = rootMcp.descriptions[name];
+        if (rootMcp.policies[name]) policy[name] = rootMcp.policies[name];
       } else {
         logger.warn('registry', `Agent "${agent.key}" references MCP server "${name}" not found in root .mcp.json`);
       }
@@ -335,6 +344,9 @@ function resolveAgentMcpServers(
     if (Object.keys(descriptions).length > 0) {
       result.mcpDescriptions = descriptions;
     }
+    if (Object.keys(policy).length > 0) {
+      result.mcpPolicy = policy;
+    }
   }
 
   // Only pass tools when explicitly defined in agent frontmatter.
@@ -344,8 +356,15 @@ function resolveAgentMcpServers(
     result.tools = agent.tools;
   }
 
-  if (agent.disallowedTools && agent.disallowedTools.length > 0) {
-    result.disallowedTools = agent.disallowedTools;
+  // Frontmatter denials plus every `deny`-tier tool of the servers this agent
+  // mounts. Deduped: a plugin migrating to .mcp.json policies may still list a
+  // tool in both places for a while.
+  const disallowed = [
+    ...(agent.disallowedTools ?? []),
+    ...(result.mcpPolicy ? deniedToolNames(result.mcpPolicy) : []),
+  ];
+  if (disallowed.length > 0) {
+    result.disallowedTools = [...new Set(disallowed)];
   }
 
   return result;

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -29,6 +29,7 @@ import {
   createSchedulingMcpServer,
 } from './tools.js';
 import { createFileBridgeMcpServer, shouldAttachFileBridge } from './mcp-file-bridge.js';
+import { createToolApprovalHooks, mcpToolName } from './tool-approval-gate.js';
 import { hydrateBranchState } from '../connectors/github/branch-state.js';
 import { taskBranchName } from '../connectors/github/branch-naming.js';
 import { createResearchMcpServer, createResearchPostToolHook, createResearchDefenseTagHook } from '../mcp/research-tools.js';
@@ -756,7 +757,20 @@ Shared folder: ${sharedPath} [READ-ONLY]
     managedSettings: buildManagedNetworkPolicy(sandboxOpts),
     ...(tools ? { tools } : {}),
     hooks: {
-      PreToolUse: createFilesystemGuardHooks(sandboxOpts),
+      PreToolUse: [
+        ...createFilesystemGuardHooks(sandboxOpts),
+        // MCP tool approval gate (docs/architecture/tool-approvals.md): attached
+        // only when one of this agent's servers declares a policy, so agents
+        // whose servers are all unmanaged are untouched. The port reads live
+        // task metadata, so a grant written by the button handler is visible to
+        // the retry without a respawn.
+        ...(def.mcpPolicy
+          ? createToolApprovalHooks(def.mcpPolicy, {
+              consumeApproval: (digest) => task.consumeToolApproval(digest),
+              requestApproval: (request) => task.requestToolApproval(def.id, request),
+            })
+          : []),
+      ],
       PostToolUse: [
         createResearchPostToolHook({
           getSharedDir: () => getSharedPath(taskId),
@@ -863,7 +877,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
                   const toolMeta = new Map<string, import('../types/agent.js').McpToolMeta>();
                   for (const m of detailed) {
                     for (const t of m.tools ?? []) {
-                      toolMeta.set(`mcp__${m.name}__${t.name}`, {
+                      toolMeta.set(mcpToolName(m.name, t.name), {
                         serverName: m.serverInfo?.name,
                         readOnly: t.annotations?.readOnly,
                       });

--- a/src/agents/tool-approval-gate.ts
+++ b/src/agents/tool-approval-gate.ts
@@ -1,0 +1,373 @@
+/**
+ * MCP Tool Approval Gate (issue #168)
+ *
+ * Classifies each MCP tool call against the policy of the server it belongs to
+ * — `allow` runs, `ask` needs a per-call human approval, `deny` never runs —
+ * and for `ask` denies the attempt, posts Slack buttons, parks the task, and
+ * lets the agent's retry spend a single-use grant bound to the exact call.
+ * The design, the config shape and the lifecycle invariants are documented in
+ * docs/architecture/tool-approvals.md; only what the code cannot say for itself
+ * is repeated here.
+ *
+ * Why a PreToolUse hook and not `canUseTool`: every agent runs under
+ * `permissionMode: bypassPermissions`, and the SDK documents that this mode
+ * auto-approves calls past `canUseTool` — "PreToolUse hook denies bypass
+ * canUseTool" (sdk.d.ts). The hook is the only interception point that holds in
+ * our configuration, and it is the same layer the filesystem guard already
+ * relies on for read-only mode. The consequence is the deny-then-retry shape
+ * above: the hook cannot pause a call and resume it later, so the action always
+ * runs through the same audited MCP path on a second attempt.
+ */
+
+import { createHash } from 'crypto';
+import type { HookCallbackMatcher, HookJSONOutput } from '@anthropic-ai/claude-agent-sdk';
+import { logger } from '../system/logger.js';
+
+/** How long a grant stays spendable. Spending it takes a chain — the requesting
+ *  agent is woken, respawns, re-reads state, retries — so the window has to fit
+ *  that, while staying small enough that what the approver saw is still roughly
+ *  what runs. */
+export const APPROVAL_TTL_MS = 30 * 60 * 1000;
+
+/** How long an unresolved *request* keeps the single pending slot. Past this it
+ *  is discarded rather than blocking every other gated call for the task's
+ *  life, and rather than minting a fresh grant if someone finds the prompt
+ *  days later. */
+export const PENDING_APPROVAL_TTL_MS = 60 * 60 * 1000;
+
+// ---- Policy ------------------------------------------------------------------
+
+/**
+ * Who decides a call — deliberately the same three words Claude Code uses for
+ * permissions. `allow` is not named `readonly` on purpose: the gate cannot
+ * verify read-ness, and read-sounding tools here have twice turned out to start
+ * builds, so the tier names the mechanism it actually controls. A policy may
+ * therefore put a cheap, repeatable mutation in `allow` on purpose.
+ *
+ * `deny` is enforced twice: listed tools are withheld up front via
+ * {@link deniedToolNames}, and the tier still refuses anything that reaches the
+ * gate — which is what covers a tool the server adds later under `default: deny`.
+ */
+export type ToolTier = 'allow' | 'ask' | 'deny';
+
+export interface McpServerPolicy {
+  /** Tier for tools not listed in `tiers`. Fail-safe default is `ask`. */
+  default: ToolTier;
+  /** Explicit per-tool tiers (bare tool names, without the mcp__ prefix). */
+  tiers: Record<string, ToolTier>;
+  /**
+   * Optional approver-facing button text per tool, stating the consequence
+   * rather than the method name. Worth writing only where the tool's name is a
+   * bad button on its own — `fully_release_rollout` and
+   * `fully_release_previous_rollout` are one word apart and mean very different
+   * things. An untitled tool renders as its bare identity: terse but honest,
+   * and the call's arguments are shown either way.
+   *
+   * This exists because the tool's *own* description is unreachable. The CLI
+   * has it — the model is given it — but exposes it to the SDK host nowhere:
+   * the single field in the SDK surface that would carry it,
+   * `McpServerStatus.tools[].description`, comes back empty in practice
+   * (verified against a live instance and a minimal repro, 2026-08-20).
+   */
+  titles: Record<string, string>;
+}
+
+/** serverKey (as in .mcp.json) → policy. Lives on AgentDef. */
+export type McpToolPolicy = Record<string, McpServerPolicy>;
+
+const MCP_TOOL_RE = /^mcp__([^_]+(?:_[^_]+)*?)__(.+)$/;
+
+/** Split a full MCP tool name into server and bare tool. */
+export function parseMcpToolName(toolName: string): { server: string; tool: string } | undefined {
+  const match = MCP_TOOL_RE.exec(toolName);
+  return match ? { server: match[1], tool: match[2] } : undefined;
+}
+
+/** Compose the SDK's qualified name for a server's tool. */
+export function mcpToolName(server: string, tool: string): string {
+  return `mcp__${server}__${tool}`;
+}
+
+/**
+ * Qualified names of every explicitly `deny`-tiered tool, for the agent's
+ * `disallowedTools`. Withholding them up front beats denying at call time: the
+ * agent never sees the tool, so it never plans around one it cannot use. The
+ * gate still enforces the tier for anything that does reach it.
+ */
+export function deniedToolNames(policy: McpToolPolicy): string[] {
+  const names: string[] = [];
+  for (const [server, serverPolicy] of Object.entries(policy)) {
+    for (const [tool, tier] of Object.entries(serverPolicy.tiers)) {
+      if (tier === 'deny') names.push(mcpToolName(server, tool));
+    }
+  }
+  return names;
+}
+
+export interface ClassifiedCall {
+  server: string;
+  tool: string;
+  tier: ToolTier;
+}
+
+/**
+ * Classify a tool call against the policy of the servers this agent uses.
+ *
+ * Returns `undefined` for anything the gate does not manage: non-MCP tools,
+ * and MCP servers with no declared policy — those behave exactly as before
+ * this feature, which is what makes rollout incremental. For a managed server,
+ * an unlisted tool falls to the server's `default` tier, so a tool added to
+ * the server later arrives gated rather than silently open.
+ */
+export function classifyToolCall(policy: McpToolPolicy | undefined, toolName: string): ClassifiedCall | undefined {
+  if (!policy) return undefined;
+  const parsed = parseMcpToolName(toolName);
+  if (!parsed) return undefined;
+  // Own-property lookups on both: the server and tool names are derived from a
+  // model-supplied string, and a prototype hit (`constructor`, `toString`) would
+  // otherwise return a truthy non-policy and throw on the next line — outside
+  // this function's caller's try block, since classification runs before it.
+  if (!Object.hasOwn(policy, parsed.server)) return undefined;
+  const serverPolicy = policy[parsed.server];
+  return {
+    server: parsed.server,
+    tool: parsed.tool,
+    tier: Object.hasOwn(serverPolicy.tiers, parsed.tool) ? serverPolicy.tiers[parsed.tool] : serverPolicy.default,
+  };
+}
+
+// ---- Digest ------------------------------------------------------------------
+
+/** Stable stringify: object keys sorted at every depth, so argument order in
+ *  the model's output can't change the digest of the same logical call. */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`);
+  return `{${entries.join(',')}}`;
+}
+
+/**
+ * Identity of a specific call. Covers the server, the tool and every argument,
+ * so an approval is spendable on exactly one call shape.
+ *
+ * The parts are hashed as a JSON array rather than concatenated with a
+ * separator: it is unambiguous without needing a byte that cannot appear in the
+ * data. The previous delimiter was a literal NUL, which made git treat this
+ * file as binary and GitHub show no diff for it at all.
+ */
+export function callDigest(server: string, tool: string, input: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify([server, tool, canonicalize(input ?? {})]))
+    .digest('hex')
+    .slice(0, 16);
+}
+
+// ---- Rendering the approval prompt -------------------------------------------
+
+/**
+ * Neutralize model- or server-supplied text for a Slack `mrkdwn` block.
+ *
+ * Argument values are the one part of the prompt the agent controls, and
+ * without this they are the hole in "rendered by the engine, not the agent": a
+ * string argument can carry newlines and `*bold*` and append its own lines to
+ * the message — a note argument ending in "*Note:* pre-agreed, safe to approve"
+ * renders as an extra instruction to the approver. Collapse whitespace, strip
+ * the mrkdwn and Block Kit sigils, and cap the length. Tool descriptions get
+ * the same treatment: they come from an external MCP server, not from us.
+ */
+function sanitizeText(value: unknown, cap: number): string {
+  const raw = typeof value === 'string' ? value : JSON.stringify(value) ?? String(value);
+  const flat = raw
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/[`*_~<>|]/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+  return flat.length > cap ? `${flat.slice(0, cap - 3)}…` : flat;
+}
+
+/** Sanitized argument value, wrapped in a code span so it reads as data. */
+function sanitizeArgumentValue(value: unknown): string {
+  return `\`${sanitizeText(value, 120)}\``;
+}
+
+/**
+ * Sanitized `key=value` list of every argument, for the prompt body.
+ *
+ * `null` is rendered rather than dropped: the digest covers it, so hiding it
+ * would have the approver approve an argument they were never shown. `undefined`
+ * is not part of the digest and is skipped. The count is capped as well as each
+ * value — Slack refuses a section over 3000 characters, and a call with hundreds
+ * of arguments would otherwise be permanently unapprovable.
+ */
+const MAX_RENDERED_ARGS = 12;
+
+function renderArguments(input: unknown): string {
+  if (!input || typeof input !== 'object') return '';
+  const entries = Object.entries(input as Record<string, unknown>).filter(([, v]) => v !== undefined);
+  const shown = entries.slice(0, MAX_RENDERED_ARGS)
+    .map(([k, v]) => `${k}=${sanitizeArgumentValue(v)}`);
+  const hidden = entries.length - shown.length;
+  return hidden > 0 ? `${shown.join(', ')} (+${hidden} more)` : shown.join(', ');
+}
+
+export interface RenderedCall {
+  /** Multi-line mrkdwn body for the Slack prompt and the audit finding. */
+  summary: string;
+  /** One-line heading: the policy's title for the tool, or its bare identity. */
+  heading: string;
+}
+
+/**
+ * Build the approval text for a gated call.
+ *
+ * The heading is the policy's title for the tool when one is written, and the
+ * bare `server:tool` identity otherwise. Both halves are rendered by the engine
+ * and sanitized: the title comes from the plugins repo, but the arguments under
+ * it are the agent's, and an unescaped string argument can otherwise append its
+ * own lines to the prompt.
+ */
+export function renderCall(serverPolicy: McpServerPolicy, call: ClassifiedCall, input: unknown): RenderedCall {
+  const title = serverPolicy.titles[call.tool];
+  const heading = (title ? sanitizeText(title, 200) : '') || `Run \`${call.server}:${call.tool}\``;
+  const args = renderArguments(input);
+
+  let summary = heading;
+  summary += `\n*Tool:* \`${call.server}:${call.tool}\``;
+  if (args) summary += `\n*Arguments:* ${args}`;
+  return { summary, heading };
+}
+
+// ---- Hook wiring -------------------------------------------------------------
+
+function deny(reason: string): HookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse' as const,
+      permissionDecision: 'deny' as const,
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+/**
+ * What the gate needs from the task. Kept as a narrow port rather than
+ * importing Task, so classification and rendering stay unit-testable without a
+ * task on disk (and so this module doesn't join the task ↔ agent import cycle).
+ */
+export interface ToolApprovalPort {
+  /**
+   * Spend a stored grant for this digest. Resolves true when one was found,
+   * unexpired, and consumed — false otherwise. The implementation must *remove*
+   * the grant synchronously, before it yields, so two calls with the same digest
+   * in one turn cannot both find it; awaiting the result then also waits for the
+   * spend to be durable, so a crash after the tool runs cannot leave the
+   * single-use grant spendable again.
+   */
+  consumeApproval(digest: string): boolean | Promise<boolean>;
+  /**
+   * Post the Slack approval and park the task. Returns `'posted'`, or
+   * `'already-pending'` when a different request is outstanding (one at a
+   * time — a queue of pending approvals is something a human learns to clear
+   * rather than read).
+   */
+  requestApproval(request: {
+    digest: string;
+    server: string;
+    tool: string;
+    summary: string;
+    heading: string;
+  }): Promise<'posted' | 'already-pending'>;
+}
+
+/**
+ * PreToolUse hooks enforcing the tool policy of this agent's MCP servers.
+ *
+ * Returns a single matcher (no `matcher` field → fires on all tools) that
+ * filters by tool name inside the callback, mirroring
+ * `createFilesystemGuardHooks`. Unmanaged tools always proceed, even when the
+ * gate's own dependencies are broken.
+ */
+export function createToolApprovalHooks(policy: McpToolPolicy, port: ToolApprovalPort): HookCallbackMatcher[] {
+  return [{
+    // Generous explicit budget: the deny path posts to Slack and fsyncs metadata
+    // inside the hook, and what a host does with a TIMED-OUT PreToolUse decision
+    // is its policy, not ours — so never get near the default.
+    timeout: 120,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    hooks: [async (input: any): Promise<HookJSONOutput> => {
+      const toolName = typeof input?.tool_name === 'string' ? input.tool_name : undefined;
+      // Classify before the try, so a throw can be attributed: an unmanaged
+      // tool must proceed even if something below would have failed, and a
+      // managed mutation must be denied rather than left to the SDK's handling
+      // of a rejected hook.
+      const call = toolName ? classifyToolCall(policy, toolName) : undefined;
+      if (!call || call.tier === 'allow') return { continue: true };
+
+      try {
+        return await decideCall(policy[call.server], port, call, input.tool_input);
+      } catch (error) {
+        // Fail closed. The arguments are agent-controlled, so this path is
+        // reachable on purpose as well as by accident (a deeply nested argument
+        // overflows the canonicalizer's recursion), and a security hook must
+        // not depend on how the host treats a rejected hook.
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error('tool-approval', `Gate failed for ${toolName} — denying`, error);
+        return deny(
+          `\`${call.tool}\` was refused because the approval gate errored while evaluating it (${message}). ` +
+          `Nothing ran. Report this to the user.`,
+        );
+      }
+    }],
+  }];
+}
+
+/** The gate's decision for one managed, non-`allow` call. Separated so the
+ *  wrapper above can turn any throw into a denial. */
+async function decideCall(
+  serverPolicy: McpServerPolicy,
+  port: ToolApprovalPort,
+  call: ClassifiedCall,
+  toolInput: unknown,
+): Promise<HookJSONOutput> {
+  if (call.tier === 'deny') {
+    return deny(
+      `\`${call.tool}\` is disabled by the \`${call.server}\` tool policy and cannot be run by any agent. ` +
+      `Nothing ran. Report what you wanted to do and why, so a human can decide.`,
+    );
+  }
+
+  // tier === 'ask': per-call approval, bound to this exact call.
+  const digest = callDigest(call.server, call.tool, toolInput);
+
+  // Already approved? Spend the grant and let this one call through.
+  if (await port.consumeApproval(digest)) {
+    logger.system(`Gated tool call ${call.server}:${call.tool} approved (${digest}) — proceeding`);
+    return { continue: true };
+  }
+
+  const rendered = renderCall(serverPolicy, call, toolInput);
+
+  const outcome = await port.requestApproval({
+    digest,
+    server: call.server,
+    tool: call.tool,
+    summary: rendered.summary,
+    heading: rendered.heading,
+  });
+
+  if (outcome === 'already-pending') {
+    return deny(
+      `Another tool call is already waiting for approval on this task. One request is resolved at a ` +
+      `time — wait for the outstanding one to be approved or denied.`,
+    );
+  }
+
+  return deny(
+    `\`${call.tool}\` needs human approval. The request has been posted and the task is pausing. ` +
+    `When it is approved you will be reactivated — re-check relevant state, then retry this exact call.`,
+  );
+}

--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -86,7 +86,7 @@ export async function deleteTrigger(id: string): Promise<void> {
 
 export async function sendApproval(
   taskId: string,
-  type: 'edit_mode' | 'research_budget' | 'merge' | 'trigger' | 'max_mode',
+  type: 'edit_mode' | 'research_budget' | 'merge' | 'trigger' | 'max_mode' | 'tool_call',
   approve: boolean,
   identity?: { github: string; pr_number: number },
   ref?: string,

--- a/src/cli/components/TaskDetail.tsx
+++ b/src/cli/components/TaskDetail.tsx
@@ -128,7 +128,7 @@ export function TaskDetail({ taskId, onBack, liveEvents, onConnect }: TaskDetail
   const logHeight = Math.max(5, termHeight - reservedLines);
 
   // Build log lines with inline approvals
-  const logLines: { node: React.ReactNode; approval?: { approvalType: 'edit_mode' | 'research_budget' | 'merge' | 'trigger' | 'max_mode'; eventIndex: number; github?: string; pr_number?: number; ref?: string } }[] = [];
+  const logLines: { node: React.ReactNode; approval?: { approvalType: 'edit_mode' | 'research_budget' | 'merge' | 'trigger' | 'max_mode' | 'tool_call'; eventIndex: number; github?: string; pr_number?: number; ref?: string } }[] = [];
 
   // Fold pr_card events so a card renders once, at its most recent `post`
   // (anchor), showing the latest merged state. `update` events refresh the data
@@ -196,7 +196,7 @@ export function TaskDetail({ taskId, onBack, liveEvents, onConnect }: TaskDetail
             logLines.push({
               node: <Text color="yellow" bold>⏳ {event.data.text as string}  [y] approve / [n] deny</Text>,
               approval: {
-                approvalType: event.data.approvalType as 'edit_mode' | 'research_budget' | 'merge' | 'trigger' | 'max_mode',
+                approvalType: event.data.approvalType as 'edit_mode' | 'research_budget' | 'merge' | 'trigger' | 'max_mode' | 'tool_call',
                 ref: event.data.ref as string | undefined,
                 eventIndex: idx,
                 // Merge approvals carry the PR identity; the API requires it on

--- a/src/connectors/api/routes.ts
+++ b/src/connectors/api/routes.ts
@@ -308,6 +308,27 @@ export function mountApiRoutes(app: Application): void {
         } else {
           await task.handleTriggerDenial(ref);
         }
+      } else if (type === 'tool_call') {
+        // Same trust model as every other gate's API path: reaching this route
+        // means operator access to the engine. `ref` carries the digest of the
+        // exact (server, tool, arguments) call being resolved — echoed from the
+        // approval event — and is verified against the pending slot inside the
+        // Task methods.
+        if (typeof ref !== 'string' || !ref) {
+          res.status(400).json({ error: 'tool_call approval requires ref (the call digest)' });
+          return;
+        }
+        const disposition = approve
+          ? await task.handleToolCallApproval(cleanApprover, ref)
+          : await task.handleToolCallDenial(ref);
+        if (disposition === 'stale') {
+          res.status(409).json({
+            ok: false,
+            stale: true,
+            error: `No pending tool-call approval for ${ref}`,
+          });
+          return;
+        }
       } else if (type === 'max_mode') {
         if (approve) {
           await task.handleMaxModeApproval(cleanApprover?.name);

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -429,6 +429,7 @@ export async function mountSlackApp(
   });
 
   registerMergeActionHandlers(app!);
+  registerToolApprovalHandlers(app!);
 
   // Handle trigger approval button
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -636,6 +637,94 @@ async function generateTitleAndSync(task: Task, thread: SlackThread): Promise<vo
   if (thread.channel.id.startsWith('D')) {
     await setAssistantThreadTitle(getSlackClient(), thread.channel.id, thread.threadId, title);
   }
+}
+
+/** Parse a tool-approval button value (`<taskId>|<digest>`). */
+function parseToolApprovalButtonValue(value: string): { taskId: string; digest: string } {
+  const pipe = value.indexOf('|');
+  if (pipe === -1) return { taskId: value, digest: '' };
+  return { taskId: value.slice(0, pipe), digest: value.slice(pipe + 1) };
+}
+
+const STALE_TOOL_APPROVAL_TEXT =
+  '⚠️ This approval prompt is stale — the pending request changed, expired, or was already resolved. ' +
+  'Nothing ran, and the task was not resumed — ping the thread if it is still needed.';
+
+/**
+ * Register the MCP tool-call approve/deny button handlers.
+ *
+ * Same shape and same trust model as the merge pair: any workspace member who
+ * can see the prompt may resolve it — identity is resolved for the audit
+ * finding only, and an external/guest clicker still resolves with their
+ * identity omitted, mirroring edit mode and merge. The Task method's atomic
+ * read-compare-clear on the digest is the single verification point.
+ *
+ * Exported for tests, which pass a fake Bolt app recording `.action`
+ * registrations; production registration happens in mountSlackApp.
+ */
+export function registerToolApprovalHandlers(boltApp: Pick<AppType, 'action'>): void {
+  /** Resolve the clicker for attribution; never blocks resolution. */
+  const resolveApprover = async (userId: string | undefined): Promise<{ id: string; name: string } | undefined> => {
+    if (!userId) return undefined;
+    try {
+      const info = await getUserInfo(userId);
+      if (isExternalUser(info)) {
+        logger.system(`Tool-call approver ${userId} is external/guest — identity omitted from the finding`);
+        return undefined;
+      }
+      return { id: userId, name: info.realName };
+    } catch (error) {
+      logger.warn('Slack', `Failed to resolve tool-call approver ${userId}`, error);
+      return { id: userId, name: userId };
+    }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  boltApp.action('approve_tool_call', async ({ action, ack, body }: any) => {
+    await ack();
+
+    const { taskId, digest } = parseToolApprovalButtonValue(String(action.value ?? ''));
+    const userId = body.user?.id || 'unknown';
+    logger.server(`Tool call approved by ${userId} for task ${taskId} (${digest})`);
+
+    try {
+      const approver = await resolveApprover(userId !== 'unknown' ? userId : undefined);
+      const task = await Task.get(taskId);
+      const disposition = await task.handleToolCallApproval(approver, digest);
+
+      if (body.channel?.id && body.message?.ts) {
+        const text = disposition === 'resolved'
+          ? `✅ *Tool call approved* by <@${userId}>`
+          : STALE_TOOL_APPROVAL_TEXT;
+        await updateMessage(body.channel.id, body.message.ts, text, []);
+      }
+    } catch (error) {
+      logger.error('Server', 'Error handling tool-call approval', error);
+    }
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  boltApp.action('deny_tool_call', async ({ action, ack, body }: any) => {
+    await ack();
+
+    const { taskId, digest } = parseToolApprovalButtonValue(String(action.value ?? ''));
+    const userId = body.user?.id || 'unknown';
+    logger.server(`Tool call denied by ${userId} for task ${taskId} (${digest})`);
+
+    try {
+      const task = await Task.get(taskId);
+      const disposition = await task.handleToolCallDenial(digest);
+
+      if (body.channel?.id && body.message?.ts) {
+        const text = disposition === 'resolved'
+          ? `❌ *Tool call denied* by <@${userId}>`
+          : STALE_TOOL_APPROVAL_TEXT;
+        await updateMessage(body.channel.id, body.message.ts, text, []);
+      }
+    } catch (error) {
+      logger.error('Server', 'Error handling tool-call denial', error);
+    }
+  });
 }
 
 // ============================================================================

--- a/src/system/__tests__/plugin-loader.test.ts
+++ b/src/system/__tests__/plugin-loader.test.ts
@@ -1,10 +1,11 @@
 /**
  * Plugin Loader — loadMcpJson tests
  *
- * Focused on the `description` handling: each server's optional human-readable
- * `description` must be surfaced separately (for the PM's team-integrations
- * context) and stripped from the connection config so the Claude Agent SDK
- * never receives a non-standard field.
+ * Focused on the two Archie extensions each server entry may carry —
+ * `description` (human-readable, for the PM's team-integrations context) and
+ * `archie` (the tool approval policy). Both must be surfaced separately and
+ * stripped from the connection config, so the Claude Agent SDK never receives a
+ * non-standard field.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -37,7 +38,7 @@ describe('loadMcpJson', () => {
 
   it('returns empty servers and descriptions when the file does not exist', () => {
     const result = loadMcpJson(join(tempDir, 'does-not-exist.json'));
-    expect(result).toEqual({ servers: {}, descriptions: {} });
+    expect(result).toEqual({ servers: {}, descriptions: {}, policies: {} });
   });
 
   it('extracts description into descriptions and strips it from the server config', async () => {
@@ -91,6 +92,14 @@ describe('loadMcpJson', () => {
     expect(servers.monday).toEqual({ type: 'http', url: 'https://mcp.monday.com/mcp' });
   });
 
+  it('leaves policies empty for a server that declares none', async () => {
+    const path = await writeMcpJson({
+      mcpServers: { notion: { type: 'http', url: 'https://mcp.notion.com/mcp' } },
+    });
+    // An unmanaged server: the gate never attaches, behaviour is as before.
+    expect(loadMcpJson(path).policies).toEqual({});
+  });
+
   it('substitutes ${MCP_*} env vars alongside description handling', async () => {
     process.env.MCP_TEST_TOKEN = 'secret-token';
     try {
@@ -113,5 +122,128 @@ describe('loadMcpJson', () => {
     } finally {
       delete process.env.MCP_TEST_TOKEN;
     }
+  });
+});
+
+/**
+ * The `archie` block is a security boundary: it decides which external
+ * mutations need a human. So it is validated strictly and a malformed one
+ * throws rather than being dropped — a silently-ignored typo would reclassify a
+ * tool as unmanaged.
+ */
+describe('loadMcpJson — archie tool policy', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'archie-mcp-policy-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function writePolicy(archie: unknown): Promise<string> {
+    return writeMcpJson({
+      mcpServers: {
+        tramline: { command: 'node', args: ['server.js'], description: 'Tramline', archie },
+      },
+    });
+  }
+
+  it('parses tiers and strips the key from the connection config', async () => {
+    const path = await writePolicy({
+      default: 'ask',
+      allow: ['list_apps', 'get_release'],
+      deny: ['start_release'],
+    });
+
+    const { servers, descriptions, policies } = loadMcpJson(path);
+
+    expect(policies.tramline).toEqual({
+      default: 'ask',
+      tiers: { list_apps: 'allow', get_release: 'allow', start_release: 'deny' },
+      titles: {},
+    });
+    // Neither extension may reach the SDK.
+    expect(servers.tramline).toEqual({ command: 'node', args: ['server.js'] });
+    expect(descriptions.tramline).toBe('Tramline');
+  });
+
+  it('defaults an unlisted tool to ask (fail safe)', async () => {
+    const path = await writePolicy({ allow: ['get_release'] });
+    expect(loadMcpJson(path).policies.tramline.default).toBe('ask');
+  });
+
+  it('accepts an allow-by-default server with explicit exceptions', async () => {
+    const path = await writePolicy({ default: 'allow', ask: ['trigger_build'], deny: ['set_mcp_mode'] });
+    expect(loadMcpJson(path).policies.tramline).toEqual({
+      default: 'allow',
+      tiers: { trigger_build: 'ask', set_mcp_mode: 'deny' },
+      titles: {},
+    });
+  });
+
+  // Optional, and only worth writing where the method name is a bad button.
+  it('parses optional per-tool titles', async () => {
+    const path = await writePolicy({
+      titles: { fully_release_rollout: '  Release to 100% of users — irreversible  ' },
+    });
+    expect(loadMcpJson(path).policies.tramline.titles)
+      .toEqual({ fully_release_rollout: 'Release to 100% of users — irreversible' });
+  });
+
+  it('rejects a non-string or empty title', async () => {
+    for (const titles of [{ t: 7 }, { t: '' }, { t: '   ' }]) {
+      const path = await writePolicy({ titles });
+      expect(() => loadMcpJson(path)).toThrow(/must be a non-empty string/);
+    }
+  });
+
+  it('rejects a non-map titles value', async () => {
+    const path = await writePolicy({ titles: ['a title'] });
+    expect(() => loadMcpJson(path)).toThrow(/must be a map of tool name to button text/);
+  });
+
+  it('rejects an unknown default tier', async () => {
+    const path = await writePolicy({ default: 'askk' });
+    expect(() => loadMcpJson(path)).toThrow(/default must be one of/);
+  });
+
+  // Catches a misspelled tier name, which would otherwise read as "nothing
+  // listed" — every tool silently falling to the default.
+  it('rejects an unknown key', async () => {
+    const path = await writePolicy({ asks: ['trigger_build'] });
+    expect(() => loadMcpJson(path)).toThrow(/unknown key "asks"/);
+  });
+
+  it('rejects a tool listed in two tiers', async () => {
+    const path = await writePolicy({ allow: ['get_release'], deny: ['get_release'] });
+    expect(() => loadMcpJson(path)).toThrow(/appears in both/);
+  });
+
+  it('rejects a non-list tier', async () => {
+    const path = await writePolicy({ allow: 'get_release' });
+    expect(() => loadMcpJson(path)).toThrow(/must be a list of tool names/);
+  });
+
+
+  // A key with `__` splits differently coming back out of the SDK's
+  // `mcp__<server>__<tool>` name, so the gate would never find the policy and
+  // every tool of the server would run ungated. Refuse the key instead.
+  it('rejects a server key that cannot survive the tool-name round trip', async () => {
+    for (const key of ['sweat__admin', '_lead', 'trail_']) {
+      const path = await writeMcpJson({
+        mcpServers: { [key]: { command: 'node', archie: { default: 'ask' } } },
+      });
+      expect(() => loadMcpJson(path)).toThrow(/does not survive/);
+    }
+  });
+
+  it('leaves an unpolicied server with an awkward key alone', async () => {
+    const path = await writeMcpJson({ mcpServers: { 'sweat__admin': { command: 'node' } } });
+    expect(loadMcpJson(path).servers).toHaveProperty('sweat__admin');
+  });
+
+  it('rejects a non-object policy', async () => {
+    const path = await writePolicy(['allow']);
+    expect(() => loadMcpJson(path)).toThrow(/must be an object/);
   });
 });

--- a/src/system/plugin-loader.ts
+++ b/src/system/plugin-loader.ts
@@ -12,6 +12,9 @@
  *
  * MCP servers are configured in a single root .mcp.json at the plugins directory root.
  * Individual agents reference server names via frontmatter `mcpServers: [...]`.
+ * Each server entry may carry two Archie extensions, both stripped before the
+ * config reaches the SDK: `description` (human-readable, for the PM roster) and
+ * `archie` (the tool approval policy — see agents/tool-approval-gate.ts).
  *
  * A special "pm" plugin can provide an overlay for the PM agent:
  *   - agents/pm.md body is appended to the PM's hardcoded prompt
@@ -23,13 +26,14 @@
 import { readFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import matter from 'gray-matter';
+import { mcpToolName, parseMcpToolName, type McpToolPolicy, type McpServerPolicy, type ToolTier } from '../agents/tool-approval-gate.js';
 import { PLUGINS_DIR, PLUGINS_DATA_DIR } from './workdir.js';
 import { logger } from './logger.js';
 import type { MaxModeSpec } from '../types/agent.js';
 
 export { PLUGINS_DIR };
 
-/** Parsed root .mcp.json — server connection configs plus optional descriptions */
+/** Parsed root .mcp.json — server connection configs plus Archie extensions */
 export interface LoadedMcpConfig {
   servers: Record<string, any>;
   /**
@@ -39,17 +43,119 @@ export interface LoadedMcpConfig {
    * roster line with what its integrations are (see registry.buildPmDef).
    */
   descriptions: Record<string, string>;
+  /**
+   * Tool approval policy per server, from an optional `archie` key on each
+   * server entry. Also stripped from `servers`. Absent for a server that
+   * declares none — such a server is unmanaged and behaves as it did before
+   * the gate existed. See agents/tool-approval-gate.ts.
+   */
+  policies: McpToolPolicy;
+}
+
+const TIERS: ToolTier[] = ['allow', 'ask', 'deny'];
+
+/**
+ * Parse and validate one server's `archie` block from .mcp.json.
+ *
+ * ```json
+ * "tramline": {
+ *   "command": "…",
+ *   "archie": {
+ *     "default": "ask",              // tier for tools not listed (default: ask)
+ *     "allow": ["get_release"],      // runs ungated
+ *     "ask":   ["extend_soak"],      // needs a per-call human approval
+ *     "deny":  ["start_release"],    // withheld from every agent
+ *     "titles": {                    // optional approver-facing button text
+ *       "extend_soak": "Extend the beta soak, delaying the production rollout"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Throws rather than dropping a malformed policy: this block decides which
+ * external mutations need a human, so a silently-ignored typo must not
+ * reclassify a tool. Unknown keys are rejected for the same reason — a
+ * misspelled tier name would otherwise read as "nothing listed".
+ */
+function parseServerPolicy(serverKey: string, raw: unknown, path: string): McpServerPolicy {
+  const where = `MCP config ${path}: server "${serverKey}" archie policy`;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${where} must be an object.`);
+  }
+  const entry = raw as Record<string, unknown>;
+
+  // The gate finds the policy by splitting the SDK's `mcp__<server>__<tool>`
+  // name back into its parts, and a key containing `__` (or a leading/trailing
+  // `_`) does not survive that round trip: the split yields a different server
+  // name, no policy is found, and every tool of this server runs UNGATED. That
+  // is the exact failure the strict parsing here exists to prevent, so refuse
+  // the key rather than load a policy that cannot be enforced.
+  if (parseMcpToolName(mcpToolName(serverKey, 'probe'))?.server !== serverKey) {
+    throw new Error(
+      `${where}: server key "${serverKey}" cannot carry a policy — it does not survive ` +
+      `the mcp__<server>__<tool> round trip (no "__", no leading or trailing "_"), so the ` +
+      `gate would never match its calls. Rename the server.`,
+    );
+  }
+
+  const allowedKeys = new Set(['default', 'titles', ...TIERS]);
+  for (const key of Object.keys(entry)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`${where}: unknown key "${key}" — expected one of default, ${TIERS.join(', ')}.`);
+    }
+  }
+
+  const fallback = entry.default ?? 'ask';
+  if (!TIERS.includes(fallback as ToolTier)) {
+    throw new Error(`${where}.default must be one of ${TIERS.join(', ')} — got ${JSON.stringify(fallback)}.`);
+  }
+
+  const tiers: Record<string, ToolTier> = {};
+  for (const tier of TIERS) {
+    const list = entry[tier];
+    if (list === undefined) continue;
+    if (!Array.isArray(list) || list.some((t) => typeof t !== 'string' || !t.trim())) {
+      throw new Error(`${where}.${tier} must be a list of tool names.`);
+    }
+    for (const tool of list as string[]) {
+      const name = tool.trim();
+      if (tiers[name] && tiers[name] !== tier) {
+        throw new Error(`${where}: tool "${name}" appears in both ${tiers[name]} and ${tier}.`);
+      }
+      tiers[name] = tier;
+    }
+  }
+
+  const titles: Record<string, string> = {};
+  if (entry.titles !== undefined) {
+    if (!entry.titles || typeof entry.titles !== 'object' || Array.isArray(entry.titles)) {
+      throw new Error(`${where}.titles must be a map of tool name to button text.`);
+    }
+    for (const [tool, title] of Object.entries(entry.titles as Record<string, unknown>)) {
+      if (typeof title !== 'string' || !title.trim()) {
+        throw new Error(`${where}.titles.${tool} must be a non-empty string.`);
+      }
+      titles[tool.trim()] = title.trim();
+    }
+  }
+
+  return { default: fallback as ToolTier, tiers, titles };
 }
 
 /**
  * Load and parse an .mcp.json file, substituting ${MCP_*} env vars.
- * Returns pure server connection configs plus any human-readable `description`
- * keys (pulled out so they never reach the SDK). Tool permissions are
- * controlled by agent frontmatter, not by .mcp.json.
+ * Returns pure server connection configs plus the two Archie extensions
+ * (`description`, `archie`), pulled out so they never reach the SDK.
+ *
+ * A syntactically broken file degrades to "no servers" with a warning, as it
+ * always has. A *malformed policy* throws instead: dropping it would silently
+ * ungate a tool someone meant to gate.
  */
 export function loadMcpJson(path: string): LoadedMcpConfig {
-  const empty: LoadedMcpConfig = { servers: {}, descriptions: {} };
+  const empty: LoadedMcpConfig = { servers: {}, descriptions: {}, policies: {} };
   if (!existsSync(path)) return empty;
+
+  let rawServers: Record<string, any>;
   try {
     const raw = readFileSync(path, 'utf-8');
     const substituted = raw.replace(/\$\{(MCP_[A-Z0-9_]+)\}/g, (_, name) => {
@@ -57,30 +163,33 @@ export function loadMcpJson(path: string): LoadedMcpConfig {
       if (!value) logger.warn('system', `MCP config: env var ${name} is not set (${path})`);
       return value ?? '';
     });
-    const parsed = JSON.parse(substituted);
-    const rawServers: Record<string, any> = parsed.mcpServers ?? {};
-
-    const servers: Record<string, any> = {};
-    const descriptions: Record<string, string> = {};
-    for (const [name, config] of Object.entries(rawServers)) {
-      // `description` is metadata for surfacing to the PM, not connection
-      // config — split it out so the SDK only sees valid server fields.
-      if (config && typeof config === 'object' && !Array.isArray(config) && 'description' in config) {
-        const { description, ...connectionConfig } = config as Record<string, any>;
-        if (typeof description === 'string' && description.trim()) {
-          descriptions[name] = description.trim();
-        }
-        servers[name] = connectionConfig;
-      } else {
-        servers[name] = config;
-      }
-    }
-
-    return { servers, descriptions };
+    rawServers = JSON.parse(substituted).mcpServers ?? {};
   } catch {
     logger.warn('system', `MCP config: failed to parse ${path}`);
     return empty;
   }
+
+  const servers: Record<string, any> = {};
+  const descriptions: Record<string, string> = {};
+  const policies: McpToolPolicy = {};
+  for (const [name, config] of Object.entries(rawServers)) {
+    if (!config || typeof config !== 'object' || Array.isArray(config)) {
+      servers[name] = config;
+      continue;
+    }
+    // `description` and `archie` are Archie metadata, not connection config —
+    // split them out so the SDK only sees valid server fields.
+    const { description, archie, ...connectionConfig } = config as Record<string, any>;
+    if (typeof description === 'string' && description.trim()) {
+      descriptions[name] = description.trim();
+    }
+    if (archie !== undefined) {
+      policies[name] = parseServerPolicy(name, archie, path);
+    }
+    servers[name] = connectionConfig;
+  }
+
+  return { servers, descriptions, policies };
 }
 
 export interface PluginRepoConfig {

--- a/src/tasks/__tests__/tool-approval.test.ts
+++ b/src/tasks/__tests__/tool-approval.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Unit tests for the MCP tool-call approval lifecycle on Task:
+ * requestToolApproval / consumeToolApproval /
+ * handleToolCallApproval / handleToolCallDenial.
+ *
+ * Calls the real prototype methods on a minimal fake task (no LLM, no SDK,
+ * no Slack) — the same harness shape as merge-approval.test.ts. The properties
+ * pinned here are the ones the guard depends on: the slot's presence always
+ * means "a prompt exists in Slack" (a failed post clears it), one-at-a-time
+ * with a 1h age-out, grants are single-use / digest-deduped / TTL-bounded, and
+ * a stale or expired click resolves to a no-op instead of minting a grant.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../persistence.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../persistence.js')>();
+  return { ...actual, appendAgentFinding: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../system/logger.js', () => ({
+  logger: {
+    system: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), info: vi.fn(),
+    slack: vi.fn(), agentAction: vi.fn(), agentFinding: vi.fn(), agentToSlack: vi.fn(),
+  },
+}));
+
+vi.mock('../../system/event-bus.js', () => ({ emitEvent: vi.fn() }));
+
+import { Task } from '../task.js';
+import { appendAgentFinding } from '../persistence.js';
+import { APPROVAL_TTL_MS, PENDING_APPROVAL_TTL_MS } from '../../agents/tool-approval-gate.js';
+import type { TaskMetadata } from '../../types/task.js';
+
+const REQUEST = {
+  digest: 'd1'.padEnd(16, '0'),
+  server: 'tramline',
+  tool: 'retry_workflow_run',
+  summary: 'Re-run this failed CI build\n*Tool:* `tramline:retry_workflow_run`\n*Arguments:* id=`wf-1`',
+  heading: 'Re-run this failed CI build',
+};
+const OTHER_DIGEST = 'd2'.padEnd(16, '0');
+
+type FakeTask = {
+  taskId: string;
+  metadata: Partial<TaskMetadata>;
+  agentProcesses: Map<string, { clearPendingTeardown: ReturnType<typeof vi.fn>; deferTeardown: ReturnType<typeof vi.fn> }>;
+  debouncedSave: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  sendMessage: ReturnType<typeof vi.fn>;
+  postInteractiveToUser: ReturnType<typeof vi.fn>;
+  suspendStatus: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+};
+
+function makeFakeTask(metadata: Partial<TaskMetadata> = {}): FakeTask {
+  return {
+    taskId: 'task-123',
+    metadata,
+    agentProcesses: new Map([
+      ['release-manager-agent', { clearPendingTeardown: vi.fn(), deferTeardown: vi.fn() }],
+      ['pm-agent', { clearPendingTeardown: vi.fn(), deferTeardown: vi.fn() }],
+    ]),
+    debouncedSave: vi.fn(),
+    save: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    postInteractiveToUser: vi.fn().mockResolvedValue(undefined),
+    suspendStatus: vi.fn(),
+    stop: vi.fn(),
+  };
+}
+
+const request = (task: FakeTask, req = REQUEST, agent = 'release-manager-agent') =>
+  Task.prototype.requestToolApproval.call(task as unknown as Task, agent, req);
+const consume = (task: FakeTask, digest: string) =>
+  Task.prototype.consumeToolApproval.call(task as unknown as Task, digest);
+const approve = (task: FakeTask, digest: string, approver = { id: 'U1', name: 'Misha' }) =>
+  Task.prototype.handleToolCallApproval.call(task as unknown as Task, approver, digest);
+const deny = (task: FakeTask, digest: string) =>
+  Task.prototype.handleToolCallDenial.call(task as unknown as Task, digest);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-07T12:00:00.000Z'));
+});
+afterEach(() => vi.useRealTimers());
+
+describe('requestToolApproval', () => {
+  it('writes the slot durably, posts, and parks the requesting agent', async () => {
+    const task = makeFakeTask();
+    expect(await request(task)).toBe('posted');
+
+    expect(task.metadata.pending_tool_approval).toMatchObject({
+      digest: REQUEST.digest,
+      server: REQUEST.server,
+      tool: REQUEST.tool,
+      requested_by: 'release-manager-agent',
+    });
+    expect(task.save).toHaveBeenCalledWith(true);
+    expect(task.postInteractiveToUser).toHaveBeenCalledTimes(1);
+    expect(task.suspendStatus).toHaveBeenCalled();
+    expect(task.agentProcesses.get('release-manager-agent')!.deferTeardown).toHaveBeenCalled();
+  });
+
+  // Regression for the review-confirmed deadlock: the slot's presence means "a
+  // prompt exists in Slack". A failed post that left it set would make every
+  // other action 'already-pending' for an hour, and a same-digest retry would
+  // park the task against a button nobody can see.
+  it('clears the slot and rethrows when the Slack post fails', async () => {
+    const task = makeFakeTask();
+    task.postInteractiveToUser.mockRejectedValueOnce(new Error('slack 500'));
+
+    await expect(request(task)).rejects.toThrow('slack 500');
+    expect(task.metadata.pending_tool_approval).toBeUndefined();
+    // and the task is NOT parked against the nonexistent prompt
+    expect(task.suspendStatus).not.toHaveBeenCalled();
+    expect(task.agentProcesses.get('release-manager-agent')!.deferTeardown).not.toHaveBeenCalled();
+
+    // the next action is not blocked
+    task.postInteractiveToUser.mockResolvedValueOnce(undefined);
+    expect(await request(task, { ...REQUEST, digest: OTHER_DIGEST })).toBe('posted');
+  });
+
+  it('refuses a second, different action while one is pending', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    task.postInteractiveToUser.mockClear();
+
+    expect(await request(task, { ...REQUEST, digest: OTHER_DIGEST })).toBe('already-pending');
+    expect(task.postInteractiveToUser).not.toHaveBeenCalled();
+  });
+
+  it('re-arms the park on a same-digest retry without re-posting', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    task.postInteractiveToUser.mockClear();
+    task.suspendStatus.mockClear();
+
+    expect(await request(task)).toBe('posted');
+    expect(task.postInteractiveToUser).not.toHaveBeenCalled(); // no duplicate prompt
+    expect(task.suspendStatus).toHaveBeenCalled();             // but the park is re-armed
+  });
+
+  // The slot's presence is what the re-arm branch and the one-at-a-time refusal
+  // both trust, so a failure anywhere between setting it and the prompt landing
+  // has to clear it — not only a failed post.
+  it('clears the slot when the durable flush fails, before anything is posted', async () => {
+    const task = makeFakeTask();
+    task.save.mockRejectedValueOnce(new Error('disk full'));
+
+    await expect(request(task)).rejects.toThrow('disk full');
+    expect(task.metadata.pending_tool_approval).toBeUndefined();
+    expect(task.postInteractiveToUser).not.toHaveBeenCalled();
+    expect(task.suspendStatus).not.toHaveBeenCalled();
+  });
+
+  // A grant is bound to the call, not the agent, so a second agent can reach a
+  // live slot with the same digest. Arming its teardown would leave a deferred
+  // stop() that resolution never cancels (both paths clear `requested_by`), and
+  // it would fire mid-retry and tear the task down.
+  it('refuses a same-digest request from a different agent instead of parking it', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    vi.clearAllMocks();
+
+    expect(await request(task, REQUEST, 'pm-agent')).toBe('already-pending');
+    expect(task.agentProcesses.get('pm-agent')!.deferTeardown).not.toHaveBeenCalled();
+    expect(task.suspendStatus).not.toHaveBeenCalled();
+  });
+
+  it('ages out a stale pending slot and replaces it', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    vi.advanceTimersByTime(PENDING_APPROVAL_TTL_MS + 1000);
+
+    expect(await request(task, { ...REQUEST, digest: OTHER_DIGEST })).toBe('posted');
+    expect(task.metadata.pending_tool_approval!.digest).toBe(OTHER_DIGEST);
+  });
+});
+
+describe('handleToolCallApproval', () => {
+  it('stores a single grant, clears the slot, and wakes the requesting agent', async () => {
+    const task = makeFakeTask();
+    await request(task);
+
+    expect(await approve(task, REQUEST.digest)).toBe('resolved');
+    expect(task.metadata.pending_tool_approval).toBeUndefined();
+    expect(task.metadata.approved_tool_calls).toHaveLength(1);
+    expect(task.metadata.approved_tool_calls![0]).toMatchObject({
+      digest: REQUEST.digest,
+      approved_by: 'U1',
+    });
+    expect(task.agentProcesses.get('release-manager-agent')!.clearPendingTeardown).toHaveBeenCalled();
+    expect(task.sendMessage).toHaveBeenCalledWith(expect.any(String), 'release-manager-agent');
+  });
+
+  it('is a stale no-op for a digest that does not match the slot', async () => {
+    const task = makeFakeTask();
+    await request(task);
+
+    expect(await approve(task, OTHER_DIGEST)).toBe('stale');
+    expect(task.metadata.pending_tool_approval!.digest).toBe(REQUEST.digest); // untouched
+    expect(task.metadata.approved_tool_calls ?? []).toHaveLength(0);
+  });
+
+  it('is a stale no-op with no grant for a prompt older than the pending TTL', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    vi.advanceTimersByTime(PENDING_APPROVAL_TTL_MS + 1000);
+
+    expect(await approve(task, REQUEST.digest)).toBe('stale');
+    expect(task.metadata.pending_tool_approval).toBeUndefined(); // slot cleared
+    expect(task.metadata.approved_tool_calls ?? []).toHaveLength(0); // NO grant minted
+    expect(vi.mocked(appendAgentFinding)).toHaveBeenCalledWith(
+      'task-123', 'system', expect.stringContaining('expired unspent'), 'decision',
+    );
+  });
+
+  it('dedupes grants by digest — two approvals cannot become two spends', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    await approve(task, REQUEST.digest);
+    await request(task); // second prompt, same call
+    await approve(task, REQUEST.digest);
+
+    expect(task.metadata.approved_tool_calls).toHaveLength(1);
+  });
+});
+
+describe('handleToolCallDenial', () => {
+  it('clears the slot durably and grants nothing', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    task.save.mockClear();
+
+    expect(await deny(task, REQUEST.digest)).toBe('resolved');
+    expect(task.metadata.pending_tool_approval).toBeUndefined();
+    expect(task.metadata.approved_tool_calls ?? []).toHaveLength(0);
+    expect(task.save).toHaveBeenCalledWith(true);
+  });
+
+  it('is a stale no-op for a mismatched digest', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    expect(await deny(task, OTHER_DIGEST)).toBe('stale');
+    expect(task.metadata.pending_tool_approval!.digest).toBe(REQUEST.digest);
+  });
+});
+
+describe('consumeToolApproval', () => {
+  it('spends a grant exactly once, splicing synchronously and awaiting the flush', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    await approve(task, REQUEST.digest);
+    task.save.mockClear();
+
+    // The splice must land before this yields: the second call is made without
+    // awaiting the first, which is exactly what two gated calls in one turn do.
+    const spend = consume(task, REQUEST.digest);
+    expect(consume(task, REQUEST.digest)).toBe(false); // single-use, synchronously
+    expect(await spend).toBe(true);
+    expect(task.metadata.approved_tool_calls).toHaveLength(0);
+    expect(task.save).toHaveBeenCalledWith(true); // the spend is durable, not debounced
+  });
+
+  // Refusing a call a human approved because a write failed is worse than the
+  // replay risk that write protects against.
+  it('still spends the grant when the flush fails', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    await approve(task, REQUEST.digest);
+    task.save.mockRejectedValueOnce(new Error('disk full'));
+
+    expect(await consume(task, REQUEST.digest)).toBe(true);
+  });
+
+  it('refuses an expired grant and prunes it', async () => {
+    const task = makeFakeTask();
+    await request(task);
+    await approve(task, REQUEST.digest);
+    vi.advanceTimersByTime(APPROVAL_TTL_MS + 1000);
+
+    expect(consume(task, REQUEST.digest)).toBe(false);
+    expect(task.metadata.approved_tool_calls).toHaveLength(0); // pruned
+  });
+
+  it('returns false with no grants on file', () => {
+    expect(consume(makeFakeTask(), REQUEST.digest)).toBe(false);
+  });
+});

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -12,6 +12,7 @@ import type { AgentDef } from '../types/agent.js';
 import { isPmAgent, isRepoAgent } from '../types/agent.js';
 import { modelDisplayLabel, resolveAgentModel, modelChangingAgentIds } from '../agents/model-label.js';
 import { prCardFingerprint, prCardTitlePlain } from '../system/pr-card-format.js';
+import { APPROVAL_TTL_MS, PENDING_APPROVAL_TTL_MS } from '../agents/tool-approval-gate.js';
 import { getGitHubClient } from '../connectors/github/client.js';
 import { createKeyedLock } from '../system/keyed-lock.js';
 
@@ -637,7 +638,7 @@ export class Task {
   async postInteractiveToUser(
     text: string,
     blocks: unknown[],
-    approvalType: 'edit_mode' | 'research_budget' | 'merge' | 'trigger' | 'max_mode',
+    approvalType: 'edit_mode' | 'research_budget' | 'merge' | 'trigger' | 'max_mode' | 'tool_call',
     channelKey?: string,
     context?: { github: string; pr_number: number },
     ref?: string,
@@ -1498,6 +1499,312 @@ export class Task {
 
     this.debouncedSave();
     await appendAgentFinding(this.taskId, 'system', 'Merge denied by user — PR not merged', 'decision');
+    await this.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
+    return 'resolved';
+  }
+
+
+  // ---- MCP tool-call approvals ---------------------------------------------
+  // The gate itself lives in agents/tool-approval-gate.ts; this section owns
+  // the metadata invariants it depends on. See docs/architecture/tool-approvals.md.
+
+  /**
+   * Spend a grant for `digest`.
+   *
+   * **Synchronous read-compare-remove, no awaits.** The gate hook calls this on
+   * every gated tool call, so two calls with the same digest in one turn must
+   * not both find the grant — the splice has to land before anything can yield.
+   * (Same invariant as `handleMergeApproval`'s clear-before-awaits.)
+   *
+   * The *spend* is then flushed durably before the caller proceeds, which is
+   * why this returns a promise on the spend path. Durability is inverted for a
+   * single-use token: losing the grant write costs an extra approval prompt,
+   * but losing the spend write means a crash — after the tool call has already
+   * run — leaves the grant on disk, unexpired and spendable a second time. The
+   * splice above is what has to be synchronous; awaiting the write afterwards
+   * costs one fsync on a path that is about to make a network call anyway.
+   */
+  consumeToolApproval(digest: string): boolean | Promise<boolean> {
+    const grants = this.metadata.approved_tool_calls;
+    if (!grants || grants.length === 0) return false;
+
+    const now = Date.now();
+    const index = grants.findIndex((a) => a.digest === digest && Date.parse(a.expires_at) > now);
+    // Prune anything stale while we're here — an unspent grant is a standing
+    // permission, so it should not outlive its window on disk.
+    const live = grants.filter((a, i) => i !== index && Date.parse(a.expires_at) > now);
+
+    if (index === -1) {
+      if (live.length !== grants.length) {
+        this.metadata.approved_tool_calls = live;
+        this.debouncedSave();
+      }
+      return false;
+    }
+
+    this.metadata.approved_tool_calls = live;
+
+    // Record that the grant was actually *spent* — without this the audit trail
+    // stops at "approved" and nobody can tell from the thread whether the call
+    // ever ran. Fire-and-forget: a failed log write must not block the call.
+    const spent = grants[index];
+    void appendAgentFinding(
+      this.taskId,
+      'system',
+      `Gated tool call ran on approval ${spent.digest}: ${spent.server}:${spent.tool}` +
+        (spent.approved_by ? ` (approved by <@${spent.approved_by}>)` : ''),
+      'completion',
+    ).catch(() => {});
+
+    // A failed flush is not a reason to refuse a call a human approved — the
+    // cost of that write being lost is a possible replay, which is strictly
+    // less bad than denying an approved action. Log and proceed.
+    return this.save(true)
+      .catch((error) => logger.warn('task', `Failed to flush spent tool-call grant ${digest}`, error))
+      .then(() => true);
+  }
+
+  /**
+   * Post a tool-call approval request and park the task.
+   *
+   * One outstanding request per task: a second gated call while one is pending
+   * is refused rather than queued, so a human never faces a stack of approval
+   * buttons to clear. There is no supersede path for a *live* request —
+   * superseding would let an agent swap the call out from under a human who is
+   * mid-way through reading it. Instead the slot ages out
+   * (PENDING_APPROVAL_TTL_MS), and a failed Slack post clears it.
+   */
+  async requestToolApproval(
+    agentId: string,
+    request: { digest: string; server: string; tool: string; summary: string; heading: string },
+  ): Promise<'posted' | 'already-pending'> {
+    // A pending request goes stale: nobody clicked, and a prompt raised against
+    // state that is now hours old should not keep blocking every other call for
+    // the rest of the task's life, nor mint a fresh grant if someone finds it
+    // days later. Past its window it is discarded and this request replaces it.
+    const pending = this.metadata.pending_tool_approval;
+    const live = pending && Date.parse(pending.requested_at) > Date.now() - PENDING_APPROVAL_TTL_MS
+      ? pending
+      : undefined;
+    if (live && live.digest !== request.digest) return 'already-pending';
+    // Same digest already pending: the agent retried before the human answered.
+    // Re-arm the park — the previous teardown has already fired, so returning
+    // without arming would leave the agent running against a prompt nobody has
+    // answered, free to try something else.
+    //
+    // Only the *requester* re-arms. A grant is bound to the call, not to the
+    // agent, so a second agent can reach this with the same digest — and both
+    // resolution paths clear the teardown of `requested_by` alone, so arming
+    // anyone else leaves a deferred stop() nothing will cancel: it fires at that
+    // agent's turn end and tears the task down while the requester's retry is
+    // in flight. Tell the other agent to wait instead.
+    if (live && live.requested_by !== agentId) return 'already-pending';
+    if (live) {
+      this.suspendStatus();
+      this.agentProcesses.get(agentId as AgentName)?.deferTeardown(() => this.stop());
+      return 'posted';
+    }
+
+    this.metadata.pending_tool_approval = {
+      digest: request.digest,
+      server: request.server,
+      tool: request.tool,
+      summary: request.summary,
+      heading: request.heading,
+      requested_by: agentId,
+      requested_at: new Date().toISOString(),
+    };
+
+    // Audit prose, fire-and-forget like the spent-finding: an awaited write here
+    // is one more way to leave the slot set with no prompt behind it.
+    void appendAgentFinding(
+      this.taskId,
+      'system',
+      `Tool-call approval requested: ${request.server}:${request.tool} — ${request.heading}`,
+      'decision',
+    ).catch(() => {});
+
+    const buttonValue = `${this.taskId}|${request.digest}`;
+    const blocks = [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: `*Approval needed:* ${request.summary}` },
+      },
+      {
+        type: 'context',
+        elements: [{
+          type: 'mrkdwn',
+          text: `Requested by \`${agentId}\` · approving runs this one call once`,
+        }],
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Approve' },
+            action_id: 'approve_tool_call',
+            value: buttonValue,
+            style: 'primary',
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Deny' },
+            action_id: 'deny_tool_call',
+            value: buttonValue,
+            style: 'danger',
+          },
+        ],
+      },
+    ];
+
+    try {
+      // Flush before posting: the resolution arrives on a *different* instance
+      // (the task is about to stop and be reloaded by the button handler), so
+      // the slot must be on disk before the park, not 500ms later.
+      await this.save(true);
+      await this.postInteractiveToUser(
+        `Approve tool call: ${request.heading}?`,
+        blocks,
+        'tool_call',
+        undefined,
+        undefined,
+        request.digest,
+      );
+    } catch (error) {
+      // The slot's presence means "a prompt exists in Slack" — the same-digest
+      // re-arm branch and the one-at-a-time refusal both key off it. Anything
+      // that fails between setting it and the prompt landing must therefore
+      // clear it, or the task spends an hour refusing every call and a retry
+      // parks it against a button nobody can see. This catch covers the flush
+      // as well as the post for that reason. Rethrow so the gate's fail-closed
+      // wrapper denies this attempt.
+      this.metadata.pending_tool_approval = undefined;
+      await this.save(true).catch((saveError) =>
+        logger.warn('task', `Failed to clear the pending tool-approval slot`, saveError),
+      );
+      throw error;
+    }
+
+    // Park: freeze the status so the wind-down doesn't resurface "working…",
+    // and defer the stop to turn-end so stopping the queue doesn't close the
+    // input stream under this in-flight hook.
+    this.suspendStatus();
+    this.agentProcesses.get(agentId as AgentName)?.deferTeardown(() => this.stop());
+    return 'posted';
+  }
+
+  /**
+   * Resolve a pending tool-call approval (approve side).
+   *
+   * Same synchronous read-compare-clear identity gate as
+   * {@link handleMergeApproval}: a click whose digest doesn't match the slot is
+   * a stale no-op and can never authorize the call currently pending. On match
+   * the grant is *stored*, not executed — the agent spends it by retrying its
+   * own call, which keeps the action running through the same audited MCP path
+   * as everything else.
+   */
+  async handleToolCallApproval(
+    approver: { id: string; name: string } | undefined,
+    expectedDigest: string,
+  ): Promise<'resolved' | 'stale'> {
+    const pending = this.metadata.pending_tool_approval;
+    if (!pending || pending.digest !== expectedDigest) {
+      logger.warn(
+        'task',
+        `Stale tool-call approval for ${expectedDigest} on task ${this.taskId} — ` +
+        `slot ${pending ? `holds ${pending.digest}` : 'is empty'}`,
+      );
+      return 'stale';
+    }
+    // The Slack message never expires on its own, so a prompt found days later
+    // would otherwise resolve and mint a fresh spendable grant against state the
+    // approver never saw. Bound the render→click interval, not just grant→spend.
+    if (Date.parse(pending.requested_at) <= Date.now() - PENDING_APPROVAL_TTL_MS) {
+      logger.warn(
+        'task',
+        `Expired tool-call approval for ${expectedDigest} on task ${this.taskId} — requested ${pending.requested_at}`,
+      );
+      this.metadata.pending_tool_approval = undefined;
+      await this.save(true);
+      await appendAgentFinding(
+        this.taskId,
+        'system',
+        `Tool-call approval expired unspent: ${pending.server}:${pending.tool} — ${pending.heading}`,
+        'decision',
+      );
+      return 'stale';
+    }
+    this.metadata.pending_tool_approval = undefined;
+
+    // Dedupe on digest so two prompts for the same call cannot become two
+    // grants: "cannot be spent twice" has to hold per *call*, not per grant.
+    const now = new Date();
+    this.metadata.approved_tool_calls = [
+      ...(this.metadata.approved_tool_calls ?? []).filter((a) => a.digest !== pending.digest),
+      {
+        digest: pending.digest,
+        server: pending.server,
+        tool: pending.tool,
+        approved_by: approver?.id,
+        approved_at: now.toISOString(),
+        expires_at: new Date(now.getTime() + APPROVAL_TTL_MS).toISOString(),
+      },
+    ];
+
+    // Cancel the park armed by the gate hook on the requesting agent —
+    // approval means "continue", so the deferred stop must not fire and tear
+    // down the task we just approved.
+    this.agentProcesses.get(pending.requested_by as AgentName)?.clearPendingTeardown();
+
+    // Durable, not debounced: the agent's retry reads this from a reloaded
+    // instance, so the grant has to be on disk before the reactivation below.
+    await this.save(true);
+
+    const bySuffix = approver?.name ? ` by ${approver.name}` : '';
+    await appendAgentFinding(
+      this.taskId,
+      'system',
+      `Tool call approved${bySuffix}: ${pending.server}:${pending.tool} — ${pending.heading}`,
+      'decision',
+    );
+    // Wake the agent that owns the grant: only a byte-identical retry from the
+    // requester spends it, and routing through the PM alone adds a
+    // re-delegation hop to the TTL clock.
+    const requester = (pending.requested_by || 'pm-agent') as AgentName;
+    emitEvent('approval:resolved', this.taskId, { type: 'tool_call', approve: true });
+    await this.sendMessage(AGENT_PROMPTS.existingTask, requester);
+    return 'resolved';
+  }
+
+  /**
+   * Resolve a pending tool-call approval (deny side). Same identity gate;
+   * clears the slot and grants nothing. No grant is ever stored on this path.
+   */
+  async handleToolCallDenial(expectedDigest: string): Promise<'resolved' | 'stale'> {
+    const pending = this.metadata.pending_tool_approval;
+    if (!pending || pending.digest !== expectedDigest) {
+      logger.warn(
+        'task',
+        `Stale tool-call denial for ${expectedDigest} on task ${this.taskId} — ` +
+        `slot ${pending ? `holds ${pending.digest}` : 'is empty'}`,
+      );
+      return 'stale';
+    }
+    this.metadata.pending_tool_approval = undefined;
+
+    this.agentProcesses.get(pending.requested_by as AgentName)?.clearPendingTeardown();
+
+    // Durable, matching the approve path: a denial lost to a crash in the
+    // debounce window would leave the slot set and block every later call.
+    await this.save(true);
+    await appendAgentFinding(
+      this.taskId,
+      'system',
+      `Tool call denied by user: ${pending.server}:${pending.tool} — ${pending.heading}`,
+      'decision',
+    );
+    emitEvent('approval:resolved', this.taskId, { type: 'tool_call', approve: false });
     await this.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
     return 'resolved';
   }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -182,6 +182,15 @@ export interface AgentDef {
    */
   maxMode?: MaxModeSpec;
 
+  /**
+   * Tool approval policy for the MCP servers this agent mounts, resolved from
+   * each server's `archie` block in the plugins repo's `.mcp.json`. When
+   * present, a PreToolUse gate intercepts calls to those servers: `allow` tools
+   * pass ungated, `ask` tools require a per-call Slack approval, `deny` tools
+   * never run. See docs/architecture/tool-approvals.md.
+   */
+  mcpPolicy?: import('../agents/tool-approval-gate.js').McpToolPolicy;
+
   /** Maximum agentic turns before stopping (default: 100) */
   maxTurns?: number;
 

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -342,6 +342,28 @@ export interface TaskMetadata {
     requested_by: string; // agent id — to clear its parked teardown on resolution
     requested_at: string; // ISO 8601, for the audit finding
   };
+  /**
+   * The single pending MCP tool-call approval (written by the PreToolUse gate
+   * in `tool-approval-gate.ts`, cleared on resolution, on a failed Slack post,
+   * or by ageing out). One at a time by design: a queue of pending approvals
+   * invites clearing them in a batch, which is the accident the gate exists to
+   * stop.
+   */
+  pending_tool_approval?: {
+    digest: string;       // identity of the exact (server, tool, arguments) call
+    server: string;       // MCP server key, for the audit finding
+    tool: string;         // bare tool name
+    summary: string;      // rendered prompt body shown to the approver
+    heading: string;      // one-line heading (the tool's description, or server:tool)
+    requested_by: string; // agent id — woken on approval; park cleared on resolution
+    requested_at: string; // ISO 8601
+  };
+  /**
+   * Grants approved but not yet spent. Each is one-shot and bound to a digest
+   * of the exact call, so it cannot be redirected to a different call or
+   * replayed. Expired entries are pruned on read.
+   */
+  approved_tool_calls?: ApprovedToolCall[];
   research_budget_extra?: number;    // Additional research budget granted via Slack approval (+5 per approval)
   research_request_count?: number;   // Persisted research request count (survives stop/reactivate)
   failure_counter?: number;          // Consecutive recovery attempts (Stage 3 idle detection)
@@ -353,6 +375,20 @@ export interface TaskMetadata {
   pending_trigger_id?: string;       // Trigger ID proposed by this task, awaiting approve/deny (read by handleTriggerApproval/Denial)
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * A human-approved, single-use permission to run one gated MCP tool call.
+ * Bound to `digest` — a hash of the server, tool and every argument — so it is
+ * spendable on that call and no other.
+ */
+export interface ApprovedToolCall {
+  digest: string;
+  server: string;
+  tool: string;
+  approved_by?: string;  // Slack user id of the approver, for the audit finding
+  approved_at: string;   // ISO 8601
+  expires_at: string;    // ISO 8601 — unspent grants go stale (APPROVAL_TTL_MS)
 }
 
 export interface LogEntry {

--- a/tools/e2e/tool-gate-check.test.ts
+++ b/tools/e2e/tool-gate-check.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toolCallApprovalRequests,
+  firstToolCallRef,
+  nonceCount,
+  decideGate,
+  type GateEvent,
+} from './tool-gate-check.js';
+
+const approval = (ref: string): GateEvent => ({
+  type: 'approval:requested',
+  data: { approvalType: 'tool_call', ref },
+});
+
+describe('event scanning', () => {
+  it('finds tool_call approvals and ignores every other approval type', () => {
+    const events: GateEvent[] = [
+      { type: 'task:created' },
+      { type: 'approval:requested', data: { approvalType: 'edit_mode' } },
+      approval('d1'),
+      { type: 'approval:resolved', data: { type: 'tool_call', approve: true } },
+    ];
+    expect(toolCallApprovalRequests(events)).toHaveLength(1);
+    expect(firstToolCallRef(events)).toBe('d1');
+  });
+
+});
+
+
+describe('decideGate', () => {
+  const good = { approvalRequests: 1, markerCountAtApprovalRequest: 0, markerCountAfterApproval: 1 };
+
+  it('passes the intended run', () => {
+    expect(decideGate(good)).toEqual({ pass: true, failures: [] });
+  });
+
+  it('fails when the gate never intercepted', () => {
+    const verdict = decideGate({ ...good, approvalRequests: 0 });
+    expect(verdict.pass).toBe(false);
+    expect(verdict.failures.join()).toContain('did not intercept');
+  });
+
+  // The regression this whole check exists for: deny not blocking execution.
+  it('fails when the mutation ran before approval', () => {
+    const verdict = decideGate({ ...good, markerCountAtApprovalRequest: 1, markerCountAfterApproval: 2 });
+    expect(verdict.pass).toBe(false);
+    expect(verdict.failures.join()).toContain('deny did not block execution');
+  });
+
+  it('fails when the grant is never spent or spent twice', () => {
+    expect(decideGate({ ...good, markerCountAfterApproval: 0 }).failures.join()).toContain('never spent');
+    expect(decideGate({ ...good, markerCountAfterApproval: 2 }).failures.join()).toContain('more than once');
+  });
+
+  it('fails when extra approvals were requested', () => {
+    const verdict = decideGate({ ...good, approvalRequests: 2 });
+    expect(verdict.pass).toBe(false);
+    expect(verdict.failures.join()).toContain('expected 1');
+  });
+});

--- a/tools/e2e/tool-gate-check.ts
+++ b/tools/e2e/tool-gate-check.ts
@@ -1,0 +1,204 @@
+/**
+ * archie-e2e tool-approval-gate check — assert the MCP tool approval gate on a
+ * live instance.
+ *
+ * Usage: npx tsx tools/e2e/tool-gate-check.ts        (requires a booted instance)
+ *
+ * Why this is a live check and not a unit test: the gate rests on the Claude
+ * CLI delivering `mcp__*` tool calls to `PreToolUse` hooks and honouring
+ * `permissionDecision: 'deny'` — behaviour that lives in the CLI binary, is
+ * version-coupled exactly like the egress allowlist (which silently regressed
+ * across a CLI bump once and ran open for six weeks), and cannot be exercised
+ * by unit tests over a fake port. This check drives a real agent at a real
+ * gated MCP tool and asserts what actually executed.
+ *
+ * The fixture is the `gatecheck` example plugin: a stub MCP server whose one
+ * mutation (`write_marker`) appends to a marker file under the bind-mounted
+ * workdir — observable from the host. The `gatecheck` server's `archie` block
+ * in `.mcp.json` allows `get_status` and leaves everything else on `ask`.
+ *
+ * Asserted, in order:
+ *   1. A gated call produces an `approval:requested` event with
+ *      `approvalType: 'tool_call'` and a digest ref — the interception fires.
+ *   2. The marker file does NOT contain the nonce at that point — deny actually
+ *      blocked execution, and nothing reached the MCP server.
+ *   3. After approving via the API, the marker gains the nonce EXACTLY ONCE —
+ *      the grant is spendable and single-use.
+ *   4. Only one tool_call approval was requested — the readonly `get_status`
+ *      call passed ungated.
+ *
+ * Pure core: event scanning + verdict functions, unit-tested in
+ * tool-gate-check.test.ts. The CLI main only does HTTP + file polling.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { randomBytes } from 'crypto';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { resolveBaseUrl } from './config.js';
+
+// ---- Pure core (unit-tested) ----
+
+export interface GateEvent {
+  type: string;
+  data?: Record<string, unknown>;
+}
+
+/** All tool_call approval requests among the task's events, oldest first. */
+export function toolCallApprovalRequests(events: GateEvent[]): GateEvent[] {
+  return events.filter(
+    (e) => e.type === 'approval:requested' && e.data?.approvalType === 'tool_call',
+  );
+}
+
+/** The digest ref of the first tool_call approval request, if any. */
+export function firstToolCallRef(events: GateEvent[]): string | undefined {
+  const first = toolCallApprovalRequests(events)[0];
+  const ref = first?.data?.ref;
+  return typeof ref === 'string' && ref ? ref : undefined;
+}
+
+/** Count occurrences of the nonce among marker-file lines. */
+export function nonceCount(markerText: string, nonce: string): number {
+  return markerText.split('\n').filter((line) => line.trim() === nonce).length;
+}
+
+export interface GateVerdict {
+  pass: boolean;
+  failures: string[];
+}
+
+/** Final verdict over the run's observations. */
+export function decideGate(observed: {
+  approvalRequests: number;
+  markerCountAtApprovalRequest: number;
+  markerCountAfterApproval: number;
+}): GateVerdict {
+  const failures: string[] = [];
+  if (observed.approvalRequests < 1) {
+    failures.push('no tool_call approval was requested — the PreToolUse gate did not intercept the MCP call');
+  }
+  if (observed.markerCountAtApprovalRequest !== 0) {
+    failures.push(
+      `marker was written ${observed.markerCountAtApprovalRequest}× before approval — deny did not block execution`,
+    );
+  }
+  if (observed.markerCountAfterApproval !== 1) {
+    failures.push(
+      `marker written ${observed.markerCountAfterApproval}× after approval (expected exactly 1) — ` +
+      (observed.markerCountAfterApproval === 0
+        ? 'the grant was never spent'
+        : 'the single-use grant was spent more than once'),
+    );
+  }
+  if (observed.approvalRequests > 1) {
+    failures.push(
+      `${observed.approvalRequests} tool_call approvals were requested (expected 1) — ` +
+      'either the readonly tool was gated or the retry re-prompted instead of spending the grant',
+    );
+  }
+  return { pass: failures.length === 0, failures };
+}
+
+// ---- CLI main ----
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const MARKER_FILE = join(REPO_ROOT, 'workdir', 'e2e', 'gate-marker.log');
+
+function markerText(): string {
+  return existsSync(MARKER_FILE) ? readFileSync(MARKER_FILE, 'utf8') : '';
+}
+
+async function api<T>(baseUrl: string, path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${baseUrl}/api${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
+  });
+  if (!res.ok) throw new Error(`${init?.method ?? 'GET'} ${path} → ${res.status}: ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function pollUntil<T>(
+  what: string,
+  capSeconds: number,
+  probe: () => Promise<T | undefined>,
+): Promise<T> {
+  const deadline = Date.now() + capSeconds * 1000;
+  for (;;) {
+    const result = await probe();
+    if (result !== undefined) return result;
+    if (Date.now() > deadline) throw new Error(`timed out after ${capSeconds}s waiting for ${what}`);
+    await sleep(5000);
+  }
+}
+
+async function main(): Promise<void> {
+  const dotenv = existsSync(join(REPO_ROOT, '.env')) ? readFileSync(join(REPO_ROOT, '.env'), 'utf8') : undefined;
+  const baseUrl = resolveBaseUrl(process.env, dotenv);
+  const nonce = `E2E-GATE-${randomBytes(4).toString('hex')}`;
+
+  console.log(`tool-gate-check: instance ${baseUrl}, nonce ${nonce}`);
+  console.log(`tool-gate-check: marker file ${MARKER_FILE}`);
+
+  // 1. Create the task: PM delegates to the gatekeeper fixture agent.
+  const { task_id } = await api<{ task_id: string }>(baseUrl, '/tasks', {
+    method: 'POST',
+    body: JSON.stringify({
+      message:
+        `[${nonce}] Ask the gatekeeper agent to do exactly this, in order: ` +
+        `(1) call its get_status tool and note the result; ` +
+        `(2) call its write_marker tool with value "${nonce}". ` +
+        `If a call reports that human approval was requested, that is expected — wait, and when ` +
+        `reactivated re-issue the same write_marker call with the same value once. ` +
+        `Do not retry beyond that, do not work around a denial, and report the final tool results.`,
+    }),
+  });
+  console.log(`tool-gate-check: task ${task_id}`);
+
+  const events = async (): Promise<GateEvent[]> =>
+    (await api<{ events: GateEvent[] }>(baseUrl, `/tasks/${task_id}/events`)).events;
+
+  // 2. Wait for the gate to intercept — the approval request event.
+  const ref = await pollUntil('a tool_call approval request', 420, async () => firstToolCallRef(await events()));
+  const markerCountAtApprovalRequest = nonceCount(markerText(), nonce);
+  console.log(`tool-gate-check: approval requested (ref ${ref}); marker count now ${markerCountAtApprovalRequest}`);
+
+  // 3. Approve that exact call via the API path.
+  await api(baseUrl, `/tasks/${task_id}/approve`, {
+    method: 'POST',
+    body: JSON.stringify({ type: 'tool_call', approve: true, ref }),
+  });
+  console.log('tool-gate-check: approved — waiting for the retry to spend the grant');
+
+  // 4. Wait for the marker to land, then let the task settle briefly and take
+  //    the final counts (a duplicate spend would appear here as a second line).
+  await pollUntil('the marker write after approval', 420, async () =>
+    nonceCount(markerText(), nonce) >= 1 ? true : undefined,
+  );
+  await sleep(20_000);
+
+  const verdict = decideGate({
+    approvalRequests: toolCallApprovalRequests(await events()).length,
+    markerCountAtApprovalRequest,
+    markerCountAfterApproval: nonceCount(markerText(), nonce),
+  });
+
+  if (!verdict.pass) {
+    console.error('tool-gate-check: FAIL');
+    for (const failure of verdict.failures) console.error(`  - ${failure}`);
+    process.exit(1);
+  }
+  console.log('tool-gate-check: PASS');
+  console.log('  - gated MCP call intercepted by PreToolUse (approval requested, nothing executed)');
+  console.log('  - approval spent exactly once; readonly tool passed ungated');
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  main().catch((error) => {
+    console.error(`tool-gate-check: ERROR — ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Implements #168 — a human-in-the-loop approval gate for critical MCP tools. Draft: the mechanism is complete, tested and documented; what wants a maintainer's eye is the config shape, which this revision deliberately simplified.

## The config

One block per server, in the plugins repo's root `.mcp.json`, next to the connection config it governs:

```json
"tramline": {
  "command": "node",
  "args": ["${MCP_TRAMLINE_SERVER_PATH}"],
  "description": "Tramline — mobile release management",
  "archie": {
    "default": "ask",
    "allow": ["list_apps", "get_release", "get_release_analytics"],
    "deny":  ["start_release", "stop_release"]
  }
}
```

| Tier | Meaning |
|---|---|
| `allow` | runs with no gate |
| `ask` | a human approves **that specific call**, arguments shown, in Slack |
| `deny` | never runs — and is withheld from every agent that mounts the server |

`default` covers everything unlisted and is `ask` when omitted, so a tool the vendor ships next quarter arrives gated rather than silently open. Invert it per server: list the safe reads for a mostly-dangerous server, list the exceptions for a mostly-safe one. The tier names are Claude Code's own permission vocabulary — no new concepts to learn.

`ask` is the whole point of the feature: it is the state that does not exist today. Right now a tool is either allowed and then invoked with no human check, or blocked outright — which is why every tool that mutates an external system is currently just switched off (`release-manager.md` carries 59 hand-listed denials, and a comment reading "re-running a failed job is a planned capability, deliberately not enabled yet").

## Default behaviour does not change

**A server with no `archie` block is unmanaged: no hook is attached, and every one of its tools behaves exactly as before.** Rollout is opt-in per server, no existing plugin changes meaning, and an agent whose servers are all unmanaged runs the same code path it ran before. The fail-safe `ask` default applies only *within* a server someone has already opted in.

## The policy belongs to the server, not the agent

Which of TeamCity's tools are dangerous is a fact about TeamCity. Declaring it once per server covers every agent that mounts it, and three things fall out for free:

- **The PM is covered** like any other agent — its overlay resolves servers through the same `resolveAgentMcpServers`. Under a frontmatter-based policy it silently wasn't, and it is the one agent holding the admin-panel server.
- **`deny` replaces the copy-pasted denylists.** In `archie-plugins`, mobile's 23 `disallowedTools` entries are a *strict subset* of release-manager's 59 — the same facts about the same three servers, maintained twice. There is currently no agent pair that diverges at all.
- **Renaming a server key moves its policy with it.** No second place to update, no orphaned policy.

Frontmatter `disallowedTools` still works and merges on top, for the case where one agent must not touch something its peers may (`restore_streak_days` on growth-ops/ops, which the PM must keep — see the consumer PR).

## What the approver reads

The heading is the policy's optional **title** for the tool, then the call's real arguments:

```
Release this rollout to 100% of users immediately — irreversible
Tool: `tramline:fully_release_rollout`
Arguments: id=`226284f5-…`
```

```json
"archie": {
  "default": "ask",
  "titles": { "fully_release_rollout": "Release this rollout to 100% of users immediately — irreversible" }
}
```

Write one only where the method name is a bad button on its own — `fully_release_rollout` and `fully_release_previous_rollout` are one word apart and mean very different things. An untitled tool renders as `Run server:tool`: terse but honest, with the sanitized arguments either way.

Both halves are rendered and sanitized **by the engine, never by the agent** — an agent's own summary of what it intends is never what the human reads. Argument values are the one part it controls, and unescaped a string argument can append its own lines to the message ("*Note:* pre-agreed, safe to approve"); values and titles alike are flattened, sigil-stripped and capped, arguments are code-spanned, and their count is capped too because Slack refuses a section over 3000 characters. Proven by test. An agent that wants to explain itself does so as its own message in the thread, beside the button rather than inside it.

## Mechanism

- **`PreToolUse`, not `canUseTool`.** Every agent runs under `permissionMode: bypassPermissions`, which the SDK documents as auto-approving calls past `canUseTool` ("PreToolUse hook denies bypass canUseTool", sdk.d.ts). The hook is the same layer the filesystem guard already trusts for read-only mode. Consequence: no pause-and-resume of the original call — deny, then a single-use grant that the agent's retry spends, so the action always runs through the same audited MCP path.
- **Approval is bound to the exact call**: `sha256(server, tool, canonicalized args)`. It cannot be redirected to another tool, other arguments, or spent twice.
- **Lifecycle invariants**, each present because an adversarial review of the predecessor branch broke the version without it: one pending request per task, 1h age-out, no supersede; a failed Slack post clears the slot (else the task wedges refusing everything for an hour); grants dedupe by digest; the spend is durable while grants are debounced (a crash must not resurrect a spent single-use token); an expired click is a stale no-op that mints nothing; findings for requested / approved-by-name / denied / expired-unspent / actually-spent.
- **Fail closed.** Any error evaluating a managed call is a deny. Unmanaged tools are classified before the try block and proceed even when the gate's own dependencies are broken.
- **Strict validation.** A malformed `archie` block fails the load — unknown tier, unknown key, a tool in two tiers. A misspelled tier (`asks:`) would otherwise read as "nothing listed", quietly dropping every tool in it to the default. A server *key* that cannot survive the `mcp__<server>__<tool>` round trip (one containing `__`) is rejected too: the gate would never match its calls, so every tool of that server would run ungated.
- **Trust model = the existing gates.** Any workspace member may resolve via Slack (identity recorded for the audit trail, external/guest identity omitted, exactly like merge and edit mode), and the CLI/API path resolves with `type: 'tool_call'` + `ref` (the digest) like every other approval type — which is also what makes the e2e harness able to drive it.

## Review round

Reviewed by an independent pass focused on stability and minimalism; the findings that survived verification are fixed in this revision:

- **Park-with-no-button (major).** The failure path that clears the pending slot covered only the Slack post, while a durable flush and an awaited findings-write sat between setting the slot and that try block. Either throwing left the slot set, and the same-digest retry then parked the task against a prompt that was never posted. The findings write is now fire-and-forget (as the spent-finding already was) and the catch covers the flush.
- **Unenforceable policy on an awkward server key (major).** A key containing `__` loaded happily and then never matched any call — silently ungating the whole server. Now rejected at load, with a test.
- **The spend was not actually durable.** It was flushed fire-and-forget, so a crash after the tool ran could leave the single-use grant spendable again — which the docs claimed was closed. The splice stays synchronous (that is what stops a double spend in one turn); the write is now awaited before the call proceeds, and a failed write logs and proceeds rather than refusing an approved action.
- **A cross-agent retry parked an agent nothing would unpark.** Both resolution paths clear the requester's teardown alone, so a second agent hitting the same live slot armed a deferred stop that fired mid-retry. It is told to wait instead.
- **Hardening:** own-property lookups in `classifyToolCall` (a tool named `constructor` reached a prototype value outside the fail-closed try); the rendered argument list is capped by count as well as by value length (an uncapped list overflows Slack's 3000-char section limit and makes the call permanently unapprovable); `null` arguments are now shown, since the digest covers them and hiding one had the approver approve an argument they never saw.
- **Deleted:** an `ApprovedToolCall.heading` field that was written and never read, a `proceed()` helper whose comment justified it with something untrue, the hand-rolled copy of `mcpToolName` in `spawn.ts`, ~30 lines of module-header prose that restated the architecture doc, and 4 redundant test cases.

Left deliberately: a malformed policy in the plugins repo throws inside every `Task.get`, not only at boot (fail-closed and loud beats a half-applied policy, but validating at sync time and keeping the previous config would fail equally closed — worth deciding separately); and the two near-clone Slack button handlers, which mirror the existing merge-handler shape.

## Changes since the first revision

The mechanism is unchanged; the configuration surface shrank by about two thirds.

- **Policy moved from agent frontmatter (`metadata.archie.mcpPolicy`) to the server entry in `.mcp.json`** — the reasons are in the section above. Verified against Claude Code 2.1.237 that an unknown key inside a server entry is ignored with no diagnostics, while a genuinely invalid entry is reported and skipped, so the file stays usable by Claude Code itself. `description` had already established the precedent; both keys are stripped before the SDK sees the config.
- **`requireTitles` is gone; `titles` is now optional.** The first revision required a title for every gated tool. The second replaced titles entirely with the tool's own description reported by its MCP server — which the live run then proved unreachable (see below), so titles are back as an optional per-tool override and the untitled case falls back to the bare `server:tool` identity.
- **The `rw` tier is gone.** It had no consumer, and "silently denied unless edit mode happens to be on" is a confusing thing for an agent to hit. It can come back if a case appears.
- **Tiers renamed** `auto`/`human` → `allow`/`ask`, plus `deny`, matching Claude Code's permission vocabulary.
- **The PM is now covered**, as a consequence of the above rather than as a fix.
- **Fixed: the gate source contained two literal NUL bytes**, which made git treat `src/agents/tool-approval-gate.ts` as binary — GitHub showed `0 additions, 0 deletions` for the single most security-relevant file in the earlier revision. The digest now joins its parts as a JSON array; the file is plain text and reviewable.
- **Rebased onto current main** (the first revision was 136 commits behind) and squashed to one commit.

## Live verification

Booted from this branch and run against a real instance (attested `git_sha` matching the checkout), because the one thing no unit test can see is whether the Claude CLI still delivers MCP tool calls to `PreToolUse` under `bypassPermissions`:

```
tool-gate-check: approval requested (ref de72f056d7263e25); marker count now 0
tool-gate-check: approved — waiting for the retry to spend the grant
tool-gate-check: PASS
  - gated MCP call intercepted by PreToolUse (approval requested, nothing executed)
  - approval spent exactly once; readonly tool passed ungated
```

The audit trail from that task, and the marker file — bind-mounted, so non-execution is observable from the host — holding exactly one line:

```
[decision]   Tool-call approval requested: gatecheck:write_marker — Append a marker line to the shared e2e marker file
[decision]   Tool call approved: gatecheck:write_marker — Append a marker line to the shared e2e marker file
[completion] Gated tool call ran on approval de72f056d7263e25: gatecheck:write_marker
```

**What that run caught.** On the first pass the heading read `Run \`gatecheck:write_marker\`` — the fallback — even though the stub server returns a description for that tool, which I had confirmed by talking to it over stdio. A minimal repro inside the container explains it: `mcpServerStatus()` reports the server `connected` with both tools, but `description` is absent on every entry and `annotations` is `{}`. The CLI has the descriptions (it gives them to the model) and exposes them to the SDK host nowhere — that field is the only one in the whole SDK type surface that would carry them, and it comes back empty. So the description-based heading was dead code in practice, and the mechanism I had used to justify deleting titles does not exist. Titles are back, optional, and the `docs` say why with the date. Side finding, pre-existing and not from this branch: the same empty `annotations` means `readOnly` — used elsewhere to phrase the Slack status line — is getting nothing either.

## Testing

`tsc` clean; full suite 96 files / 1528 tests green. New coverage: the gate (tiers, digest binding, rendering/sanitization of both arguments and descriptions, fail-closed paths), the task lifecycle on the real `Task` prototype methods via the merge-approval harness pattern, `.mcp.json` policy parsing and its rejection cases, and the registry wiring (policy attaches to every mounting agent, does not leak to servers the agent has not mounted, `deny` lands in `disallowedTools` deduped, and the PM is covered through its overlay).

Plus a **live tripwire**: `tools/e2e/tool-gate-check.ts` with the `gatecheck` example plugin (stub MCP server, dependency-free) drives a booted instance over the HTTP API and asserts interception, deny-blocks-execution (a marker file under the bind-mounted workdir proves non-execution from the host), single-use spend, and that the `allow`-tier tool passes ungated. Same rationale as the egress check: `PreToolUse` delivery for MCP tools lives in the Claude CLI, is version-coupled, and silently regressed across a CLI bump once. Documented as section 3c of the `archie-e2e` skill. Run it after any SDK bump before trusting the gate with a write-scoped credential.

## Consumer

`sweatco/archie-plugins#140` is the pilot, rewritten onto this schema. Tramline's entire rule becomes twelve lines in `.mcp.json` — `default: ask` with its nine reads under `allow` — so its 36 write tools move from "flatly denied" to "held for per-call approval", which is the capability that PR has been waiting on. Nothing outside Tramline changes: the other 12 agents' effective permissions are byte-identical, and every other server keeps its denials in agent frontmatter untouched.

That PR also carries the vendored `tramline-mcp` bundle with honest per-tool descriptions from `sweatco/tramline#139` — which matters more under this revision than it did before, since the approval button's heading *is* the tool's own description now. Merge order is load-bearing and documented there: tramline#139 deployed to the instance (it merged on 7 Aug) → engine deploy → verify a live button → plugins → swap `MCP_TRAMLINE_API_KEY` to write scope last.

## Relation to #260

#260 was the Tramline-specific first cut, which went through four adversarial review rounds; closing it in favour of this. Every property listed above is regression-tested here.

## Open questions

1. **Config shape** — `default` + `allow`/`ask`/`deny` per server in `.mcp.json`. Comfortable? The alternative considered and rejected was a sidecar `mcp-policy.json` keyed by server name: zero risk to the `.mcp.json` schema, but two files to keep in sync and mandatory key-drift validation.
2. **Per-agent divergence has no expression** beyond `disallowedTools`. No current agent pair needs one; the coarse tool meanwhile is a second server entry with its own credential (`tramline` read-only, `tramline-rw` gated), which also gets credential scoping right. Confirm it stays out of v1?
3. **Reusable approvals** ("approve this tool for the rest of the task") — listed in the issue as a possible follow-up. Not included; the per-call default is the point. Confirm it stays out?
4. **A grant is not bound to the requesting agent** — the digest covers server, tool and arguments, so another agent on the same task making the byte-identical call could spend it. Reading it as "the *action* was approved" is intentional, but `requested_by` in the audit trail then names the requester rather than the executor. Tighten, or document as is (currently documented)?
5. **Redaction** of secret-looking argument values in the preview (the issue's open question) — not addressed beyond sanitization and capping. v1 or follow-up?
