### PR TITLE
fix(sandbox): share package-manager caches instead of one per task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - NODE_ENV=development
 
     volumes:
-      # Workdir mount — contains repos/, sessions/
+      # Workdir mount — contains repos/, sessions/, caches/
       - ./workdir:/workdir
 
       # Plugins — mounted explicitly because workdir/plugins is a symlink

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -276,6 +276,7 @@ archie-hq/
 ├── workdir/              # Runtime state (gitignored)
 │   ├── plugins/          # Symlink to archie-plugins (or auto-cloned via ARCHIE_PLUGINS)
 │   ├── plugins-data/     # Persistent per-plugin data
+│   ├── caches/           # Shared npm/yarn/Corepack caches (all agents, all tasks)
 │   ├── repos/            # Auto-cloned (or pre-cloned with SSH)
 │   └── sessions/         # Task persistence (shared/metadata.json, shared/knowledge.log)
 └── docs/                 # Documentation

--- a/src/agents/__tests__/sandbox.test.ts
+++ b/src/agents/__tests__/sandbox.test.ts
@@ -16,6 +16,7 @@ import {
   TRUSTED_PACKAGE_REGISTRY_DOMAINS,
   type SandboxOptions,
 } from '../sandbox.js';
+import { CACHES_DIR } from '../../system/workdir.js';
 
 const base: SandboxOptions = {
   cwd: '/workdir/sessions/task-1/workspace',
@@ -58,12 +59,10 @@ describe('buildManagedNetworkPolicy', () => {
 });
 
 describe('buildPackageManagerCacheEnv', () => {
-  const WORKSPACE = '/workdir/sessions/task-1/workspace';
-
   it('moves npm and yarn caches off the read-only $HOME', () => {
-    const env = buildPackageManagerCacheEnv(WORKSPACE);
-    expect(env.npm_config_cache).toBe(`${WORKSPACE}/.cache/npm`);
-    expect(env.YARN_CACHE_FOLDER).toBe(`${WORKSPACE}/.cache/yarn`);
+    const env = buildPackageManagerCacheEnv();
+    expect(env.npm_config_cache).toBe(`${CACHES_DIR}/npm`);
+    expect(env.YARN_CACHE_FOLDER).toBe(`${CACHES_DIR}/yarn`);
   });
 
   it('redirects yarn 4 global folder and Corepack home, not just the cache', () => {
@@ -71,26 +70,26 @@ describe('buildPackageManagerCacheEnv', () => {
     // redirected cache alone leaves it dying on ENOENT (observed with the mobile
     // repo's pinned yarn 4.12.0). Corepack fetches pinned releases into
     // COREPACK_HOME, which is unwritable for the same reason.
-    const env = buildPackageManagerCacheEnv(WORKSPACE);
-    expect(env.YARN_GLOBAL_FOLDER).toBe(`${WORKSPACE}/.cache/yarn-global`);
-    expect(env.COREPACK_HOME).toBe(`${WORKSPACE}/.cache/corepack`);
+    const env = buildPackageManagerCacheEnv();
+    expect(env.YARN_GLOBAL_FOLDER).toBe(`${CACHES_DIR}/yarn-global`);
+    expect(env.COREPACK_HOME).toBe(`${CACHES_DIR}/corepack`);
   });
 
-  it('scopes caches per workspace so agents cannot share a cache', () => {
-    // A shared cache (e.g. under /tmp) would let one agent stage content another
-    // agent later installs from.
-    const a = buildPackageManagerCacheEnv('/workdir/sessions/task-a/workspace');
-    const b = buildPackageManagerCacheEnv('/workdir/sessions/task-b/workspace');
-    expect(a.npm_config_cache).not.toBe(b.npm_config_cache);
-    expect(a.YARN_CACHE_FOLDER).not.toBe(b.YARN_CACHE_FOLDER);
-  });
-
-  it('keeps every cache path inside the workspace, which is the writable region', () => {
-    // If a cache escaped the workspace it would land somewhere denied and the
-    // EROFS failure would come straight back.
-    for (const value of Object.values(buildPackageManagerCacheEnv(WORKSPACE))) {
-      expect(value.startsWith(`${WORKSPACE}/`)).toBe(true);
+  it('shares one cache across agents and tasks rather than scoping it per workspace', () => {
+    // The regression this guards: caches used to live at
+    // `<task>/agents/<agent>/.cache`, so every task re-downloaded the same bytes
+    // and kept them forever — 697 per-task caches, ~285 GB, never reclaimed. The
+    // paths are constants now precisely so no caller can reintroduce that.
+    const env = buildPackageManagerCacheEnv();
+    expect(env).toEqual(buildPackageManagerCacheEnv());
+    for (const value of Object.values(env)) {
+      expect(value.startsWith(`${CACHES_DIR}/`)).toBe(true);
+      expect(value).not.toContain('/sessions/');
     }
+  });
+
+  it('takes no arguments, so a cache cannot be scoped to a caller-supplied path', () => {
+    expect(buildPackageManagerCacheEnv.length).toBe(0);
   });
 });
 

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -15,6 +15,7 @@
 
 import { resolve, normalize } from 'path';
 import type { HookCallbackMatcher, HookJSONOutput } from '@anthropic-ai/claude-agent-sdk';
+import { CACHES_DIR } from '../system/workdir.js';
 
 // ---- Types ----
 
@@ -150,9 +151,44 @@ export function buildManagedNetworkPolicy(opts: SandboxOptions) {
  * is what actually blocked `npm install` in edit mode; the failure reads like a
  * network problem (it names the registry URL) but is purely filesystem.
  *
- * Pointed at the agent's own workspace rather than a shared `/tmp`: a shared
- * cache would let one agent stage content that another agent later installs
- * from, which is a cross-task integrity problem we get to avoid for free.
+ * Shared across every agent and task (`CACHES_DIR`), NOT per workspace. This
+ * used to point at the agent's own workspace to avoid a shared cache letting one
+ * agent stage content another agent later installs from — the alternative on the
+ * table then was `/tmp`, which is world-writable inside the sandbox and a bad
+ * place for this. A managed directory under the workdir is not: it costs one
+ * `allowWrite` entry, and the caches it holds are content-addressed and verified
+ * on read, so the staging attack does not survive the integrity check.
+ *
+ * Verified rather than assumed, because the whole design rests on it. Corrupting
+ * a cached tarball for a lockfile-pinned package and reinstalling gives
+ * `npm warn tarball ... seems to be corrupted. Refreshing cache.` — npm hashes
+ * content while streaming and compares against the lockfile's `integrity`, so a
+ * mismatch discards the entry and refetches. Poisoning a pinned install needs a
+ * SHA-512 preimage. Yarn Berry checks cache zips against `yarn.lock` checksums
+ * (`checksumBehavior: throw`) on the same terms.
+ *
+ * The exception, accepted knowingly: `_npx`. It is a materialized, *executable*
+ * `node_modules` that npx reuses on directory presence and never re-verifies —
+ * appending to a file inside it and re-running the same `npx` command executes
+ * the modified code, with a `package-lock.json` sitting unread beside it. npm
+ * derives `_npx`, `_cacache` and `_tuf` from the single `cache` config
+ * (`@npmcli/config` definitions: `cache`), so there is no env that splits them.
+ * MCP servers launched `npx -y` therefore share a tamperable tree. Closing it
+ * means either preinstalling those servers in the image (couples the plugins repo
+ * to the Dockerfile) or symlinking `_cacache` out to a shared dir while `_npx`
+ * stays per-task and gets reaped. Both work; neither was worth the complexity
+ * against a per-task cost of ~285 GB.
+ *
+ * Note the sharing is only sound for package managers that verify against a
+ * committed lockfile. pip (`requirements.txt` without hashes) and Bundler
+ * (`Gemfile.lock` carries no digests) do NOT have this property — do not add
+ * their caches here on the strength of the reasoning above.
+ *
+ * Concurrency: npm's `_cacache` is built for concurrent writers. Yarn Berry's
+ * global cache is weaker — parallel installs can leave a partial zip — but
+ * `checksumBehavior: throw` rejects it and refetches, so it surfaces as a flaky
+ * install rather than a silently wrong one. `createKeyedLock` is available if
+ * that ever shows up in practice.
  *
  * `npm_config_cache` is npm's env form of the `cache` config; yarn 1 reads
  * `YARN_CACHE_FOLDER`. Yarn 4 (Berry) needs more: it creates its *global folder*
@@ -166,8 +202,8 @@ export function buildManagedNetworkPolicy(opts: SandboxOptions) {
  * instantly on the global-folder ENOENT while yarn 1 in the same sandbox worked
  * fine — which is why this covers both generations rather than just the cache.
  */
-export function buildPackageManagerCacheEnv(workspace: string): Record<string, string> {
-  const cacheRoot = resolve(workspace, '.cache');
+export function buildPackageManagerCacheEnv(): Record<string, string> {
+  const cacheRoot = CACHES_DIR;
   return {
     npm_config_cache: resolve(cacheRoot, 'npm'),
     YARN_CACHE_FOLDER: resolve(cacheRoot, 'yarn'),

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -39,7 +39,7 @@ import {
   appendUsageRecord,
   readKnowledgeLog,
 } from '../tasks/persistence.js';
-import { WORKDIR, getBaseCachePath, getPluginsHeadInfo } from '../system/workdir.js';
+import { WORKDIR, CACHES_DIR, getBaseCachePath, getPluginsHeadInfo } from '../system/workdir.js';
 import {
   createRecoverableInputGenerator,
 } from './message-queue.js';
@@ -324,7 +324,10 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
     cwd,
     denyReadPaths: [WORKDIR],
     allowReadPaths: [workspace, sharedPath, ...claudeReadDirs, ...pluginReadPaths],
-    allowWritePaths: [workspace, ...claudeWriteDirs],
+    // CACHES_DIR is shared by every agent and must be writable, or package
+    // managers hit the EROFS that buildPackageManagerCacheEnv exists to avoid.
+    // allowWrite only — a path in both lists loses its rw mount (see sandbox.ts).
+    allowWritePaths: [workspace, CACHES_DIR, ...claudeWriteDirs],
     denyWritePaths: [sharedPath, ...pluginPaths, ...protectedWorkspaceFiles],
     allowedNetworkDomains: def.allowedNetworkDomains,
   };
@@ -553,9 +556,11 @@ Shared folder: ${sharedPath} [READ-ONLY]
       cwd,
       denyReadPaths: [WORKDIR],
       allowReadPaths: [workspace, ...allClonePaths, ...claudeReadDirs, ...readOnlyPaths],
+      // CACHES_DIR stays writable in both modes: a readonly agent still runs
+      // package managers (typecheck, test), and they need the cache regardless.
       allowWritePaths: editAllowed
-        ? [workspace, ...allClonePaths, ...claudeWriteDirs]
-        : [workspace, ...claudeWriteDirs],
+        ? [workspace, CACHES_DIR, ...allClonePaths, ...claudeWriteDirs]
+        : [workspace, CACHES_DIR, ...claudeWriteDirs],
       denyWritePaths: editAllowed
         ? [...readOnlyPaths, ...protectedWorkspaceFiles, ...cloneGitHeads]
         : [...allClonePaths, ...readOnlyPaths],
@@ -693,7 +698,7 @@ Shared folder: ${sharedPath} [READ-ONLY]
       CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
       // Redirect npm/yarn caches off the read-only $HOME, or installs fail with
       // EROFS before the network allowlist matters. See buildPackageManagerCacheEnv.
-      ...buildPackageManagerCacheEnv(workspace),
+      ...buildPackageManagerCacheEnv(),
       // Sourced by every non-interactive bash the agent runs; maps the sandbox's
       // per-session proxy onto tools that ignore the standard *_PROXY vars (Yarn
       // Berry). Set by the Dockerfiles — forwarded because the SDK replaces env.

--- a/src/system/workdir.ts
+++ b/src/system/workdir.ts
@@ -42,6 +42,20 @@ export const TRIGGERS_DIR = join(WORKDIR, 'triggers');
 export const PLUGINS_DATA_DIR = join(WORKDIR, 'plugins-data');
 
 /**
+ * Shared package-manager caches (npm, yarn, Corepack), written by every agent.
+ *
+ * Deliberately outside `SESSIONS_DIR`: cache content is a function of the
+ * lockfiles being installed, not of the task installing them, so scoping it per
+ * task means every task re-downloads the same bytes and keeps its own copy
+ * forever. That is what it did until this directory existed — 697 per-task
+ * caches holding ~285 GB, two thirds of it a single `_npx` tree.
+ *
+ * See `buildPackageManagerCacheEnv` for why sharing is safe (and the one place
+ * it isn't).
+ */
+export const CACHES_DIR = join(WORKDIR, 'caches');
+
+/**
  * Directory holding encrypted runtime secrets (e.g. OAuth tokens).
  * Defaults to `/app/secrets` (the docker-mounted volume) when present,
  * otherwise `<repo>/secrets` for local development. Override with
@@ -77,6 +91,7 @@ export async function bootstrapWorkdir(): Promise<void> {
   await mkdir(SESSIONS_DIR, { recursive: true });
   await mkdir(TRIGGERS_DIR, { recursive: true });
   await mkdir(PLUGINS_DATA_DIR, { recursive: true });
+  await mkdir(CACHES_DIR, { recursive: true });
   await mkdir(OAUTH_DIR, { recursive: true, mode: 0o700 });
   await mkdir(OAUTH_PENDING_DIR, { recursive: true, mode: 0o700 });
 

--- a/tools/e2e/egress-probe.mts
+++ b/tools/e2e/egress-probe.mts
@@ -17,6 +17,7 @@
  * gets), so a pass here bounds every other agent.
  */
 
+import { dirname } from 'node:path';
 import { query } from '/app/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs';
 import {
   buildSandboxConfig,
@@ -32,10 +33,21 @@ const ALLOWED_HOST = `https://${TRUSTED_PACKAGE_REGISTRY_DOMAINS[0]}/npm`;
 
 const WORKSPACE = '/tmp/egress-check-ws';
 
+// Package-manager caches live in one shared directory outside the workspace, so
+// the probe's sandbox has to allow writing there or step 3 fails on EROFS for a
+// reason that has nothing to do with the network. Derived from the env builder
+// rather than hardcoded: this file is outside `tsconfig.json`'s `src/**/*`
+// include, so a drifting cache location is not a type error here — it is a
+// silent PKG=failed. Reading the path back from the function keeps the two in
+// step by construction.
+const cacheEnv = buildPackageManagerCacheEnv();
+const CACHE_ROOT = dirname(cacheEnv.npm_config_cache);
+
 const sandboxOpts = {
   cwd: WORKSPACE,
   allowReadPaths: [WORKSPACE],
-  allowWritePaths: [WORKSPACE],
+  // allowWrite only — a path in both lists loses its rw mount (see sandbox.ts).
+  allowWritePaths: [WORKSPACE, CACHE_ROOT],
   allowedNetworkDomains: [...TRUSTED_PACKAGE_REGISTRY_DOMAINS],
 };
 
@@ -62,7 +74,7 @@ const it = query({
       SHELL: '/bin/bash',
       // Same cache redirection spawn.ts applies — without it npm dies on the
       // read-only $HOME and step 3 fails for a reason unrelated to the network.
-      ...buildPackageManagerCacheEnv(WORKSPACE),
+      ...cacheEnv,
       // Same as spawn.ts: maps the sandbox proxy onto Yarn Berry's own config keys.
       ...(process.env.BASH_ENV ? { BASH_ENV: process.env.BASH_ENV } : {}),
       ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),


### PR DESCRIPTION
Moves package-manager caches from `<task>/agents/<agent>/.cache` to a single `workdir/caches/`, shared by every agent and task. Addresses the recent growth curve in #275 (see [the investigation comment](https://github.com/sweatco/archie-hq/issues/275#issuecomment-5315983506) for the full measurements).

## Why

`2b23da0` fixed a real bug — `$HOME` is not writable in the sandbox, so `npm install` died on `EROFS` while fetching, before the network allowlist mattered. It redirected the caches into the agent's workspace. The alternative it weighed was `/tmp`, which is world-writable inside the sandbox and rightly rejected; but "not `/tmp`" became "per task", and a managed directory under the workdir was never on the table.

Cache content is a function of the lockfiles being installed, not of the task installing them. So every task re-downloaded the same bytes into its own directory, and nothing ever deletes a task directory.

Measured on prod before this change:

- **697** per-task caches holding **~285 GB** of the **424 GB** under `sessions/`
- `.cache` dirs created after `2b23da0`: **697**. Created before it: **0**.
- Median task directory: **1.4 MB → 301 MB** across that commit (Jul 28 → Jul 29)
- Worst per task: `mobile` 792 MB, `release-manager` 752 MB, `growth-ops` 301 MB

Steady state is now bounded by *distinct packages* rather than *tasks × packages*, and installs stop re-downloading — so this is a latency and bandwidth win as well as disk.

## Why sharing is safe

These caches are content-addressed and verified on read, which I checked rather than assumed:

- Corrupting a cached tarball for a lockfile-pinned package and reinstalling gives `npm warn tarball ... seems to be corrupted. Refreshing cache.` — npm hashes content while streaming and compares against the lockfile's `integrity`, so a mismatch discards the entry and refetches. Poisoning a pinned install needs a SHA-512 preimage.
- Yarn Berry validates cache zips against `yarn.lock` `checksum:` entries (`checksumBehavior: throw` by default), on the same terms.

The reasoning is npm/yarn-specific and the call-site comment says so: pip (`requirements.txt` without hashes) and Bundler (`Gemfile.lock` carries no digests) do **not** have this property, so their caches must not be added here on the strength of it.

## The accepted exception: `_npx`

`_npx` is a materialized, *executable* `node_modules` that npx reuses on directory presence and never re-verifies. Appending a line to a file inside it and re-running the same `npx` command executes the modified code, with a `package-lock.json` sitting unread beside it. So MCP servers launched `npx -y` (e.g. `@sweatco/gws-cli-mcp`) now share a tree a compromised agent could tamper with.

npm derives `_npx`, `_cacache` and `_tuf` from the single `cache` config (`@npmcli/config` definitions), so no environment variable splits them. The two ways to close it:

1. **Preinstall** the MCP servers in the image and drop `npx` from `.mcp.json` — clean, but couples the plugins repo to the Dockerfile, cutting against plugins being independently deployable.
2. **Symlink `_cacache`** out to the shared directory while `_npx` stays per-task and gets reaped — verified working, including an offline reinstall from the warm shared cache, so a per-task `_npx` costs no bandwidth.

Both work. Neither was judged worth the complexity against a per-task cost of ~285 GB. This is a deliberate risk acceptance, documented at the call site so the next reader inherits the reasoning rather than the conclusion.

## Concurrency

npm's `_cacache` is built for concurrent writers. Yarn Berry's global cache is weaker — parallel installs can leave a partial zip — but `checksumBehavior: throw` rejects it and refetches, so it surfaces as a flaky install rather than a silently wrong one. `createKeyedLock` is available if that shows up in practice; not pre-built.

## What this does not fix

The slower pre-existing growth in #275 stays open: edit-mode clones never reclaimed (~0.8 GB/day since March), plus `claude/*/tmp` and `shared/attachments`. Those still want a retention policy — but the rate drops from ~18 GB/day to ~1 GB/day, which turns it from urgent into schedulable.

## Changes

- `src/system/workdir.ts` — `CACHES_DIR` constant, created in `bootstrapWorkdir()`
- `src/agents/sandbox.ts` — `buildPackageManagerCacheEnv()` takes no argument and returns constant paths; the rationale comment is rewritten to record the integrity evidence, the `_npx` exception, the pip/Bundler caveat, and the concurrency note
- `src/agents/spawn.ts` — one call site; `CACHES_DIR` added to `allowWritePaths` for both the base and repo-agent sandboxes (allowWrite only — a path in both lists loses its rw mount)
- `src/agents/__tests__/sandbox.test.ts` — the two tests that asserted per-workspace scoping are replaced by ones asserting the shared invariant and that the function takes no path argument, so the old behavior cannot be reintroduced quietly
- `docs/guides/local-development.md`, `docker-compose.yml` — workdir layout mentions `caches/`

## Verification

`npm run typecheck` clean; full suite **1108 passed (78 files)**.

Verified live on a booted instance (`archie-e2e`), attested against this branch's SHA.

**The live run caught a regression in this PR.** The first egress check failed with `PKG=failed`. Attributed by running the same check against both branches:

| instance | result |
| --- | --- |
| `8fa4dea` (pre-change baseline) | `npm install: ok` — passed |
| `85cb72b` (this branch, before the probe fix) | `PKG=failed` — failed |

`tools/e2e/egress-probe.mts` builds its **own** `SandboxOptions` rather than going through `spawn.ts`, listing only its workspace in `allowWrite`. Once the caches moved, npm died on `EROFS` there and the check reported the *network* boundary as broken — exactly the misattribution `buildPackageManagerCacheEnv`'s comment warns about. It escaped static checking because `tsconfig.json` includes only `src/**/*`, so the probe's stale `buildPackageManagerCacheEnv(WORKSPACE)` call (one argument to a now-zero-argument function) was not a type error. Fixed in `5bbd477`, which also derives the cache root from the function's return instead of hardcoding it, so the two cannot drift again.

After that fix:

```
npm install:          ok (expected ok)
yarn berry proxy:     mapped (expected mapped)
Egress check passed: sandboxed Bash reaches allowlisted hosts only.
```

Verified from a real sandboxed agent inside the container:

| Claim | Evidence |
| --- | --- |
| Cache is shared, not per-task | `echo $npm_config_cache` → `/workdir/caches/npm` |
| Install works, no EROFS | `added 1 package in 170ms`; dir is `drwxr-xr-x archie archie` |
| Shared cache actually used | `left-pad` index entries in `/workdir/caches/npm/_cacache/index-v5` |
| No per-task `.cache` created | `find sessions -maxdepth 4 -name .cache -newermt <boot>` → 0 |
| Lifecycle unaffected | `basic-nonce`: `task:created` → PM reply → `task:completed` |

Evidence files: `e2e-evidence/basic-nonce.{json,md}`. Teardown clean.

### Repo agent + real yarn install, through the edit-mode path

The run above only exercised the *base* sandbox. A second `edit-mode-approval` run covers the `editAllowed` branch of `allowWritePaths` and a real Yarn Berry install, on `sweatco/sweatcoin-frontend` (yarn 4.5.3, Corepack-pinned):

| Claim | Evidence |
| --- | --- |
| Repo agent spawns; edit-mode gate works end to end | `Spawned repo agent frontend-83df-agent`; `Edit mode requested` → `Edit mode approved by user` → agent `[completion]` |
| `yarn install` succeeds in the edit-mode sandbox | `Done with warnings in 30s`; agent: "NO EROFS / read-only-filesystem errors in any of the six commands" |
| Yarn writes to the shared cache, not the task dir | `$YARN_GLOBAL_FOLDER=/workdir/caches/yarn-global` → cache **736 MB**; per-task `.cache` dirs created: **0** |
| **A second task reuses that cache** | `frontend-6c8a-agent` in a different task: install **17.4s** (vs 30s cold), cache **unchanged at 736 MB**, "Fetch step took 0s 985ms = no new downloads" |

That last row is the whole point of the change, measured: under the per-task scheme the second task would have downloaded its own 736 MB copy. Both task clones still hold their own `node_modules` (859 MB / 340 MB) — that is the materialized install, not the cache, and it is what the separate retention policy in #275 would reap.

Evidence files: `e2e-evidence/edit-mode-approval.{json,md}`.

### Two findings from the run (neither caused by this PR)

- **`YARN_CACHE_FOLDER` is dead config for Yarn Berry.** Yarn 4.5.3 ignored it and used `$YARN_GLOBAL_FOLDER/cache`; `/workdir/caches/yarn` was never created. `YARN_CACHE_FOLDER` is the yarn 1 variable, which the existing comment already says — worth knowing it contributes nothing on Berry repos. `COREPACK_HOME` likewise stayed unused (yarn resolves from the image, so the `packageManager` pin triggered no Corepack fetch).
- **node-gyp's cache is still unwritable.** Two native postinstalls (`@newrelic/native-metrics`, `@contrast/fn-inspect`) failed with `ENOENT: mkdir '/home/archie/.cache/node-gyp'`. node-gyp derives that path from `$HOME`, which this PR does not touch, so the gap predates it and is unchanged by it — but it is the same class of bug `buildPackageManagerCacheEnv` exists to fix, and native modules do not build in the sandbox today. Not folded in here to keep the diff to one decision; worth its own change (an `npm_config_devdir` pointed at `CACHES_DIR`).

### Still not covered

**Concurrency.** Two agents installing into the shared cache simultaneously — the known risk noted above. Both installs in this run were sequential.

## Operational note

Existing `sessions/task-*/agents/*/.cache` directories are orphaned by this change — nothing reads them after deploy. They are safe to delete for any task that is not `in_progress`; they are pure caches and regenerate on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
