### PR TITLE
Document MoEngage MCP env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,9 @@ MCP_TEAMCITY_URL=https://your-teamcity-instance.com
 MCP_TEAMCITY_TOKEN=tc_your-api-token
 MCP_FIREBASE_SERVICE_ACCOUNT_PATH=/path/to/firebase-service-account-key.json
 MCP_ROLLBAR_ACCESS_TOKEN=your-rollbar-post-server-item-access-token
+MCP_MOENGAGE_API_KEY=your-moengage-campaign-api-key
+MCP_MOENGAGE_WORKSPACE_ID=your-moengage-workspace-id
+MCP_MOENGAGE_DATA_CENTER=02
 
 # OAuth-based MCP servers
 # Generate the key once and append it directly to .env so the value


### PR DESCRIPTION
Companion to sweatco/archie-plugins#149, which adds the `moengage` server to the plugins `.mcp.json`. Documents the three env vars it needs:

- `MCP_MOENGAGE_API_KEY` — Campaign API key (dashboard → Settings → Account → API keys; needs Campaigns **View** + **Create & Manage**)
- `MCP_MOENGAGE_WORKSPACE_ID` — workspace (app) ID
- `MCP_MOENGAGE_DATA_CENTER` — `02` matches our `dashboard-02.moengage.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1gFadbrWsENo4pYUh5Hg4