### PR TITLE
docs(e2e): say how to prepare a git worktree before booting

### DIFF
--- a/.claude/skills/archie-e2e/SKILL.md
+++ b/.claude/skills/archie-e2e/SKILL.md
@@ -22,6 +22,24 @@ Verify acceptance criteria against a live Archie instance booted from the branch
 - For the edit-mode and merge-approval scenarios: at least one configured engineering repo in the workdir (see the recipes' prerequisite notes).
 - macOS Docker Desktop caveat: a wedged `docker-credential-desktop` helper can stall `docker compose up --build` during registry auth — upstream of the harness's bounded wait, so boot appears to hang before any diagnostics. Verify with `docker-credential-desktop list </dev/null`; if it hangs, point `DOCKER_CONFIG` at a scratch dir without `credsStore` for the run (leave your real `~/.docker/config.json` untouched). The scratch config also drops the `desktop-linux` context, so additionally set `DOCKER_HOST=unix://$HOME/.docker/run/docker.sock` or every docker command will fail to reach the daemon (observed in the 2026-07-05 QA run).
 
+### Booting from a git worktree
+
+A worktree checkout is a fresh tree, so `workdir/` and `claude-data/` do not exist in it and the boot creates empty ones. An instance booted that way has no history and no per-channel state: the CLI task list has nothing to paginate, and — because the channel store is what makes announce-once work — **the instance re-announces every `Archie…` canvas into its real Slack channel on first contact.** That is a live, user-visible post caused purely by test setup.
+
+Before the first boot in a new worktree:
+
+```bash
+ln -s /path/to/main/checkout/workdir      workdir
+ln -s /path/to/main/checkout/claude-data  claude-data
+cp -R /path/to/main/checkout/secrets      secrets     # a real copy, NOT a symlink
+```
+
+`workdir` is designed for concurrent access by many containers, so sharing it between checkouts is correct rather than risky — and copying it is not an option at ~20G.
+
+**`secrets/` is the exception and must be a real directory.** `Dockerfile.dev` does `COPY secrets/ /tmp/ca-src/`, and Docker's build context does not follow symlinks at the context root: a symlinked `secrets` fails the build with `"/secrets": not found`. Bind mounts *do* follow host symlinks, which is why `workdir` and `claude-data` are fine. The same asymmetry is why `docker-compose.yml` re-mounts `./workdir/plugins` explicitly — a symlink *inside* a mounted tree does not resolve in the container.
+
+Also set a free `PORT` in the worktree's `.env`. Main's 3000 is usually taken by another checkout's container; `boot.ts` will relocate around a squatter on its own, but the `archie-debug` MCP resolves its URL once at spawn, so an explicit port is one less thing to reconcile.
+
 **Rollback:** delete `.claude/skills/archie-e2e/` and `tools/e2e/` — the harness has no side effects and nothing else references them (plus one `e2e-evidence/` line in `.gitignore`).
 
 ## 1. Boot


### PR DESCRIPTION
## What & why

The E2E harness already knows worktrees exist — `boot.ts` relocates around "a foreign archie from another worktree" holding the port — but nothing in the skill or the guides says how to *prepare* one. Following the documented boot steps exactly, in a fresh worktree, gets you an instance with an empty `workdir/`.

That is not just a thin test fixture. The channel store is what makes canvas announce-once work, so an instance with an empty workdir **re-announces every `Archie…` canvas into its real Slack channel on first contact** — a live, user-visible post caused purely by test setup. It also leaves the CLI task list with nothing to paginate, which makes some verification impossible rather than merely awkward.

I hit both of those while QA'ing #269 against the real workspace, from following the skill as written.

## How it works

A "Booting from a git worktree" subsection in the skill's Prerequisites, giving the three commands and — more usefully — why one of them differs:

- `workdir` and `claude-data` are **symlinked** to the main checkout. Sharing is correct rather than risky (workdir is built for concurrent container access), and copying isn't an option at ~20G.
- `secrets/` must be a **real copy**. `Dockerfile.dev` does `COPY secrets/ /tmp/ca-src/`, and Docker's build context does not follow symlinks at the context root — a symlinked `secrets` fails the build with `"/secrets": not found`. Bind mounts *do* follow host symlinks, which is why the other two are fine. That same asymmetry is why `docker-compose.yml` re-mounts `./workdir/plugins` explicitly.
- Set a free `PORT`, since the `archie-debug` MCP resolves its URL once at spawn.

Docs only — no code, no behaviour change.

## Verification

Not a code change, so there is nothing to run. The content is what I actually did to fix the instance mid-QA: after symlinking, two consecutive boots produced zero canvas announcements where the first boot had announced two, and the instance saw the real 297 sessions instead of an empty tree.

Split out of #269 deliberately — it is unrelated to that feature and #269 is already in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
