### PR TITLE
fix(slack): let watched-channel bot posts reach trigger dispatch

### DIFF
--- a/src/connectors/slack/__tests__/task-routing.test.ts
+++ b/src/connectors/slack/__tests__/task-routing.test.ts
@@ -55,3 +55,37 @@ describe('group-DM (G…) routing parity', () => {
     ).toBe(true);
   });
 });
+
+describe('bot_message routing (legacy-webhook bot posts)', () => {
+  // Bots posting through a legacy webhook carry `subtype: 'bot_message'`, which the
+  // subtype gate used to drop before trigger dispatch was ever consulted. They are
+  // forwarded only as a watched top-level channel post — the case the pre-existing
+  // "trigger is watching" test above missed, because it used a subtype-less human post.
+  const botPost = { type: 'message', subtype: 'bot_message', channel: 'C0XYZ', ts: '1' };
+
+  it('forwards a bot post when a trigger is watching the channel', () => {
+    expect(shouldForwardMessageEvent(botPost, () => true)).toBe(true);
+  });
+
+  it('ignores a bot post when no trigger is watching', () => {
+    expect(shouldForwardMessageEvent(botPost, () => false)).toBe(false);
+  });
+
+  it('ignores a bot thread reply even when a trigger is watching', () => {
+    expect(
+      shouldForwardMessageEvent({ ...botPost, ts: '2', thread_ts: '1' }, () => true),
+    ).toBe(false);
+  });
+
+  it('ignores a bot message in a DM', () => {
+    expect(
+      shouldForwardMessageEvent({ ...botPost, channel: 'D0ABC' }, () => true),
+    ).toBe(false);
+  });
+
+  it('still drops other subtypes, watched or not', () => {
+    expect(
+      shouldForwardMessageEvent({ ...botPost, subtype: 'message_changed' }, () => true),
+    ).toBe(false);
+  });
+});

