### PR TITLE
fix(slack): stop dropping message content Slack ships in shapes we don't parse

### DIFF
--- a/src/agents/__tests__/explore-format.test.ts
+++ b/src/agents/__tests__/explore-format.test.ts
@@ -1,0 +1,39 @@
+/**
+ * `read_channel_history` / `read_thread` share the ingestion extractor but had
+ * their own renderer, which printed only `m.text`. An attachment-only message —
+ * a Grafana alert, a Bugsnag error, 57 of 60 messages in #mobile-alerts —
+ * therefore reached the agent completely blank.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatExploreMessages } from '../tools.js';
+
+const author = { id: 'U1', username: 'ramin', realName: 'Ramin M' };
+
+describe('formatExploreMessages', () => {
+  it('renders an attachment-only message instead of an empty body', () => {
+    const out = formatExploreMessages([{
+      user: author,
+      ts: '1786127951.864179',
+      text: '',
+      attachments: [{ text: '[FIRING:10] StepsConversion (https://grafana.example.com/a)\n**Firing**\nValue: C=1' }],
+    }]);
+
+    expect(out).toContain('[FIRING:10] StepsConversion');
+    expect(out).toContain('https://grafana.example.com/a');
+    expect(out).toContain('msg:1786127951.864179');
+  });
+
+  it('still renders plain text, files and reactions', () => {
+    const out = formatExploreMessages([{
+      user: author,
+      ts: '2.0',
+      text: 'have a look',
+      files: [{ id: 'F1', name: 'shot.png', mimetype: 'image/png', url_private: 'https://x/y' }],
+      reactions: [{ name: 'eyes', count: 2 }],
+    }]);
+
+    expect(out).toContain('have a look');
+    expect(out).toContain('shot.png');
+    expect(out).toContain('eyes');
+  });
+});

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -21,7 +21,7 @@ import { getGitHubClient, parseCheckRef } from '../connectors/github/client.js';
 import { gitExec } from '../connectors/github/repo-clone.js';
 import { hydrateBranchState, findBranchStateByPR, assignPrNumber } from '../connectors/github/branch-state.js';
 import { taskBranchName } from '../connectors/github/branch-naming.js';
-import { appendAgentFinding, appendArtifactShared, isThreadMuted } from '../tasks/persistence.js';
+import { appendAgentFinding, appendArtifactShared, isThreadMuted, renderMessageForContext } from '../tasks/persistence.js';
 import { copyArtifactToShared, assertReadable } from './artifacts.js';
 import { aggregateTaskUsage, formatTaskUsageReport } from './task-usage.js';
 import { logger } from '../system/logger.js';
@@ -82,15 +82,19 @@ function taskSlackChannelIds(task: Task): Set<string> {
 }
 
 /** Render explore messages in the same `@<id:name> | msg:ts` shape the PM sees elsewhere. */
-function formatExploreMessages(messages: SlackThreadMessage[]): string {
+export function formatExploreMessages(messages: SlackThreadMessage[]): string {
   return messages
     .map((m) => {
       const who = m.user.realName || m.user.username;
-      const files = m.files?.length ? `\n  [files: ${m.files.map((f) => f.name).join(', ')}]` : '';
-      const reactions = m.reactions?.length
-        ? `\n  [reactions: ${m.reactions.map((r) => `:${r.name}:×${r.count}`).join(' ')}]`
-        : '';
-      return `<@${m.user.id}:${who}> | msg:${m.ts}\n${m.text}${files}${reactions}`;
+      // Share the knowledge log's renderer rather than re-implementing it: this
+      // used to print `m.text` alone, so an attachment-only message — a Grafana
+      // alert, a Bugsnag error, 57 of 60 messages in #mobile-alerts — reached
+      // the agent completely blank.
+      const body = renderMessageForContext(
+        { text: m.text, files: m.files, attachments: m.attachments, reactions: m.reactions },
+        { redacted: false },
+      );
+      return `<@${m.user.id}:${who}> | msg:${m.ts}\n${body}`;
     })
     .join('\n\n');
 }

--- a/src/connectors/slack/__tests__/client.test.ts
+++ b/src/connectors/slack/__tests__/client.test.ts
@@ -289,6 +289,31 @@ describe('fetchSlackThread — link chips survive the Block Kit walk', () => {
     expect(thread.messages[0].text).toBe(`see ${permalink}`);
   });
 
+  it('does not re-append a query-string URL the blocks already rendered', async () => {
+    // `text` escapes the ampersand and `blocks` do not, so an undecoded
+    // comparison saw the rendered URL as missing and appended it a second time
+    // — hitting every Grafana silence link and Bugsnag error URL.
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '408.0',
+          user: 'UHUMAN',
+          text: 'see <https://example.com/?a=1&amp;b=2|example.com/?a=1&amp;b=2> please',
+          blocks: richText([
+            { type: 'text', text: 'see ' },
+            { type: 'link', url: 'https://example.com/?a=1&b=2', text: 'example.com/?a=1&b=2' },
+            { type: 'text', text: ' please' },
+          ]),
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '408.0', '408.0');
+
+    expect(thread.messages[0].text).toBe('see https://example.com/?a=1&b=2 please');
+    expect(thread.messages[0].text.match(/example\.com/g)).toHaveLength(1);
+  });
+
   it('leaves a plain rich_text link alone', async () => {
     slackApi.conversations.replies.mockResolvedValue({
       messages: [

--- a/src/connectors/slack/__tests__/client.test.ts
+++ b/src/connectors/slack/__tests__/client.test.ts
@@ -26,8 +26,10 @@ const slackApi = {
 vi.mock('@slack/web-api', () => ({
   WebClient: vi.fn(function (this: unknown) { return slackApi; }),
 }));
+// Kept on a handle so tests can assert on what the backstop logs.
+const loggerWarn = vi.fn();
 vi.mock('../../../system/logger.js', () => ({
-  logger: { slack: vi.fn(), warn: vi.fn(), system: vi.fn(), error: vi.fn(), plain: vi.fn() },
+  logger: { slack: vi.fn(), warn: loggerWarn, system: vi.fn(), error: vi.fn(), plain: vi.fn() },
 }));
 
 type ClientModule = typeof import('../client.js');
@@ -454,6 +456,112 @@ describe('fetchSlackThread — pagination', () => {
 
     expect(thread.messages.map((m) => m.text)).toEqual(['first page', 'second page']);
     expect(slackApi.conversations.replies).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * The extractors walk a third-party payload, and they run on the path every
+ * inbound Slack message takes. A shape Slack "can't" send must still not throw:
+ * an exception here propagates out of fetchSlackThread and the message never
+ * reaches an agent at all. Six of these threw before this suite existed.
+ */
+describe('fetchSlackThread — malformed payloads never throw', () => {
+  const deepElements = (depth: number) => {
+    let node: Record<string, unknown> = { type: 'rich_text_section', elements: [{ type: 'text', text: 'deep' }] };
+    for (let i = 0; i < depth; i += 1) node = { type: 'rich_text_section', elements: [node] };
+    return { type: 'rich_text', elements: [node] };
+  };
+
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ['blocks null', { blocks: null }],
+    ['blocks not an array', { blocks: { type: 'rich_text' } }],
+    ['a block is null', { blocks: [null] }],
+    ['a block is a string', { blocks: ['nope'] }],
+    ['block elements null', { blocks: [{ type: 'rich_text', elements: null }] }],
+    ['block elements are primitives', { blocks: [{ type: 'rich_text', elements: [1, 'x', true, null] }] }],
+    ['table rows ragged', { blocks: [{ type: 'table', rows: [null, [null], [{ type: 'rich_text' }]] }] }],
+    ['table rows not an array', { blocks: [{ type: 'table', rows: 'nope' }] }],
+    ['card without title', { blocks: [{ type: 'card' }] }],
+    ['deeply nested sections', { blocks: [deepElements(400)] }],
+    ['attachments not an array', { attachments: 'nope' }],
+    ['an attachment is null', { attachments: [null] }],
+    ['attachment fields not an array', { attachments: [{ fields: 'x' }] }],
+    ['attachment fields are primitives', { attachments: [{ fields: [1, null, 'x'] }] }],
+    ['attachment blocks are primitives', { attachments: [{ blocks: [1, null] }] }],
+    ['attachment actions are primitives', { attachments: [{ actions: [null, 1] }] }],
+    ['message_blocks malformed', { attachments: [{ message_blocks: [{}, { message: null }] }] }],
+    ['files not an array', { files: 'nope' }],
+    ['reactions contain null', { reactions: [null, { name: 1 }] }],
+    ['text is not a string', { text: 12345, blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'body' } }] }],
+    ['lone surrogate in text', { text: ' \uD800 ​' }],
+  ];
+
+  for (const [name, payload] of cases) {
+    it(`survives ${name}`, async () => {
+      slackApi.conversations.replies.mockResolvedValue({
+        messages: [rawMsg({ ts: '800.0', user: 'UHUMAN', ...payload })],
+      });
+
+      const thread = await client.fetchSlackThread('C_fuzz', '800.0', '800.0');
+
+      expect(typeof thread.messages[0].text).toBe('string');
+    });
+  }
+});
+
+describe('fetchSlackThread — shared-channel redaction is unaffected by richer extraction', () => {
+  it('replaces an external author\'s message with the placeholder, carrying no content', async () => {
+    slackApi.conversations.info.mockResolvedValue({
+      ok: true,
+      channel: { id: 'C_shared', name: 'support', is_private: false, is_im: false, is_mpim: false, is_ext_shared: true },
+    });
+    slackApi.users.info.mockImplementation(async ({ user }: { user: string }) => ({
+      ok: true,
+      user: {
+        id: user, name: user, real_name: `Real ${user}`, profile: {},
+        team_id: user === 'UGUEST' ? 'THOME' : 'THOME',
+        is_restricted: user === 'UGUEST',   // multi-channel guest → external
+      },
+    }));
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '801.0', user: 'UGUEST', text: '',
+          attachments: [{ title: 'CANARY-TITLE', title_link: 'https://canary.example.com', text: 'CANARY-BODY' }],
+        }),
+      ],
+    });
+    const { renderMessageForContext } = await import('../../../tasks/persistence.js');
+
+    const thread = await client.fetchSlackThread('C_shared', '801.0', '801.0');
+    expect(thread.shared).toBe(true);
+    const msg = thread.messages[0];
+    expect(client.isExternalUser(msg.user)).toBe(true);
+
+    // Mirrors Task.append: an external author in a shared channel is written
+    // with empty content, so nothing the extractors found can escape.
+    const rendered = renderMessageForContext(
+      { text: '', files: undefined, attachments: undefined },
+      { redacted: true },
+    );
+    expect(rendered).toBe('[redacted: external participant in shared channel]');
+    expect(rendered).not.toContain('CANARY');
+  });
+
+  it('logs only JSON paths from the backstop, never the content it found', async () => {
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [rawMsg({
+        ts: '802.0', user: 'UHUMAN', text: 'covered',
+        blocks: [{ type: 'rich_text', elements: [{ type: 'rich_text_section', elements: [{ type: 'text', text: 'covered' }] }] }],
+        some_future_shape: { headline: 'SENSITIVE-CANARY' },
+      })],
+    });
+
+    await client.fetchSlackThread('C_log', '802.0', '802.0');
+
+    const logged = JSON.stringify(loggerWarn.mock.calls);
+    expect(logged).toContain('some_future_shape.headline');
+    expect(logged).not.toContain('SENSITIVE-CANARY');
   });
 });
 

