### PR TITLE
fix(pm): tell the new-task trigger where the request is

### DIFF
--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -7,7 +7,13 @@
  */
 
 export const AGENT_PROMPTS = {
-  newTask: 'New task created, assign owner',
+  // Every trigger here names knowledge.log, because none of them carry the
+  // request itself — the user's message is only ever in the log. `newTask` used
+  // to be the exception ('New task created, assign owner'), and a PM that read
+  // it literally could conclude the trigger was a contentless system event and
+  // silently complete the task without ever opening the log. Observed live: a
+  // user @mentioned Archie and got no reply at all.
+  newTask: 'New task created. Check knowledge.log for the request, then assign an owner.',
   existingTask: 'New input received. Check knowledge.log for the update.',
   recovery: 'Task was interrupted. Check knowledge.log for current state and continue where you left off.',
 


### PR DESCRIPTION
## The failure

A user @mentioned Archie in Slack and got **no reply at all**. No error, nothing in the thread beyond the `:eyes:` reaction — the task just completed.

The message had been captured correctly; the PM never looked at it. Its own reasoning, from the session transcript:

> **Triggering Message:** "New task created, assign owner" — [system]-style bootstrap message. There is no actual user request content.
> **Context from knowledge.log:** Not yet read.
> **Tool Evaluation:** report_completion: no message needed; silent completion is correct for an empty trigger.

It then called `report_completion` and ended the turn.

## Why the trigger invites that reading

Every constant in `AGENT_PROMPTS` names `knowledge.log`, because none of them carry the request — the user's message only ever lives in the log and the agent has to open it. `newTask` was the one exception:

| constant | names the log? |
|---|---|
| **`newTask`** | **no** — "New task created, assign owner" |
| `existingTask` | yes — "Check knowledge.log for the update." |
| `recovery` | yes |
| `reinforcePM` | yes |
| `reminder` | yes |
| `reinforceAgent` | yes |

Read literally, `newTask` is a contentless system event, and silence is a defensible response to it. Nothing in the string says the request is in a file. This change makes it consistent with its five siblings.

## Scope of the claim

This is a **prompt nudge, not enforcement**. It cannot be proven by a unit test, and a passing live run would not prove much either: five other live tasks on the same instance, with the same trigger string, read the log first and answered normally. The failure was roughly one in six — nondeterministic short-circuiting, not a broken code path.

The stronger fix is structural: refuse `report_completion` as the *first* action on a task whose log was never opened. That is deliberately **not** attempted here, by request — this PR is the minimal wording change.

Found while live-testing #266; unrelated to that branch, which had captured the message correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