--- a/src/connectors/slack/__tests__/task-routing.test.ts
+++ b/src/connectors/slack/__tests__/task-routing.test.ts
@@ -57,31 +57,13 @@ describe('group-DM (G…) routing parity', () => {
 });
 
 describe('bot_message routing (legacy-webhook bot posts)', () => {
-  const botPost = { type: 'message', subtype: 'bot_message', channel: 'C0XYZ', ts: '1' };
+  const bot = { type: 'message', subtype: 'bot_message', channel: 'C0XYZ', ts: '1' };
 
-  it('forwards a bot post when a trigger is watching the channel', () => {
-    expect(shouldForwardMessageEvent(botPost, () => true)).toBe(true);
-  });
-
-  it('ignores a bot post when no trigger is watching', () => {
-    expect(shouldForwardMessageEvent(botPost, () => false)).toBe(false);
-  });
-
-  it('ignores a bot thread reply even when a trigger is watching', () => {
-    expect(
-      shouldForwardMessageEvent({ ...botPost, ts: '2', thread_ts: '1' }, () => true),
-    ).toBe(false);
-  });
-
-  it('ignores a bot message in a DM', () => {
-    expect(
-      shouldForwardMessageEvent({ ...botPost, channel: 'D0ABC' }, () => true),
-    ).toBe(false);
-  });
-
-  it('still drops other subtypes, watched or not', () => {
-    expect(
-      shouldForwardMessageEvent({ ...botPost, subtype: 'message_changed' }, () => true),
-    ).toBe(false);
+  it('forwards only via the watched top-level arm', () => {
+    expect(shouldForwardMessageEvent(bot, () => true)).toBe(true);
+    expect(shouldForwardMessageEvent(bot, () => false)).toBe(false);
+    expect(shouldForwardMessageEvent({ ...bot, ts: '2', thread_ts: '1' }, () => true)).toBe(false);
+    expect(shouldForwardMessageEvent({ ...bot, channel: 'D0ABC' }, () => true)).toBe(false);
+    expect(shouldForwardMessageEvent({ ...bot, subtype: 'message_changed' }, () => true)).toBe(false);
   });
 });

--- a/src/connectors/slack/__tests__/task-routing.test.ts
+++ b/src/connectors/slack/__tests__/task-routing.test.ts
@@ -57,10 +57,6 @@ describe('group-DM (G…) routing parity', () => {
 });
 
 describe('bot_message routing (legacy-webhook bot posts)', () => {
-  // Bots posting through a legacy webhook carry `subtype: 'bot_message'`, which the
-  // subtype gate used to drop before trigger dispatch was ever consulted. They are
-  // forwarded only as a watched top-level channel post — the case the pre-existing
-  // "trigger is watching" test above missed, because it used a subtype-less human post.
   const botPost = { type: 'message', subtype: 'bot_message', channel: 'C0XYZ', ts: '1' };
 
   it('forwards a bot post when a trigger is watching the channel', () => {

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -789,7 +789,15 @@ export async function handleSlackEvent(event: {
     // Ambient top-level channel message (no task, not an @mention, not a thread
     // reply) — the only place channel-message triggers fire. @mentions and DMs
     // are excluded above so a message aimed at Archie never also fires a trigger.
-    await dispatchChannelMessageTriggers(event, thread.channel.name);
+    // Match on the fetched root, not `event`: attachments are stripped at the Bolt
+    // boundary, so a webhook bot's `event.text` is empty and its content — the part
+    // a filter needs to see — only exists on the re-fetched message.
+    const root = thread.messages.find((m) => m.ts === event.ts);
+    await dispatchChannelMessageTriggers(
+      event,
+      thread.channel.name,
+      root ? renderMessageForContext(root, { redacted: false }) : event.text,
+    );
   }
   // Otherwise: a reply in a human-started thread the bot wasn't part of — ignore
 }
@@ -802,6 +810,7 @@ export async function handleSlackEvent(event: {
 async function dispatchChannelMessageTriggers(
   event: { channel: string; user: string; text: string; ts: string },
   channelName: string,
+  matchText: string,
 ): Promise<void> {
   const triggers = getChannelMessageTriggers(event.channel);
   if (triggers.length === 0) return;
@@ -809,7 +818,7 @@ async function dispatchChannelMessageTriggers(
   const matches = (trigger: Trigger): boolean =>
     trigger.conditions.some((c) => {
       if (c.type !== 'channel_message' || c.channel_id !== event.channel) return false;
-      if (c.match?.contains && !event.text.toLowerCase().includes(c.match.contains.toLowerCase())) return false;
+      if (c.match?.contains && !matchText.toLowerCase().includes(c.match.contains.toLowerCase())) return false;
       if (c.match?.from_user && event.user !== c.match.from_user) return false;
       return true;
     });
@@ -819,7 +828,7 @@ async function dispatchChannelMessageTriggers(
     try {
       await fireTrigger(trigger, {
         kind: 'message',
-        text: event.text,
+        text: matchText,
         threadId: event.ts,
         channelId: event.channel,
         channelName,

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -789,9 +789,7 @@ export async function handleSlackEvent(event: {
     // Ambient top-level channel message (no task, not an @mention, not a thread
     // reply) — the only place channel-message triggers fire. @mentions and DMs
     // are excluded above so a message aimed at Archie never also fires a trigger.
-    // Match on the fetched root, not `event`: attachments are stripped at the Bolt
-    // boundary, so a webhook bot's `event.text` is empty and its content — the part
-    // a filter needs to see — only exists on the re-fetched message.
+    // Bolt strips attachments: `event.text` is empty for a webhook bot, the root isn't.
     const root = thread.messages.find((m) => m.ts === event.ts);
     await dispatchChannelMessageTriggers(
       event,

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -790,12 +790,8 @@ export async function handleSlackEvent(event: {
     // reply) — the only place channel-message triggers fire. @mentions and DMs
     // are excluded above so a message aimed at Archie never also fires a trigger.
     // Bolt strips attachments: `event.text` is empty for a webhook bot, the root isn't.
-    const root = thread.messages.find((m) => m.ts === event.ts);
-    await dispatchChannelMessageTriggers(
-      event,
-      thread.channel.name,
-      root ? renderMessageForContext(root, { redacted: false }) : event.text,
-    );
+    const root = thread.messages.find((m) => m.ts === event.ts) ?? { text: event.text };
+    await dispatchChannelMessageTriggers(event, thread.channel.name, renderMessageForContext(root, { redacted: false }));
   }
   // Otherwise: a reply in a human-started thread the bot wasn't part of — ignore
 }
@@ -806,9 +802,9 @@ export async function handleSlackEvent(event: {
  * the triggering thread. External authors are already filtered upstream.
  */
 async function dispatchChannelMessageTriggers(
-  event: { channel: string; user: string; text: string; ts: string },
+  event: { channel: string; user: string; ts: string },
   channelName: string,
-  matchText: string,
+  text: string,
 ): Promise<void> {
   const triggers = getChannelMessageTriggers(event.channel);
   if (triggers.length === 0) return;
@@ -816,7 +812,7 @@ async function dispatchChannelMessageTriggers(
   const matches = (trigger: Trigger): boolean =>
     trigger.conditions.some((c) => {
       if (c.type !== 'channel_message' || c.channel_id !== event.channel) return false;
-      if (c.match?.contains && !matchText.toLowerCase().includes(c.match.contains.toLowerCase())) return false;
+      if (c.match?.contains && !text.toLowerCase().includes(c.match.contains.toLowerCase())) return false;
       if (c.match?.from_user && event.user !== c.match.from_user) return false;
       return true;
     });
@@ -826,7 +822,7 @@ async function dispatchChannelMessageTriggers(
     try {
       await fireTrigger(trigger, {
         kind: 'message',
-        text: matchText,
+        text,
         threadId: event.ts,
         channelId: event.channel,
         channelName,

--- a/src/connectors/slack/task-routing.ts
+++ b/src/connectors/slack/task-routing.ts
@@ -43,8 +43,12 @@ export function isAckableEvent(eventType: string, channelId: string): boolean {
  * Verbatim extraction of the inline filter at events.ts:167-180.
  *
  * Returns false unless `type === 'message'` and the subtype is empty or one of
- * `file_share` / `thread_broadcast`. Otherwise forwards when the message is a
- * thread reply, a DM, or a watched top-level channel post.
+ * `file_share` / `thread_broadcast` / `bot_message`. Otherwise forwards when the
+ * message is a thread reply, a DM, or a watched top-level channel post.
+ *
+ * `bot_message` is forwarded ONLY as a watched top-level channel post. Bots that
+ * post through a legacy webhook (empty `text`, content in attachments) carry that
+ * subtype, which is how a watched report never reached trigger dispatch at all.
  *
  * `hasWatchingTrigger` is a lazy predicate: it is only consulted for top-level
  * channel posts, so the trigger-index lookup still never runs for DMs or thread
@@ -67,12 +71,13 @@ export function shouldForwardMessageEvent(
   if (event.type !== 'message') {
     return false;
   }
-  if (event.subtype && !['file_share', 'thread_broadcast'].includes(event.subtype)) {
+  if (event.subtype && !['file_share', 'thread_broadcast', 'bot_message'].includes(event.subtype)) {
     return false;
   }
   const isDm = event.channel.startsWith('D');
   const isThreadReply = !!event.thread_ts && event.thread_ts !== event.ts;
   const isTopLevelChannelMsg = !isDm && !isThreadReply && !event.thread_ts;
   const watchedByTrigger = isTopLevelChannelMsg && hasWatchingTrigger(event.channel);
+  if (event.subtype === 'bot_message') return watchedByTrigger;
   return isThreadReply || isDm || watchedByTrigger;
 }

--- a/src/connectors/slack/task-routing.ts
+++ b/src/connectors/slack/task-routing.ts
@@ -40,15 +40,11 @@ export function isAckableEvent(eventType: string, channelId: string): boolean {
 
 /**
  * Whether an inbound `message` event should be forwarded into task routing.
- * Verbatim extraction of the inline filter at events.ts:167-180.
  *
  * Returns false unless `type === 'message'` and the subtype is empty or one of
  * `file_share` / `thread_broadcast` / `bot_message`. Otherwise forwards when the
- * message is a thread reply, a DM, or a watched top-level channel post.
- *
- * `bot_message` is forwarded ONLY as a watched top-level channel post. Bots that
- * post through a legacy webhook (empty `text`, content in attachments) carry that
- * subtype, which is how a watched report never reached trigger dispatch at all.
+ * message is a thread reply, a DM, or a watched top-level channel post — except
+ * `bot_message` (legacy-webhook bots), which forwards only via the watched arm.
  *
  * `hasWatchingTrigger` is a lazy predicate: it is only consulted for top-level
  * channel posts, so the trigger-index lookup still never runs for DMs or thread

--- a/src/connectors/slack/task-routing.ts
+++ b/src/connectors/slack/task-routing.ts
@@ -42,9 +42,8 @@ export function isAckableEvent(eventType: string, channelId: string): boolean {
  * Whether an inbound `message` event should be forwarded into task routing.
  *
  * Returns false unless `type === 'message'` and the subtype is empty or one of
- * `file_share` / `thread_broadcast` / `bot_message`. Otherwise forwards when the
- * message is a thread reply, a DM, or a watched top-level channel post — except
- * `bot_message` (legacy-webhook bots), which forwards only via the watched arm.
+ * `file_share` / `thread_broadcast` / `bot_message`. Otherwise forwards thread
+ * replies, DMs, and watched top-level channel posts — `bot_message` only the last.
  *
  * `hasWatchingTrigger` is a lazy predicate: it is only consulted for top-level
  * channel posts, so the trigger-index lookup still never runs for DMs or thread
@@ -74,6 +73,5 @@ export function shouldForwardMessageEvent(
   const isThreadReply = !!event.thread_ts && event.thread_ts !== event.ts;
   const isTopLevelChannelMsg = !isDm && !isThreadReply && !event.thread_ts;
   const watchedByTrigger = isTopLevelChannelMsg && hasWatchingTrigger(event.channel);
-  if (event.subtype === 'bot_message') return watchedByTrigger;
-  return isThreadReply || isDm || watchedByTrigger;
+  return watchedByTrigger || (event.subtype !== 'bot_message' && (isThreadReply || isDm));
 }


### PR DESCRIPTION
## The problem

A channel-message trigger could never fire on a report posted by a bot through a legacy incoming webhook. Two independent causes, both upstream of the trigger itself:

- **The event was discarded before triggers were consulted.** Those posts arrive with `subtype: bot_message`, which the inbound subtype gate dropped outright.
- **The filter tested an empty string.** Their `text` is empty and all content lives in attachments, which Bolt strips at the event boundary — so the `contains` filter matched against `""`.

## The fix

- `bot_message` now passes the gate, but **only as a watched top-level channel post** — never a thread reply, never a DM. A channel with no trigger watching it behaves exactly as before, so the blast radius is the set of channels that already have a trigger.
- The `contains` filter matches the re-fetched root message rendered through `renderMessageForContext` — the same helper `read_channel_history` already uses for attachment-only messages. Root-only on purpose: rendering replies too would let a human quoting the phrase fire the trigger.

Deliberately unchanged: the matcher stays inline, `FireContext.text` stays unread, and no agent gains a tool or permission.

## Verified live, both ways

Run against real instances fed by real Slack events, with a throwaway trigger watching #archie-test-channel for "Expired Feature Flags Report". The probe went through a genuine Slack incoming webhook, reproducing the report's shape exactly — `subtype: bot_message`, empty `text`, phrase only in `attachments[0].text` — with a third-party `bot_id` (`B0BQKB5G0KF`), so it was never a self-authored post.

| Build | Message | Result |
|---|---|---|
| base `544a538` | [webhook probe](https://sweatcoin.slack.com/archives/C0BL50N2600/p1786963661555699) | **nothing** — no task, no fire, no log line |
| base `544a538` | [control](https://sweatcoin.slack.com/archives/C0BL50N2600/p1786963556094269) — phrase in `text` | **fired** → [`PROBE OK`](https://sweatcoin.slack.com/archives/C0BL50N2600/p1786963569596199?thread_ts=1786963556.094269) in-thread |
| this PR | [same webhook probe](https://sweatcoin.slack.com/archives/C0BL50N2600/p1786970098895989) | **fired** → [`PROBE OK`](https://sweatcoin.slack.com/archives/C0BL50N2600/p1786970116511159?thread_ts=1786970098.895989) in the probe's own thread, 18s later |

`544a538` is the commit production runs, and its control fired seconds before the probe was ignored — so the silence was the subtype gate, not a dead pipeline. On this PR the reply lands in the webhook message's own thread, which is exactly the path the real report needs for its file attachment.

## Also verified

- Against the four real messages of an actual report: all four were dropped before, all four now reach dispatch, and only the header matches the filter — one fire per report rather than one per chunk.
- `npm run typecheck` and `npm run build` clean; new routing test covers all four arms of the bot case. The one suite failure, `TaskList.test.tsx`, fails identically on unmodified `main`.

## Before merge

Production pins its image tag in the systemd unit on `archie-hq0`, so merging alone changes nothing until someone bumps it and restarts.