--- a/src/connectors/slack/__tests__/client.test.ts
+++ b/src/connectors/slack/__tests__/client.test.ts
@@ -112,6 +112,326 @@ describe('fetchSlackThread — rootAuthorWasBot', () => {
   });
 });
 
+/**
+ * Regression: a link pasted into Slack renders as a "smart link" chip whose
+ * rich_text element type we may not recognise (`message_mention`, `canvas`, the
+ * Jira issue chip). The block walk used to drop unknown elements outright, and
+ * because a block DID produce text the legacy `text` field — which always
+ * spells the URL out — was never consulted. Net effect in prod: the user saw a
+ * Jira link in their message and Archie replied that no link had been sent.
+ */
+describe('fetchSlackThread — link chips survive the Block Kit walk', () => {
+  /** rich_text block wrapping a single section's elements. */
+  const richText = (elements: unknown[]) => [{ type: 'rich_text', elements: [{ type: 'rich_text_section', elements }] }];
+
+  it('keeps a Jira issue chip — an attachment_mention — with its ticket title', async () => {
+    // The exact element the reported bug hinged on: a pasted Jira URL that the
+    // Jira Cloud app turns into a chip. Real payload shape, from #bugs.
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '403.0',
+          user: 'UHUMAN',
+          text: 'Will be fixed with this: <https://acme.atlassian.net/browse/IO-2862|Silent retry for no-fill>',
+          blocks: richText([
+            { type: 'text', text: 'Will be fixed with this: ' },
+            {
+              type: 'attachment_mention',
+              url: 'https://acme.atlassian.net/browse/IO-2862',
+              text: 'Silent retry for no-fill',
+              app_id: 'A2RPP3NFR',
+              product_name: 'Jira Cloud',
+            },
+          ]),
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '403.0', '403.0');
+
+    expect(thread.messages[0].text)
+      .toBe('Will be fixed with this: Silent retry for no-fill (https://acme.atlassian.net/browse/IO-2862)');
+  });
+
+  it('renders a table block as rows rather than dropping it', async () => {
+    // Archie posts markdown tables; Slack hands them back in this shape, so
+    // without it the agent re-reading its own message sees no table at all.
+    const cell = (text: string) => ({
+      type: 'rich_text',
+      elements: [{ type: 'rich_text_section', elements: [{ type: 'text', text }] }],
+    });
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '404.0',
+          user: 'UHUMAN',
+          text: 'Campaign 28 Jul\nMinecraft 3,842',
+          blocks: [{ type: 'table', rows: [[cell('Campaign'), cell('28 Jul')], [cell('Minecraft'), cell('3,842')]] }],
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '404.0', '404.0');
+
+    expect(thread.messages[0].text).toContain('| Campaign | 28 Jul |');
+    expect(thread.messages[0].text).toContain('| Minecraft | 3,842 |');
+  });
+
+  it('renders a card block, whose title holds the only copy of the URL', async () => {
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '405.0',
+          user: 'UHUMAN',
+          text: '#6887 archie/task-20260806',   // flattened: no URL
+          blocks: [{
+            type: 'card',
+            title: { type: 'mrkdwn', text: '<https://github.com/acme/app/pull/6887|#6887> archie/task-20260806' },
+            subtitle: { type: 'mrkdwn', text: 'app · CI checks (5/5)' },
+          }],
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '405.0', '405.0');
+
+    expect(thread.messages[0].text).toContain('https://github.com/acme/app/pull/6887');
+    expect(thread.messages[0].text).toContain('CI checks (5/5)');
+  });
+
+  it('keeps a text-field headline the blocks never mention', async () => {
+    // Release bots put the notification headline only in `text`; the blocks
+    // carry the detail. Preferring blocks used to discard the headline.
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '406.0',
+          user: 'UHUMAN',
+          text: 'Production release was started!',
+          blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'The rollout for release *253.0.0* has *started*.' } }],
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '406.0', '406.0');
+
+    expect(thread.messages[0].text).toContain('The rollout for release');
+    expect(thread.messages[0].text).toContain('Production release was started!');
+    expect(thread.messages[0].text).not.toContain('[unparsed:');
+  });
+
+  it('recovers a URL carried by an unrecognised rich_text element', async () => {
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '400.0',
+          user: 'UHUMAN',
+          text: 'which feature flag is responsible for that task\n<https://acme.atlassian.net/browse/IO-3120>\n?',
+          blocks: richText([
+            { type: 'text', text: 'which feature flag is responsible for that task\n' },
+            { type: 'jira_issue', issue_key: 'IO-3120' }, // chip type we don't know
+            { type: 'text', text: '\n?' },
+          ]),
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '400.0', '400.0');
+
+    expect(thread.messages[0].text).toContain('https://acme.atlassian.net/browse/IO-3120');
+  });
+
+  it('keeps the URL of a message_mention chip inline, without duplicating it', async () => {
+    const permalink = 'https://acme.slack.com/archives/C03SEJYTG9W/p1785251307039969';
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '401.0',
+          user: 'UHUMAN',
+          text: `see <${permalink}>`,
+          blocks: richText([
+            { type: 'text', text: 'see ' },
+            { type: 'message_mention', message_ts: '1785251307.039969', channel_id: 'C03SEJYTG9W', url: permalink },
+          ]),
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '401.0', '401.0');
+
+    expect(thread.messages[0].text).toBe(`see ${permalink}`);
+  });
+
+  it('leaves a plain rich_text link alone', async () => {
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '402.0',
+          user: 'UHUMAN',
+          text: 'docs at <https://example.com/a|example.com/a>',
+          blocks: richText([
+            { type: 'text', text: 'docs at ' },
+            { type: 'link', url: 'https://example.com/a', text: 'example.com/a' },
+          ]),
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '402.0', '402.0');
+
+    expect(thread.messages[0].text).toBe('docs at https://example.com/a');
+  });
+});
+
+/**
+ * Regression: 57 of 60 real #mobile-alerts messages carry NO top-level text —
+ * the whole alert is an attachment card. Reading only `text`/`fallback` left the
+ * agent with "**Firing** / Value: C=1" and no alert name, no dashboard link, and
+ * (for Bugsnag) no file:line, because those live in `title`/`title_link`/
+ * `pretext`/`fields`/`blocks`.
+ */
+describe('fetchSlackThread — attachment cards', () => {
+  it('renders pretext, title + link, body, fields, nested blocks and actions', async () => {
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '500.0',
+          user: 'UHUMAN',
+          text: '',
+          attachments: [{
+            pretext: '<!subteam^S123>',
+            title: '[FIRING:10] StepsConversionTotalSteps',
+            title_link: 'https://grafana.example.com/alerting/grafana/abc/view?orgId=1',
+            text: '**Firing**\nValue: C=1',
+            fields: [
+              { title: 'Handled error', value: 'API error 423' },
+              { title: 'Location', value: 'packages/monitoring/createErrorReporter.tsx:107' },
+            ],
+            blocks: [{
+              type: 'actions',
+              elements: [{ type: 'button', text: { type: 'plain_text', text: 'Ticket' }, url: 'https://example.com/t/1' }],
+            }],
+            footer: 'Grafana v13.0.3',
+          }],
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_att', '500.0', '500.0');
+    const att = thread.messages[0].attachments![0].text;
+
+    expect(att).toContain('<!subteam^S123>');
+    expect(att).toContain('[FIRING:10] StepsConversionTotalSteps');
+    expect(att).toContain('https://grafana.example.com/alerting/grafana/abc/view?orgId=1');
+    expect(att).toContain('**Firing**');
+    expect(att).toContain('Location: packages/monitoring/createErrorReporter.tsx:107');
+    expect(att).toContain('[Ticket] https://example.com/t/1');
+    expect(att).toContain('Grafana v13.0.3');
+  });
+
+  it('drops the fallback restatement when fields already carry it', async () => {
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '501.0',
+          user: 'UHUMAN',
+          text: '',
+          attachments: [{
+            fallback: 'Error: API error 423: Locked',
+            fields: [{ title: 'Handled error', value: 'Error: API error 423: Locked' }],
+          }],
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_att', '501.0', '501.0');
+
+    expect(thread.messages[0].attachments![0].text).toBe('Handled error: Error: API error 423: Locked');
+  });
+});
+
+/**
+ * The backstop that makes capture reliable rather than merely correct today:
+ * anything the allowlist-shaped extractors miss is appended and logged instead
+ * of silently dropped. Verified to fire zero times across 466 real messages from
+ * six channels, so a hit means a genuinely new Slack shape.
+ */
+describe('fetchSlackThread — unrendered-content backstop', () => {
+  it('appends and logs content no extractor reached', async () => {
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '600.0',
+          user: 'UHUMAN',
+          text: 'look at this',
+          blocks: [{ type: 'rich_text', elements: [{ type: 'rich_text_section', elements: [{ type: 'text', text: 'look at this' }] }] }],
+          // A shape no extractor knows, carrying real content.
+          some_future_card: { headline: 'Deploy 4.2 rolled back' },
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_res', '600.0', '600.0');
+
+    expect(thread.messages[0].text).toContain('look at this');
+    expect(thread.messages[0].text).toContain('[unparsed: Deploy 4.2 rolled back]');
+  });
+
+  it('stays quiet when Slack merely restates the body in its legacy dialect', async () => {
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '601.0',
+          user: 'UHUMAN',
+          // mrkdwn dialect: emphasis, bullets, <url|label>, escaped ampersand.
+          text: '*Recap*\n- see <https://x.example.com/a?b=1&amp;c=2|x.example.com/a…>',
+          blocks: [{
+            type: 'rich_text',
+            elements: [
+              { type: 'rich_text_section', elements: [{ type: 'text', text: 'Recap', style: { bold: true } }] },
+              {
+                type: 'rich_text_list',
+                style: 'bullet',
+                elements: [{
+                  type: 'rich_text_section',
+                  elements: [
+                    { type: 'text', text: 'see ' },
+                    { type: 'link', url: 'https://x.example.com/a?b=1&c=2', text: 'x.example.com/a…' },
+                  ],
+                }],
+              },
+            ],
+          }],
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_res', '601.0', '601.0');
+
+    expect(thread.messages[0].text).not.toContain('[unparsed:');
+    // Ampersand decoded, so the query string is usable.
+    expect(thread.messages[0].text).toContain('https://x.example.com/a?b=1&c=2');
+  });
+});
+
+describe('fetchSlackThread — pagination', () => {
+  it('follows next_cursor so the newest replies are not dropped', async () => {
+    slackApi.conversations.replies
+      .mockResolvedValueOnce({
+        messages: [rawMsg({ ts: '700.0', user: 'UHUMAN', text: 'first page' })],
+        response_metadata: { next_cursor: 'CURSOR1' },
+      })
+      .mockResolvedValueOnce({
+        messages: [rawMsg({ ts: '701.0', user: 'UHUMAN2', text: 'second page' })],
+      });
+
+    const thread = await client.fetchSlackThread('C_page', '700.0', '701.0');
+
+    expect(thread.messages.map((m) => m.text)).toEqual(['first page', 'second page']);
+    expect(slackApi.conversations.replies).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('fetchChannelHistory — public only, chronological', () => {
   it('refuses a private channel before reading any history', async () => {
     slackApi.conversations.info.mockResolvedValue({

--- a/src/connectors/slack/__tests__/client.test.ts
+++ b/src/connectors/slack/__tests__/client.test.ts
@@ -220,6 +220,31 @@ describe('fetchSlackThread — link chips survive the Block Kit walk', () => {
     expect(thread.messages[0].text).not.toContain('[unparsed:');
   });
 
+  it('appends only the uncovered lines of the text field, not the whole body', async () => {
+    // Taking the whole field whenever any line was missing duplicated entire
+    // message bodies (47 of 3,778 real messages) — one unmatched link line
+    // dragged every already-rendered line in with it.
+    slackApi.conversations.replies.mockResolvedValue({
+      messages: [
+        rawMsg({
+          ts: '407.0',
+          user: 'UHUMAN',
+          text: 'I was logged out on ios\nafter update to 206.0.2\n<https://admin.example.com/users/128001|admin>',
+          blocks: richText([{ type: 'text', text: 'I was logged out on ios\nafter update to 206.0.2\n' }]),
+        }),
+      ],
+    });
+
+    const thread = await client.fetchSlackThread('C_chip', '407.0', '407.0');
+    const text = thread.messages[0].text;
+
+    // The missing link line is recovered...
+    expect(text).toContain('https://admin.example.com/users/128001');
+    // ...without restating the two lines the blocks already rendered.
+    expect(text.match(/I was logged out on ios/g)).toHaveLength(1);
+    expect(text.match(/after update to 206\.0\.2/g)).toHaveLength(1);
+  });
+
   it('recovers a URL carried by an unrecognised rich_text element', async () => {
     slackApi.conversations.replies.mockResolvedValue({
       messages: [

--- a/src/connectors/slack/__tests__/edit-extraction.test.ts
+++ b/src/connectors/slack/__tests__/edit-extraction.test.ts
@@ -1,0 +1,112 @@
+/**
+ * A `message_changed` edit used to be logged from Slack's flat `text` fallback
+ * with only mentions resolved, while the identical message posted fresh went
+ * through the full block/attachment extraction. Observed live: editing a message
+ * to add a Jira link logged the raw `<url|label>` mrkdwn, where posting the same
+ * link fresh logged `label (url)` — and anything carried in `blocks` or
+ * `attachments` was lost on the edit path entirely.
+ *
+ * `extractMessageContent` is the shared entry point that closes that gap: one
+ * raw payload in, the same rendering as every other inbound message out.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const slackApi = {
+  auth: { test: vi.fn() },
+  conversations: { info: vi.fn(), replies: vi.fn(), history: vi.fn() },
+  users: { info: vi.fn(), conversations: vi.fn(), list: vi.fn() },
+  usergroups: { list: vi.fn() },
+};
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn(function (this: unknown) { return slackApi; }),
+}));
+vi.mock('../../../system/logger.js', () => ({
+  logger: { slack: vi.fn(), warn: vi.fn(), system: vi.fn(), error: vi.fn(), plain: vi.fn() },
+}));
+
+type ClientModule = typeof import('../client.js');
+let client: ClientModule;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  slackApi.auth.test.mockResolvedValue({
+    user_id: 'UBOT', bot_id: 'BBOT', team_id: 'THOME', url: 'https://acme.slack.com',
+  });
+  slackApi.usergroups.list.mockResolvedValue({ usergroups: [] });
+  slackApi.users.list.mockResolvedValue({ members: [] });
+  slackApi.users.info.mockImplementation(async ({ user }: { user: string }) => ({
+    ok: true, user: { id: user, name: user.toLowerCase(), real_name: `Real ${user}`, team_id: 'THOME', profile: {} },
+  }));
+  slackApi.conversations.info.mockResolvedValue({
+    ok: true, channel: { id: 'C1', name: 'bot-test', is_private: false, is_im: false, is_mpim: false },
+  });
+  client = await import('../client.js');
+  await client.initSlackClient('xoxb-test');
+});
+
+describe('extractMessageContent — the edit path renders like every other path', () => {
+  it('renders a Jira chip added by an edit as `title (url)`, not raw mrkdwn', async () => {
+    // The payload from the live edit that exposed this.
+    const edited = {
+      type: 'message',
+      ts: '1786225194.525969',
+      user: 'UHUMAN',
+      text: 'I am just testing some changes. <https://acme.atlassian.net/browse/IO-3021?a=1&amp;b=2|[BE][CoreExp] Support failed flow for joinable offer>',
+      blocks: [{
+        type: 'rich_text',
+        elements: [{
+          type: 'rich_text_section',
+          elements: [
+            { type: 'text', text: 'I am just testing some changes. ' },
+            {
+              type: 'attachment_mention',
+              url: 'https://acme.atlassian.net/browse/IO-3021?a=1&b=2',
+              text: '[BE][CoreExp] Support failed flow for joinable offer',
+              product_name: 'Jira Cloud',
+            },
+          ],
+        }],
+      }],
+    };
+
+    const { text } = await client.extractMessageContent(edited, 'C1');
+
+    expect(text).toBe(
+      'I am just testing some changes. [BE][CoreExp] Support failed flow for joinable offer '
+      + '(https://acme.atlassian.net/browse/IO-3021?a=1&b=2)',
+    );
+    expect(text).not.toContain('|');      // no raw <url|label> mrkdwn
+    expect(text).not.toContain('&amp;');  // entity decoded
+  });
+
+  it('surfaces attachment cards on an edited message', async () => {
+    const edited = {
+      type: 'message', ts: '2.0', user: 'UHUMAN', text: '',
+      attachments: [{ title: '[FIRING:2] DiskFull', title_link: 'https://g.example.com/a', text: 'Value: 1' }],
+    };
+
+    const { text, attachments } = await client.extractMessageContent(edited, 'C1');
+
+    expect(text).toBe('');
+    expect(attachments?.[0].text).toContain('[FIRING:2] DiskFull');
+    expect(attachments?.[0].text).toContain('https://g.example.com/a');
+  });
+
+  it('still resolves mentions, as the old cleanSlackText path did', async () => {
+    const edited = {
+      type: 'message', ts: '3.0', user: 'UHUMAN',
+      text: 'ping <@UOTHER> about this',
+    };
+
+    const { text } = await client.extractMessageContent(edited, 'C1');
+
+    expect(text).toBe('ping <@UOTHER:Real UOTHER> about this');
+  });
+
+  it('returns empty text rather than throwing on a payload it cannot read', async () => {
+    const { text } = await client.extractMessageContent({ type: 'message', ts: '4.0', blocks: null }, 'C1');
+    expect(typeof text).toBe('string');
+  });
+});

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -632,7 +632,11 @@ function recoverMissingUrls(extracted: string, textField: string | undefined): s
   if (!textField || typeof textField !== 'string') return [];
   const missing: string[] = [];
   for (const match of textField.matchAll(TEXT_FIELD_URL)) {
-    const url = match[1];
+    // Decode before comparing: `text` escapes `&` but `blocks` does not, so a
+    // query-string URL that the block walk DID render still looked absent and
+    // got appended a second time — which is every Grafana silence link and
+    // Bugsnag error URL.
+    const url = decodeSlackEntities(match[1]);
     if (extracted.includes(url) || missing.includes(url)) continue;
     missing.push(url);
   }
@@ -1932,6 +1936,31 @@ export function extractMentionText(text: string, botUserId: string): string {
  */
 export function isBotMention(text: string, botUserId: string): boolean {
   return text.includes(`<@${botUserId}>`);
+}
+
+/**
+ * Run one raw Slack message payload through the full inbound extraction —
+ * blocks, attachment cards, files, mention resolution, entity decoding — the
+ * same path `fetchSlackThread` uses.
+ *
+ * For callers that hold a message payload directly rather than fetching a
+ * thread, notably the `message_changed` edit handler. Resolving mentions alone
+ * (`cleanSlackText`) leaves that caller with Slack's flat `text` fallback, so an
+ * edited message rendered its links as raw `<url|label>` mrkdwn and anything
+ * living in `blocks` or `attachments` did not survive at all.
+ */
+export async function extractMessageContent(
+  message: unknown,
+  channelId: string,
+): Promise<{ text: string; attachments?: SlackAttachment[]; files?: SlackFile[] }> {
+  const [resolved] = await resolveRawMessages([message as SlackHistoryMessage], channelId);
+  if (!resolved) return { text: '' };
+  const authorless = (resolved.attachments ?? []).map((a) => ({ text: a.text }));
+  return {
+    text: resolved.text,
+    ...(authorless.length > 0 ? { attachments: authorless } : {}),
+    ...(resolved.files?.length ? { files: resolved.files } : {}),
+  };
 }
 
 /**

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -799,7 +799,15 @@ function collectUnrenderedText(
     found.push({ path, text: text.slice(0, MAX_UNRENDERED_FRAGMENT_CHARS) });
   };
 
-  walk(payload, '', '');
+  try {
+    walk(payload, '', '');
+  } catch (error) {
+    // This is a diagnostic over an arbitrary third-party payload. It must never
+    // be the reason a Slack message fails to reach an agent, so a fault here
+    // degrades to "found nothing" rather than propagating out of the fetch.
+    logger.warn('Slack', 'collectUnrenderedText failed; skipping the backstop for this message', error);
+    return [];
+  }
   return found;
 }
 
@@ -857,15 +865,24 @@ async function resolveRawMessages(
     if (consumedTopBlocks) {
       // `text` is a first-class content field, not a lossless mirror of the
       // blocks: an app's notification headline ("Production release was
-      // started!") often lives ONLY there. So keep it whenever the blocks don't
-      // already say it, and fall back to URL-only recovery when they do — that
-      // covers a smart-link chip whose element type we can't read.
+      // started!") often lives ONLY there.
+      //
+      // Reconciled line by line rather than as one blob. Taking the whole field
+      // whenever any part of it was missing duplicated the entire message body
+      // on 47 of 3,778 real messages — one unmatched line, usually a link,
+      // dragged every already-rendered line in with it. Lines with no
+      // substantial word are skipped (they carry nothing `recoverMissingUrls`
+      // won't catch) so stray punctuation isn't echoed back.
       const body = ownParts.join('\n');
-      if (msg.text && !isCovered(msg.text, normalizeForMatch(body), new Set(contentTokens(body)))) {
-        ownParts.push(msg.text);
-      } else {
-        ownParts.push(...recoverMissingUrls(body, msg.text));
+      const normalizedBody = normalizeForMatch(body);
+      const bodyTokens = new Set(contentTokens(body));
+      for (const line of (msg.text ?? '').split('\n')) {
+        const trimmed = line.trim();
+        if (contentTokens(trimmed).length === 0) continue;
+        if (isCovered(trimmed, normalizedBody, bodyTokens)) continue;
+        ownParts.push(trimmed);
       }
+      ownParts.push(...recoverMissingUrls(ownParts.join('\n'), msg.text));
     } else if (msg.text) {
       ownParts.push(msg.text);
     }

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -344,7 +344,7 @@ export async function getMessageReactions(channel: string, timestamp: string): P
     // external participants unresolved elsewhere.
     const nameById = new Map((await listWorkspaceUsers()).map((u) => [u.id, u.realName]));
     return raw
-      .filter((r): r is { name: string; count?: number; users?: string[] } => typeof r.name === 'string')
+      .filter((r): r is { name: string; count?: number; users?: string[] } => Boolean(r) && typeof r?.name === 'string')
       .map((r) => {
         const users = (r.users ?? []).map((uid) => nameById.get(uid) ?? uid);
         return { name: r.name, count: r.count ?? 0, ...(users.length > 0 ? { users } : {}) };
@@ -629,7 +629,7 @@ const TEXT_FIELD_URL = /<((?:https?|mailto):[^|>\s]+)(?:\|[^>]*)?>/g;
  * missing, deduped and in order.
  */
 function recoverMissingUrls(extracted: string, textField: string | undefined): string[] {
-  if (!textField) return [];
+  if (!textField || typeof textField !== 'string') return [];
   const missing: string[] = [];
   for (const match of textField.matchAll(TEXT_FIELD_URL)) {
     const url = match[1];
@@ -876,7 +876,7 @@ async function resolveRawMessages(
       const body = ownParts.join('\n');
       const normalizedBody = normalizeForMatch(body);
       const bodyTokens = new Set(contentTokens(body));
-      for (const line of (msg.text ?? '').split('\n')) {
+      for (const line of String(msg.text ?? '').split('\n')) {
         const trimmed = line.trim();
         if (contentTokens(trimmed).length === 0) continue;
         if (isCovered(trimmed, normalizedBody, bodyTokens)) continue;
@@ -921,6 +921,7 @@ async function resolveRawMessages(
     const attachments: RawAttachment[] = [];
     if (rawAttachments && Array.isArray(rawAttachments)) {
       for (const att of rawAttachments) {
+        if (!att || typeof att !== 'object') continue;
         // Prefer structured message_blocks; skip text/fallback when present to
         // avoid duplicating the same content.
         const seg: string[] = [];
@@ -966,7 +967,8 @@ async function resolveRawMessages(
           push(att.pretext);
           push(att.service_name ?? att.author_name);
           push(att.title && att.title_link ? `${att.title} (${att.title_link})` : att.title ?? att.title_link);
-          const fieldLines = (att.fields ?? [])
+          const fieldLines = (Array.isArray(att.fields) ? att.fields : [])
+            .filter((field) => field && typeof field === 'object')
             .map((field) => [field.title, field.value].filter(Boolean).join(': '))
             .filter(Boolean);
           // `fallback` is a flat restatement of the whole card, so when the
@@ -985,11 +987,12 @@ async function resolveRawMessages(
           // `message_blocks` (a forwarded Slack message) and previously unread,
           // which is why a #bugs report's "Ticket" button rendered as the
           // fallback string "[no preview available]".
-          for (const block of att.blocks ?? []) {
+          for (const block of Array.isArray(att.blocks) ? att.blocks : []) {
             push(extractBlockText(block as { type: string; elements?: Array<unknown> }));
           }
           push(att.footer);
-          for (const action of att.actions ?? []) {
+          for (const action of Array.isArray(att.actions) ? att.actions : []) {
+            if (!action || typeof action !== 'object') continue;
             push(action.text ? `[${action.text}]${action.url ? ` ${action.url}` : ''}` : undefined);
           }
           seg.push(...recoverMissingUrls(seg.join('\n'), att.text || att.fallback));
@@ -1063,8 +1066,10 @@ async function resolveRawMessages(
         // `rows` is a cell matrix, each cell its own rich_text block. Archie
         // posts markdown tables and Slack hands them back in this shape, so
         // without this the agent re-reading its own message sees no table at all.
-        const rows = (block as { rows?: Array<Array<unknown>> }).rows ?? [];
+        const rows = (block as { rows?: Array<Array<unknown>> }).rows;
+        if (!Array.isArray(rows)) return '';
         return rows
+          .filter((row): row is Array<unknown> => Array.isArray(row))
           .map((row) => `| ${row.map((cell) => extractBlockText(cell as { type: string })).join(' | ')} |`)
           .join('\n');
       }
@@ -1111,6 +1116,10 @@ async function resolveRawMessages(
     const parts: string[] = [];
 
     for (const element of elements) {
+      // Slack's arrays are typed, but this walks a third-party payload — a
+      // primitive or null where an element belongs must not take the whole
+      // thread fetch down with it.
+      if (!element || typeof element !== 'object') continue;
       const el = element as {
         type: string;
         elements?: Array<unknown>;
@@ -1279,6 +1288,7 @@ async function resolveRawMessages(
 
     if (attachments && Array.isArray(attachments)) {
       for (const att of attachments) {
+        if (!att || typeof att !== 'object') continue;
         // Files nested in attachment
         processFiles(att.files);
 
@@ -1303,7 +1313,7 @@ async function resolveRawMessages(
     const raw = (msg as { reactions?: Array<{ name?: string; count?: number }> }).reactions;
     if (!raw || !Array.isArray(raw)) return [];
     return raw
-      .filter((r): r is { name: string; count?: number } => typeof r.name === 'string')
+      .filter((r): r is { name: string; count?: number } => Boolean(r) && typeof r?.name === 'string')
       .map((r) => ({ name: r.name, count: r.count ?? 0 }));
   };
 

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -547,7 +547,19 @@ function applyMentionReplacements(
     return channelName ? `#<${channelId}:${channelName}>` : match;
   });
 
-  return result;
+  // Undo Slack's escaping last, after every `<…>` construct has been parsed, so
+  // a user who literally typed "&lt;" doesn't turn into a bogus mention.
+  return decodeSlackEntities(result);
+}
+
+/**
+ * Reverse the only three escapes Slack applies to message text. Left encoded,
+ * `&amp;` corrupts every URL with a query string the agent reads back — and it
+ * appears in `text` but not in `blocks`, so decoding is also what lets the two
+ * dialects be compared.
+ */
+function decodeSlackEntities(text: string): string {
+  return text.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
 }
 
 /**
@@ -563,14 +575,232 @@ async function fetchThreadHistory(
 ): Promise<RawSlackMessage[]> {
   const client = getSlackClient();
 
-  const result = await client.conversations.replies({
-    channel,
-    ts: threadTs,
-    oldest,
-    inclusive: oldest ? false : true,
-  });
+  // `conversations.replies` returns oldest-first and pages, so ignoring
+  // `next_cursor` would drop the NEWEST replies — including, on a long enough
+  // thread, the very message that triggered this fetch. Follow the cursor, with
+  // a page cap so a runaway thread can't stall the turn.
+  const raw: SlackHistoryMessage[] = [];
+  let cursor: string | undefined;
+  let page = 0;
+  do {
+    const result = await client.conversations.replies({
+      channel,
+      ts: threadTs,
+      oldest,
+      inclusive: oldest ? false : true,
+      cursor,
+      limit: 1000,
+    });
+    raw.push(...(result.messages ?? []));
+    cursor = result.response_metadata?.next_cursor || undefined;
+    page += 1;
+    if (cursor && page >= THREAD_PAGE_LIMIT) {
+      logger.warn(
+        'Slack',
+        `Thread ${channel}:${threadTs} exceeds ${THREAD_PAGE_LIMIT} pages (${raw.length} messages) — older replies kept, newest truncated`,
+      );
+      break;
+    }
+  } while (cursor);
 
-  return resolveRawMessages(result.messages ?? [], channel);
+  return resolveRawMessages(raw, channel);
+}
+
+/** Max `conversations.replies` pages per thread fetch (1000 messages each). */
+const THREAD_PAGE_LIMIT = 5;
+
+/**
+ * Slack encodes links in the legacy `text` field as `<url>` or `<url|label>`.
+ * Mentions share that bracket syntax (`<@U…>`, `<#C…>`, `<!here>`) but never
+ * carry a scheme, so requiring one isolates real URLs.
+ */
+const TEXT_FIELD_URL = /<((?:https?|mailto):[^|>\s]+)(?:\|[^>]*)?>/g;
+
+/**
+ * Recover URLs that the Block Kit walk dropped.
+ *
+ * `blocks` is the richer source and is preferred, but Slack renders an
+ * ever-growing set of pasted links as "smart link" chips carried by rich_text
+ * element types we don't know about (`message_mention`, `canvas`, the Jira
+ * issue chip, …). An unrecognised element contributes nothing, so the link
+ * vanishes from the agent's view entirely — the user sees a link in Slack and
+ * Archie insists no link was sent. The legacy `text` field always spells the
+ * raw URL out, so treat it as the backstop: append anything `extracted` is
+ * missing, deduped and in order.
+ */
+function recoverMissingUrls(extracted: string, textField: string | undefined): string[] {
+  if (!textField) return [];
+  const missing: string[] = [];
+  for (const match of textField.matchAll(TEXT_FIELD_URL)) {
+    const url = match[1];
+    if (extracted.includes(url) || missing.includes(url)) continue;
+    missing.push(url);
+  }
+  return missing;
+}
+
+/**
+ * Object keys whose string values are Slack plumbing, never message content:
+ * ids, timestamps, colours, asset URLs, enum tags, layout hints. Everything not
+ * listed here is treated as potential content by `collectUnrenderedText`.
+ */
+const PLUMBING_KEYS = new Set([
+  'type', 'subtype', 'ts', 'id', 'user', 'team', 'channel', 'mrkdwn_in', 'verbatim',
+  'emoji', 'short', 'style', 'indent', 'border', 'offset', 'length', 'range',
+  'username', 'name', 'unicode', 'skin_tone', 'locale', 'lang', 'color', 'inviter',
+  // Accessibility label. On an image *block* it is the only content and the
+  // `image` case renders it; on an image *element* inside a context row it is
+  // just an icon name ("vcs", "app").
+  'alt_text',
+  'mimetype', 'filetype', 'pretty_type', 'permalink', 'permalink_public',
+  // Attachment author identity is carried structurally in `SlackAttachment.author`
+  // (a resolved SlackAuthor), and the card path renders `author_name` when Slack
+  // gave us no id to resolve — so these are never the only copy.
+  'author_name', 'author_subname', 'author_link',
+  // Deliberately rendered by the structural pass above; listing them here keeps
+  // the same content from being reported twice when phrasing differs.
+  'fallback', 'value',
+]);
+
+/**
+ * Slack's naming is regular enough to classify plumbing by suffix, which beats
+ * enumerating keys we haven't met yet (`canvas_update_section_ids` was not on
+ * anyone's list). Content keys are plain nouns — `text`, `title`, `pretext`,
+ * `footer`, `description`, `alt_text`.
+ */
+const PLUMBING_KEY_SUFFIX = /_(id|ids|ts|url|urls|icon|icons|users|type|subtype|color|code|link|team|hash|name|files)$/;
+
+function isPlumbingKey(key: string): boolean {
+  return PLUMBING_KEYS.has(key) || PLUMBING_KEY_SUFFIX.test(key);
+}
+
+/**
+ * Normalise text before asking "did we already render this?".
+ *
+ * Slack ships the same content twice in different dialects: `blocks` carry
+ * structure while the legacy `text` field carries mrkdwn (`*bold*`,
+ * `<url|label>`). A raw substring test calls those a mismatch and reports the
+ * whole message body as unrendered, which would bury the real signal.
+ */
+function normalizeForMatch(text: string): string {
+  return decodeSlackEntities(text)
+    // Link brackets become separators, not nothing: `<url|label>` names the same
+    // target twice, and deleting the delimiters would weld the url's tail to the
+    // label's head into a token ("comAshkenia") that matches nothing.
+    .replace(/[<>|]/g, '/')
+    .replace(/\b(?:https?:\/\/|mailto:)/g, '') // one dialect keeps the scheme, one drops it
+    .replace(/[*_~`]/g, '')            // mrkdwn emphasis, absent from rich_text
+    .replace(/[-•·‣]/g, '')            // list bullets: "- item" vs "• item"
+    // Whitespace is dropped entirely, not collapsed: the two dialects disagree
+    // about where paragraph and list breaks fall, and a break is never the only
+    // thing a fragment contributes.
+    .replace(/\s+/g, '');
+}
+
+/**
+ * Words worth matching on: alphanumeric runs of 4+ characters, lowercased.
+ * URL schemes are dropped because one dialect prints them and the other doesn't.
+ * Derived from the ORIGINAL string, not the whitespace-stripped form — stripping
+ * first welds "…#6887 archie/…" into the token "6887archie", which matches
+ * nothing and reads as a loss.
+ */
+function contentTokens(text: string): string[] {
+  return (decodeSlackEntities(text).toLowerCase().match(/[\p{L}\p{N}]{4,}/gu) ?? [])
+    .filter((token) => token !== 'http' && token !== 'https' && token !== 'mailto');
+}
+
+/**
+ * Is `candidate` already accounted for in the rendered output?
+ *
+ * Exact containment first. Failing that, token coverage: the legacy `text` field
+ * and `blocks` describe the same content in different dialects — mrkdwn
+ * emphasis, different list bullets, and a link like `<http://x.com/a|x.com/a>`
+ * that names its target twice where rich_text names it once. Requiring every
+ * substantial word to appear somewhere, rather than the whole run verbatim,
+ * tolerates the dialects without tolerating real loss: a dropped Jira link takes
+ * its distinctive tokens with it.
+ */
+function isCovered(candidate: string, normalizedRendered: string, renderedTokens: Set<string>): boolean {
+  const normalized = normalizeForMatch(candidate);
+  if (!normalized) return true;
+  if (normalizedRendered.includes(normalized)) return true;
+  const tokens = contentTokens(candidate);
+  if (tokens.length === 0) return false;
+  return tokens.every((token) => renderedTokens.has(token));
+}
+
+/**
+ * Whole subtrees with no message content, or content already handled by a
+ * dedicated extractor (`files` → `[Files: …]`, `reactions` → `[Reactions: …]`,
+ * `actions` → button labels).
+ */
+const PLUMBING_SUBTREES = new Set([
+  'bot_profile', 'icons', 'profile', 'user_profile', 'edited', 'reactions', 'files',
+  'metadata', 'third_party_auth', 'accessory', 'actions', 'root', 'shares',
+  'pinned_info', 'pinned_to',
+  // Interactive-control chrome, not message content: an app's overflow menu and
+  // select options ("More actions…", "Why am I seeing this?").
+  'placeholder', 'options', 'option_groups', 'initial_option', 'confirm',
+]);
+
+/** Cap on salvaged fragments, so a pathological payload can't flood the log. */
+const MAX_UNRENDERED_FRAGMENTS = 10;
+const MAX_UNRENDERED_FRAGMENT_CHARS = 300;
+
+/**
+ * Find text present in the raw Slack payload that our structural extraction did
+ * not surface.
+ *
+ * This is the backstop that makes capture *reliable* rather than merely correct
+ * today. Every extractor above is an allowlist — a `switch` over block types, a
+ * fixed set of attachment fields — and Slack keeps shipping new shapes (smart
+ * link chips, `markdown` and `table` blocks, Lists, canvases). An allowlist
+ * meets a new shape by silently dropping it, which is exactly how a pasted Jira
+ * link and a Grafana alert headline both vanished. So instead of trusting the
+ * allowlist to be complete, walk the payload and diff: anything that looks like
+ * human-readable text and does not already appear in the rendered output is
+ * reported. The caller appends it (nothing is lost) and logs it (we find out,
+ * and can then render it properly).
+ *
+ * Returns fragments in document order, deduped, each with its JSON path for the
+ * log line.
+ */
+function collectUnrenderedText(
+  payload: unknown,
+  rendered: string,
+): Array<{ path: string; text: string }> {
+  const found: Array<{ path: string; text: string }> = [];
+  const seen = new Set<string>();
+  const normalizedRendered = normalizeForMatch(rendered);
+  const renderedTokens = new Set(contentTokens(rendered));
+
+  const walk = (node: unknown, key: string, path: string): void => {
+    if (found.length >= MAX_UNRENDERED_FRAGMENTS) return;
+    if (Array.isArray(node)) {
+      node.forEach((item, i) => walk(item, key, `${path}[${i}]`));
+      return;
+    }
+    if (node && typeof node === 'object') {
+      for (const [childKey, child] of Object.entries(node)) {
+        if (PLUMBING_SUBTREES.has(childKey)) continue;
+        walk(child, childKey, path ? `${path}.${childKey}` : childKey);
+      }
+      return;
+    }
+    if (typeof node !== 'string') return;
+    if (isPlumbingKey(key)) return;
+    // Content is prose: it has letters. This filters ids, hex colours,
+    // timestamps and enum-ish tokens without needing to name them all.
+    if (!/\p{L}/u.test(node)) return;
+    const text = node.trim();
+    const normalized = normalizeForMatch(text);
+    if (!normalized || seen.has(normalized) || isCovered(text, normalizedRendered, renderedTokens)) return;
+    seen.add(normalized);
+    found.push({ path, text: text.slice(0, MAX_UNRENDERED_FRAGMENT_CHARS) });
+  };
+
+  walk(payload, '', '');
+  return found;
 }
 
 /**
@@ -624,7 +854,19 @@ async function resolveRawMessages(
       }
     }
 
-    if (!consumedTopBlocks && msg.text) {
+    if (consumedTopBlocks) {
+      // `text` is a first-class content field, not a lossless mirror of the
+      // blocks: an app's notification headline ("Production release was
+      // started!") often lives ONLY there. So keep it whenever the blocks don't
+      // already say it, and fall back to URL-only recovery when they do — that
+      // covers a smart-link chip whose element type we can't read.
+      const body = ownParts.join('\n');
+      if (msg.text && !isCovered(msg.text, normalizeForMatch(body), new Set(contentTokens(body)))) {
+        ownParts.push(msg.text);
+      } else {
+        ownParts.push(...recoverMissingUrls(body, msg.text));
+      }
+    } else if (msg.text) {
       ownParts.push(msg.text);
     }
 
@@ -640,14 +882,22 @@ async function resolveRawMessages(
       }
     }
 
-    // Attachments (forwarded messages, shared content, unfurls). Each entry
-    // becomes one SlackAttachment with its author + text correlated.
+    // Attachments (forwarded messages, shared content, unfurls, and every
+    // bot-posted alert card). Each entry becomes one SlackAttachment with its
+    // author + text correlated.
     const rawAttachments = msg.attachments as Array<{
       author_id?: string;
+      author_name?: string;
+      service_name?: string;
       text?: string;
       fallback?: string;
       pretext?: string;
       title?: string;
+      title_link?: string;
+      footer?: string;
+      fields?: Array<{ title?: string; value?: string }>;
+      blocks?: Array<unknown>;
+      actions?: Array<{ text?: string; url?: string }>;
       message_blocks?: Array<{ message?: { user?: string; blocks?: Array<unknown> } }>;
     }> | undefined;
 
@@ -674,9 +924,58 @@ async function resolveRawMessages(
           }
         }
 
-        if (!consumedFromBlocks) {
-          const attText = att.text || att.fallback;
-          if (attText && !seg.includes(attText)) seg.push(attText);
+        if (consumedFromBlocks) {
+          // A forwarded Slack message: the body came from message_blocks and the
+          // author is resolved from `authorId`, so only the trailing provenance
+          // line and an unresolvable author name are left to pick up.
+          if (!authorId && att.author_name) seg.unshift(att.author_name);
+          if (att.footer && !seg.includes(att.footer)) seg.push(att.footer);
+          // The forwarder's own `text` is usually a duplicate of the blocks, but
+          // not always — on a shared Slack message it can hold the pings that
+          // aren't in the quoted body.
+          const body = normalizeForMatch(seg.join('\n'));
+          if (att.text && !body.includes(normalizeForMatch(att.text))) seg.push(att.text);
+          seg.push(...recoverMissingUrls(seg.join('\n'), att.text || att.fallback));
+        } else {
+          // A bot-posted attachment is a card, not a paragraph: Grafana and
+          // Alertmanager put the alert name in `title` and its dashboard URL in
+          // `title_link`, the paged group in `pretext`, and Bugsnag puts the
+          // error location in `fields`. Reading only `text`/`fallback` left the
+          // agent with a bare "**Firing** / Value: C=1" and no idea which alert
+          // fired or where to look.
+          const push = (part: string | undefined) => {
+            if (part && !seg.includes(part)) seg.push(part);
+          };
+          push(att.pretext);
+          push(att.service_name ?? att.author_name);
+          push(att.title && att.title_link ? `${att.title} (${att.title_link})` : att.title ?? att.title_link);
+          const fieldLines = (att.fields ?? [])
+            .map((field) => [field.title, field.value].filter(Boolean).join(': '))
+            .filter(Boolean);
+          // `fallback` is a flat restatement of the whole card, so when the
+          // structured fields already say it (Bugsnag) printing both just
+          // doubles the error string.
+          const coveredByFields = (candidate: string | undefined) =>
+            Boolean(candidate) && fieldLines.length > 0
+            && isCovered(
+              candidate!,
+              normalizeForMatch(fieldLines.join('\n')),
+              new Set(contentTokens(fieldLines.join('\n'))),
+            );
+          push(att.text || (coveredByFields(att.fallback) ? undefined : att.fallback));
+          fieldLines.forEach(push);
+          // Block Kit nested inside the attachment. Distinct from
+          // `message_blocks` (a forwarded Slack message) and previously unread,
+          // which is why a #bugs report's "Ticket" button rendered as the
+          // fallback string "[no preview available]".
+          for (const block of att.blocks ?? []) {
+            push(extractBlockText(block as { type: string; elements?: Array<unknown> }));
+          }
+          push(att.footer);
+          for (const action of att.actions ?? []) {
+            push(action.text ? `[${action.text}]${action.url ? ` ${action.url}` : ''}` : undefined);
+          }
+          seg.push(...recoverMissingUrls(seg.join('\n'), att.text || att.fallback));
         }
 
         const text = seg.join('\n');
@@ -695,21 +994,74 @@ async function resolveRawMessages(
   /**
    * Extract text from a Block Kit block (handles rich_text, section, etc.)
    */
-  const extractBlockText = (block: { type: string; text?: { text?: string }; elements?: Array<unknown> }): string => {
+  const extractBlockText = (block: { type: string; text?: { text?: string } | string; elements?: Array<unknown> }): string => {
     if (!block) return '';
+
+    // `text` is an object on section/header, a bare string on markdown blocks.
+    const blockText = typeof block.text === 'string' ? block.text : block.text?.text;
 
     switch (block.type) {
       case 'rich_text':
-        // rich_text blocks have nested elements (sections, lists, quotes, etc.)
-        return extractRichTextElements(block.elements || []);
+        // A rich_text block's direct children are paragraph-level: sections,
+        // lists, quotes, code blocks. Render each separately and join on newline
+        // — extractRichTextElements concatenates its input with no separator
+        // (correct for the words *inside* a section, wrong across them, which
+        // used to run a list straight onto the end of the preceding sentence).
+        return (block.elements || [])
+          .map((el) => extractRichTextElements([el]))
+          .filter(Boolean)
+          .join('\n');
 
       case 'section':
-        // Section blocks have a text field
-        return block.text?.text || '';
-
       case 'header':
-        // Header blocks have a text field
-        return block.text?.text || '';
+      case 'markdown':
+        // Single text payload. `markdown` is what Archie posts with; Slack
+        // normally hands it back as rich_text, but not contractually.
+        return blockText || '';
+
+      case 'image':
+        // Alt text / caption is the only readable content; the URL keeps the
+        // reference resolvable.
+        return [blockText, (block as { alt_text?: string }).alt_text, (block as { image_url?: string }).image_url]
+          .filter(Boolean).join(' — ');
+
+      case 'video': {
+        const v = block as { title?: { text?: string }; description?: { text?: string }; title_url?: string };
+        return [v.title?.text, v.description?.text, v.title_url].filter(Boolean).join(' — ');
+      }
+
+      case 'actions':
+        // Button rows. The label plus its link is often the whole point of the
+        // block (e.g. a bug tracker's "Ticket" button).
+        return (block.elements ?? [])
+          .map((el) => {
+            const e = el as { text?: { text?: string }; url?: string };
+            if (!e.text?.text) return '';
+            return `[${e.text.text}]${e.url ? ` ${e.url}` : ''}`;
+          })
+          .filter(Boolean)
+          .join(' ');
+
+      case 'table': {
+        // `rows` is a cell matrix, each cell its own rich_text block. Archie
+        // posts markdown tables and Slack hands them back in this shape, so
+        // without this the agent re-reading its own message sees no table at all.
+        const rows = (block as { rows?: Array<Array<unknown>> }).rows ?? [];
+        return rows
+          .map((row) => `| ${row.map((cell) => extractBlockText(cell as { type: string })).join(' | ')} |`)
+          .join('\n');
+      }
+
+      case 'card': {
+        // Link-preview card (a GitHub PR unfurl, for one). Both halves are
+        // mrkdwn, and the title is where the URL lives — `text` carries only the
+        // flattened label.
+        const card = block as { title?: { text?: string }; subtitle?: { text?: string } };
+        return [card.title?.text, card.subtitle?.text].filter(Boolean).join('\n');
+      }
+
+      case 'divider':
+        return '';
 
       case 'context':
         // Context blocks have elements array with text/image objects
@@ -725,6 +1077,12 @@ async function resolveRawMessages(
         return '';
 
       default:
+        // Unknown block type — Slack adds them (`table`, `markdown`, …) faster
+        // than this switch grows. Salvage the two shapes every block follows
+        // rather than returning nothing; `collectUnrenderedText` catches the
+        // rest.
+        if (blockText) return blockText;
+        if (block.elements) return extractRichTextElements(block.elements);
         return '';
     }
   };
@@ -792,14 +1150,38 @@ async function resolveRawMessages(
           parts.push(`<#${el.channel_id}>`);
           break;
 
-        case 'emoji':
-          // Emoji
-          parts.push(`:${el.name}:`);
+        case 'emoji': {
+          // Slack's own text dialect spells a modified emoji `:pray::skin-tone-2:`.
+          const skinTone = (el as { skin_tone?: number }).skin_tone;
+          parts.push(skinTone ? `:${el.name}::skin-tone-${skinTone}:` : `:${el.name}:`);
           break;
+        }
 
-        case 'link':
-          // URL link
-          parts.push(el.url || '');
+        // `attachment_mention` is the "smart link" chip a third-party app's
+        // unfurl turns a pasted URL into — a Jira issue link is one, which is
+        // exactly the element that used to make a linked ticket vanish. Same
+        // shape as `link`: url plus a display label worth keeping (the ticket
+        // title).
+        case 'attachment_mention':
+        case 'link': {
+          // Keep the label when it says something the URL doesn't — "(details)"
+          // on a Bugsnag link, a page title on a Notion one. Slack's own
+          // auto-generated labels are just the truncated URL, so those collapse.
+          const url = el.url ?? '';
+          const label = el.text && !normalizeForMatch(url).includes(normalizeForMatch(el.text))
+            ? el.text
+            : undefined;
+          parts.push(label ? `${label} (${url})` : url || el.text || '');
+          break;
+        }
+
+        case 'canvas':
+          // Canvas chip. Sometimes only a file id — which is itself the
+          // information — and sometimes a docs URL alongside it.
+          parts.push(
+            `[canvas ${(el as { file_id?: string }).file_id}]`
+            + (el.url ? ` ${el.url}` : ''),
+          );
           break;
 
         case 'usergroup':
@@ -810,6 +1192,15 @@ async function resolveRawMessages(
         case 'broadcast':
           // @here, @channel, @everyone
           parts.push(`<!${(el as { range?: string }).range}>`);
+          break;
+
+        default:
+          // Slack keeps adding rich_text element types for "smart link" chips
+          // (message_mention, canvas, and whatever ships next). Salvage whatever
+          // the unknown element carries rather than dropping it silently —
+          // `recoverMissingUrls` below is the second line of defence.
+          if (el.url) parts.push(el.url);
+          else if (el.text) parts.push(el.text);
           break;
       }
     }
@@ -947,9 +1338,33 @@ async function resolveRawMessages(
     const botName = rawMsg.bot_profile?.name;
     const teamId = rawMsg.bot_profile?.team_id || rawMsg.team;
     const reactions = extractReactions(msg);
+
+    // Backstop: whatever the structural pass above failed to surface gets
+    // appended here and logged, so a Slack shape we don't know about degrades
+    // into slightly untidy text instead of silently disappearing.
+    let ownTextWithResidue = ownText;
+    // File ids count as accounted-for: Slack's text fallback for a file share is
+    // the bare id, and we capture it structurally on `SlackFile.id` even though
+    // only the name is printed.
+    const fileNames = (files ?? []).map((f) => `${f.name} ${f.id}`).join('\n');
+    const unrendered = collectUnrenderedText(
+      msg,
+      [ownText, ...attachments.map((a) => a.text), fileNames].join('\n'),
+    );
+    if (unrendered.length > 0) {
+      logger.warn(
+        'Slack',
+        `Unrendered message content at ${unrendered.map((u) => u.path).join(', ')} ` +
+        `(ts ${msg.ts}) — extend extractBlockText/extractMessageParts to render it properly`,
+      );
+      ownTextWithResidue = [ownText, `[unparsed: ${unrendered.map((u) => u.text).join(' | ')}]`]
+        .filter(Boolean)
+        .join('\n');
+    }
+
     return {
       user: msg.user || '',
-      text: applyMentionReplacements(ownText, userInfoMap, groupInfoMap, channelInfoMap),
+      text: applyMentionReplacements(ownTextWithResidue, userInfoMap, groupInfoMap, channelInfoMap),
       ts: msg.ts || '',
       ...(files && files.length > 0 ? { files } : {}),
       ...(resolvedAttachments.length > 0 ? { attachments: resolvedAttachments } : {}),

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -26,6 +26,7 @@ import {
   postEphemeral,
   getSlackClient,
   cleanSlackText,
+  extractMessageContent,
 } from './client.js';
 import { ensureChannelCanvas } from './channel-canvas.js';
 import { shouldCreateNewTask, shouldForwardMessageEvent, isAckableEvent } from './task-routing.js';
@@ -33,7 +34,7 @@ import { Task } from '../../tasks/task.js';
 import { AGENT_PROMPTS } from '../../agents/prompts.js';
 import { logger } from '../../system/logger.js';
 import { getIsShuttingDown } from '../../system/shutdown.js';
-import { findTaskByThread } from '../../tasks/persistence.js';
+import { findTaskByThread, renderMessageForContext } from '../../tasks/persistence.js';
 import { getChannelMessageTriggers, fireTrigger, triggerWhat } from '../../system/trigger-scheduler.js';
 import type { Trigger } from '../../types/trigger.js';
 import { generateTaskTitle } from '../../tasks/title-generator.js';
@@ -886,10 +887,18 @@ async function handleSlackEdit(event: any): Promise<void> {
     return;
   }
 
-  // Resolve <@U…>/<#C…> mentions to the <@ID:Name> form used throughout the
-  // knowledge log. Only the new text is logged — the pre-edit text already
-  // lives in the log under the same `msg:<ts>` id.
-  const newText = await cleanSlackText(newRaw, channelId);
+  // Run the edited message through the same extraction as any other inbound
+  // message — blocks, attachment cards, link chips, entity decoding — not just
+  // mention resolution. Editing a message to add a Jira link used to log the
+  // raw `<url|label>` mrkdwn while the identical link posted fresh logged as
+  // `label (url)`, and anything carried in `blocks` was lost on the edit path.
+  // Only the new text is logged — the pre-edit text already lives in the log
+  // under the same `msg:<ts>` id.
+  const extracted = await extractMessageContent(msg, channelId);
+  const newText = renderMessageForContext(
+    { text: extracted.text, attachments: extracted.attachments },
+    { redacted: false },
+  );
   const author: SlackAuthor = {
     id: msg.user,
     username: authorInfo?.name ?? msg.user,


### PR DESCRIPTION
## What happened

A user linked a Jira ticket in a DM and asked which feature flag gated it. Archie replied that no link had been sent — three times, insisting "links and attachments aren't reaching me from this DM, only plain text does" — until the reporter typed `IO-3120` out as plain text.

Archie was not ignoring the link. Pulling the prod session (`task-20260806-2202-au13a8`) shows what actually reached the agent:

```
which feature flag is responsible for that task

?
```

A blank line exactly where the chip was, and no `atlassian` string anywhere in the task's event log. The link never arrived.

## Root cause

`resolveRawMessages` prefers Slack's structured `blocks` over the legacy `text` field, and walks them with allowlists — a `switch` over block and rich_text element types, plus a fixed set of attachment fields. An unrecognised shape falls through the switch and contributes nothing. And because a block *did* yield text, the `msg.text` fallback (which always spells the raw URL out as `<https://…>`) was skipped.

A pasted Jira URL arrives as a chip whose element type is `attachment_mention` — confirmed from a real `#bugs` payload:

```json
{"type": "attachment_mention",
 "url": "https://sweatcoin.atlassian.net/browse/IO-2862",
 "text": "[BE][FE][A/B] Silent retry + terminal modal for rewarded-ad no-fill",
 "app_id": "A2RPP3NFR", "product_name": "Jira Cloud"}
```

Not in the switch, so it disappeared. Slack-permalink chips (`message_mention`) failed the same way — which means Archie's own advice in that thread, "paste the message permalink and I'll read it", would also have failed.

## The same gap ate much more than links

Measured against **3,778 real messages from 11 channels**, including thread replies:

| what was lost | where | scale |
|---|---|---|
| Alert name (`title`) + dashboard link (`title_link`), paged group (`pretext`), Bugsnag's error file:line (`fields`) | attachment cards read as `text`/`fallback` only | 57 of 60 #mobile-alerts messages carry **no top-level text at all** — the card *is* the message |
| Entire tables | `table` blocks unhandled; Archie posts markdown tables and Slack returns them in this shape, so its own analysis tables were invisible on the next turn | 171 messages |
| Notification headline | release bots put it only in `text`, detail in `blocks`; preferring blocks discarded it | 171 messages |
| PR URL | `card` blocks (GitHub previews) hold it only in `title`; `text` has a flattened `#6887` | #bugs |
| Ticket button link | nested attachment `blocks` never read → rendered as fallback `[no preview available]` | every #bugs report |
| Paragraph/list breaks | a rich_text block's paragraph-level children joined with `''`, running bullet lists onto the preceding sentence | widespread |
| Newest thread replies | `conversations.replies` returns oldest-first and pages; `next_cursor` ignored | any thread past one page, incl. possibly the triggering message |
| Canvas chips, emoji skin tones, `&amp;` in URLs | various | — |

## The fix

Two layers, because fixing each shape individually leaves the same trap for whatever Slack invents next.

**Structural** — `attachment_mention` handled alongside `link` (keeping the label, so the ticket *title* arrives too, which alone would have answered the original question); attachment cards render `pretext` / `title` + `title_link` / body / `fields` / nested `blocks` / `footer` / `actions`; new block cases for `table`, `card`, `markdown`, `image`, `video`, `actions`, `divider`; `text` kept whenever the blocks don't already say it; entities decoded; thread fetch paginates.

**A backstop that inverts the default** — `collectUnrenderedText` walks the raw payload and diffs it against what was rendered. Anything prose-like and unaccounted-for is **appended** (nothing is lost) and **logged with its JSON path** (we find out, and can render it properly next). Plumbing is classified by key *suffix* rather than enumeration, which is what catches keys nobody has met yet, like `canvas_update_section_ids`.

## Verification

Calibrating the backstop to silence is what makes it a signal rather than noise — Slack ships the same content twice in different dialects (`blocks` structured vs `text` in mrkdwn), so a naive diff flagged 329 of 466 messages.

| corpus | messages | messages with residue |
|---|---|---|
| 6 channels, first pass | 466 | 329 → 0 |
| 11 channels + thread replies | 3,778 | 271 → **0** |

Zero false positives means a future hit is a genuinely new Slack shape. **Three of the fixes above were found by the backstop, not by reading code** — `table` blocks, the text-only headline, and the paragraph-break bug.

Channels sampled: #mobile-alerts, #bugs, #support, #sweatcoin-rc, #revenue-ads, #data-early-warning-system, #bot-test, #bot-test-canvas, #archie-test-channel.

13 new unit tests pin the reported bug and each newly handled shape, including two that assert the backstop stays *quiet* on dialect differences. Verified red before the fix. Full suite: 1006 passing, typecheck clean.

## Notes for review

- The tests were driven from the real payloads above, not invented — the `attachment_mention`, `table`, `card` and release-bot fixtures are trimmed copies of production messages.
- `PLUMBING_KEYS` deliberately silences `fallback` and `value` because the structural pass renders them. If Slack ever puts unique content in a new `value`-shaped field, the backstop won't flag it.
- Residue is capped at 10 fragments × 300 chars per message, so a pathological payload is truncated rather than unbounded.
- One path remains unexercised against real payloads: **Slack Connect redaction**. #support is externally shared, but the scan forced every author to an internal user, so `[redacted: external participant…]` and `[forwarded from … — external]` were not covered.
- `npm run lint` cannot run in this checkout (`eslint: command not found`) — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Risk assessment (asked before merge)

Measuring rather than asserting turned up two problems in the first commit, both fixed in `f2cb299`:

**Body duplication — was real, now 0.3%.** Taking the whole `text` field whenever any part of it was missing duplicated entire message bodies on **47 of 3,778** messages: one unmatched line (usually a link whose label the blocks rendered but whose URL only `text` carries) dragged every already-rendered line in with it. Now reconciled line by line — likely-redundant output is 100 short lines, 4.5k of 1.6M chars.

**The backstop could have taken down all ingestion.** `collectUnrenderedText` walks an arbitrary third-party payload on every inbound message; an exception would have propagated out of `fetchSlackThread` and no message would have reached an agent. It's a diagnostic, so it now degrades to "found nothing" plus a warning.

### What this changes for every Slack message

Output grows ~41% (1.14M raw `text` chars → 1.61M rendered) across the corpus. That is the point — the added characters are the alert names, dashboard links, file:lines and tables that were being dropped — but it means slightly larger knowledge logs and prompts.

### Residual risks, honestly

| risk | severity | mitigation |
|---|---|---|
| Shapes absent from the corpus (DMs, group DMs, workflow messages, huddles) render into an `[unparsed: …]` tail | cosmetic | bounded at 10 fragments × 300 chars; logged with JSON path |
| Entity decoding is new: someone who types a literal `&lt;@U123&gt;` now yields an unresolved `<@U123>` in agent context, which would ping a real person if echoed verbatim | low, novel | decoding runs after mention parsing, so it cannot produce a *resolved* mention; worth knowing it exists |
| A >1000-reply thread now fetches up to 5 pages where it used to fetch 1 | low | capped at 5 pages with a warning; more content is the intended fix |
| Slack Connect redaction untested against real payloads — the scan forced every author internal | **untested path** | logic itself unchanged by this PR |
| `PLUMBING_KEYS` silences `fallback` and `value`; new content in a `value`-shaped field wouldn't be flagged | low | documented in code |

### Confidence

High on **no crash and no regression in the normal path**: 1007 tests pass, typecheck clean, and every changed branch was exercised against real production payloads from 11 channels. The extraction is also strictly additive — no branch that previously produced text now produces less.

Lower on **cosmetic surprises in shapes I could not sample**, and the honest gap is Slack Connect redaction. Both fail loudly (a warning, or untidy text) rather than silently, which is the opposite of the bug being fixed here.


---

## Full check battery

Every check run against the branch head. Two rounds of findings, both fixed (`f2cb299`, `d1767b6`).

| check | result |
|---|---|
| `npm run typecheck` | clean |
| `npm run build` (tsc emit) | clean |
| `npm test` | **1030 passing**, 73 files |
| Residue over 3,778 real messages / 11 channels | **0** |
| Slack Connect redaction, real #support payloads + real workspace identities | **183 guest-authored messages redacted, 0 content leaks** |
| Backstop log privacy (paths only, never content) | pass — canary string absent from warnings |
| Malformed/hostile payloads (21 shapes) | **7 threw → all fixed**, now pass |
| Thread pagination: page cap, params stable across pages, single call when no cursor | pass |
| Entity decoding cannot manufacture a resolvable mention | pass |
| `restoreMentions` round-trip with decoded `&` | pass |
| Agent-facing `fetchChannelHistory` renders cards too | pass |
| Backstop overhead | **0.081 ms/message** |
| Downstream coupling on extracted text (grep) | none — `handleSlackEdit` compares the raw event field, nothing dedupes on rendered text |
| Debug leftovers / stray files in diff | none; `workdir/` gitignored |
| `npm run lint` | **cannot run — repo has no `eslint.config.js`**; pre-existing, unrelated |

### Round 1 — measured risk (`f2cb299`)

Reported above: whole-body duplication on 47/3,778 messages, and a backstop that could have taken down all ingestion. Both fixed.

### Round 2 — malformed payloads (`d1767b6`)

A sweep of 21 malformed shapes found **7 that threw**, of which **3 were introduced by this branch** (ragged `table` rows, non-array `attachments[].fields`, primitives inside `fields`) and **4 were pre-existing** (primitive inside a block's `elements`, null attachment, null entry in `reactions`, non-string `text` reaching `recoverMissingUrls`).

None is a shape Slack sends today, so this is hardening — but the failure mode is out of proportion to the cause: an exception in `resolveRawMessages` propagates out of `fetchSlackThread`, so **the message never reaches an agent at all**. A message silently not arriving is precisely the bug class this PR exists to fix, so the extractors now tolerate a non-object entry in every array they walk.

### Redaction — the gap named in the risk assessment, now closed

Run against real #support payloads with real `users.info` identities (`is_restricted` guest flags and team ids intact, home team `T03PDDDEK`). One genuine multi-channel guest authors 183 of the 761 messages. All 183 render as exactly `[redacted: external participant in shared channel]`; 578 internal messages render in full. The extractors' richer output structurally cannot leak, because `Task.append` writes empty content for an external author in a shared channel — verified end-to-end rather than assumed.

### Not run, and why

- **E2E harness / live boot** — drives the CLI channel via the `archie-debug` MCP, so it exercises none of the Slack ingestion path this PR changes. `tsc` emit plus 1030 unit tests cover what a boot would.
- **Live Slack round-trip** — would mean posting into a real channel; the extraction is verified against 3,778 real captured payloads instead.


---

## Live boot verification

Booted from this branch in Docker and driven against the **real Slack API**. No writes to Slack — read-only tools only.

```
Attested: instance composed from 4a758a54a2a02b055cbce1f93d6eaebddee69dc6
Healthy: http://localhost:3000
Teardown clean: `docker compose ps --all` reports no containers for this project.
```

A task was created via `POST /api/tasks` instructing the PM to use `read_channel_history` on #mobile-alerts and `read_thread` on the #bugs thread carrying the real Jira chip, and to quote verbatim or answer `NO-CONTENT` / `NO-JIRA-LINK`. It reached `completed`. What the agent actually reported:

**#mobile-alerts — 3 of 3 messages rendered** (pre-fix these arrived as empty strings):

```
[FIRING:6] Steps Conversion - Blank walkchain - iOS (copy) (https://grafana.sweatco.team/alerting/grafana/bey9fkcybe7eoe/view?orgId=1)
[FIRING:1] Steps Conversion - Conversion median - Android (copy) (19064) (https://grafana.sweatco.team/alerting/grafana/cey918mqhb0g0e/view?orgId=1)
[FIRING:10] Steps Conversion - Total Steps (95p) - iOS (copy) (https://grafana.sweatco.team/alerting/grafana/aey98ni7gfncwc/view?orgId=1)
```

These are messages that **postdate the captured corpus** — live traffic that did not exist when the fixtures were built, so this is not a replay of the data the fix was tuned on.

**#bugs — the Jira `attachment_mention` chip, the exact element behind the original report:**

```
Jira ticket key: IO-2862
Jira URL: https://sweatcoin.atlassian.net/browse/IO-2862
Verbatim: Will be fixed with this: [BE][FE][A/B] Silent retry + terminal modal for
          rewarded-ad no-fill (https://sweatcoin.atlassian.net/browse/IO-2862)
```

Both `NO-CONTENT` and `NO-JIRA-LINK` are absent from the reply. Evidence pair written by the harness's validated writer as `slack-read-extraction.json` / `.md` (gitignored local scratch).

### What the live boot does not cover

Inbound Slack **events** (message → `handleSlackEvent` → task → knowledge log). The environment has `SLACK_BOT_TOKEN` but no `SLACK_APP_TOKEN`, so there is no socket mode, and webhooks cannot reach a local boot without a tunnel. The instance can *call* Slack, which is what the read path needs; it cannot *receive*. Covering ingestion live would need a public URL wired up plus someone posting a message — a separate exercise.
