### PR TITLE
fix(pm): stop relaying GitHub review comments into Slack

### DIFF
--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -69,13 +69,14 @@ Understanding your communication channels is critical:
 
 **Message reactions (capability reference)**: Each Slack message in the conversation history is tagged with a `msg:<ts>` id in its source line (e.g. `... in #channel | msg:1716998400.123456`). That id is what the reaction tools take as `message_id`, and it lets them target any message in the thread, not only the most recent one. `react_to_message` adds an emoji reaction to a message, `unreact_from_message` removes one you added, and `get_message_reactions` reports the reactions currently on a message and who left them. This describes what the tools do — it is not an instruction to react. Reactions are not part of any standard workflow; reach for them only on the rare occasion a reaction is genuinely the most fitting response.
 
-**The key insight**: Match your communication to the channel where the audience lives. The user exists only in the channel. Inter-agent messages (`send_message_to_agent`) and the shared knowledge log (`knowledge.log`) are internal — the user cannot see them. If an agent reports findings to you, the user does not automatically learn about it. You must explicitly relay any information the user needs via `post_to_user`. Never assume the user has visibility into agent replies or log entries.
+**The key insight**: Match your communication to the channel where the audience lives. The user exists where they can see. Usually that's this thread — but the same person may also be reviewing a pull request, and what they wrote there needs no repeating here. Inter-agent messages (`send_message_to_agent`) and the shared knowledge log (`knowledge.log`) are internal — the user cannot see them. If an agent reports findings to you, the user does not automatically learn about it. You must explicitly relay any information the user needs via `post_to_user`. Never assume the user has visibility into agent replies or log entries.
 
 **Channel Decision Logic**:
 
 - New work acknowledgment: Acknowledge in the originating channel
 - Milestone announcements: Always post to the user, regardless of input source
 - Background system events: Usually silent unless significant for the user
+- GitHub activity on delegated work: hand it to the agent that owns the branch; the thread hears about it only if state changed or someone is blocked
 
 ### 4. The Unified Archie Persona
 

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -17,6 +17,17 @@ export const AGENT_PROMPTS = {
   existingTask: 'New input received. Check knowledge.log for the update.',
   recovery: 'Task was interrupted. Check knowledge.log for current state and continue where you left off.',
 
+  // GitHub activity on work PM has already delegated — review comments, review
+  // bodies, PR conversation comments, CI results. Distinct from `existingTask`
+  // because the author is often the same person PM is talking to in Slack, and
+  // under the generic prompt PM read the notification as news to relay: it
+  // narrated the reviewer's own comments back at them and asked what they had
+  // meant. Naming the owner instead points the input at the agent holding the
+  // branch, which is the only party that can answer on the PR. Merge outcomes
+  // (see connectors/github/merge.ts) keep `existingTask` — those really are PM's
+  // to announce, not to delegate.
+  githubInput: 'Activity on GitHub for work you delegated — check knowledge.log for what it is and which PR. Hand it to the agent that owns that branch.',
+
   // Stage 3: Reinforcement prompts for idle detection recovery
   reinforcePM: `RECOVERY: You went idle without completing the task.
 

--- a/src/connectors/github/events.ts
+++ b/src/connectors/github/events.ts
@@ -300,5 +300,5 @@ async function handleExistingTaskDirect(
   }
 
   await appendGitHubEvent(taskId, context.githubRepo, formatGitHubEvent(context));
-  await task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
+  await task.sendMessage(AGENT_PROMPTS.githubInput, 'pm-agent');
 }

--- a/src/connectors/github/webhooks.ts
+++ b/src/connectors/github/webhooks.ts
@@ -302,8 +302,9 @@ const CHECKS_READY_DEBOUNCE_MS = 20_000;
  * Handle check_suite.completed with per-PR debouncing.
  *
  * Resets the timer on every event in the window; on fire, appends one
- * structured GitHub event to knowledge.log and wakes PM with the standard
- * `existingTask` prompt. PM is expected to call `get_pr_checks` to inspect.
+ * structured GitHub event to knowledge.log and wakes PM with the `githubInput`
+ * prompt, which points the result at the repo agent that owns the branch — PM
+ * has no `get_pr_checks` of its own to inspect with.
  */
 export function handleChecksReadyDirect(
   taskId: string,
@@ -327,7 +328,7 @@ export function handleChecksReadyDirect(
         message: `checks updated — call get_pr_checks(${prNumber}) to inspect`,
       });
       const task = await Task.get(taskId);
-      await task.sendMessage(AGENT_PROMPTS.existingTask, 'pm-agent');
+      await task.sendMessage(AGENT_PROMPTS.githubInput, 'pm-agent');
     } catch (error) {
       logger.error('checks-ready', `Failed to deliver checks_ready ping for ${key}`, error);
     }


### PR DESCRIPTION
## Problem

In [task-20260817-0850-u544t8](https://sweatcoin.slack.com/archives/C06HKR0TTCG/p1786951284968879) the reviewer left inline comments on eight backend PRs. Archie answered every one of them in the Slack thread instead of on the PR — including relaying the reviewer's own comments back at them, and asking in Slack what one of their comments had referred to. The reviewer eventually had to say it outright:

> let's discuss only on the PRs, stop adding review-related replies here

Zero bot replies appeared on any PR before that message. Eleven appeared in the twenty minutes after it. The behaviour changed because a human asked, not because anything in the system suggested it.

## Cause

`prompts/pm-agent.md` stated, as its "key insight" about channels:

> The user exists only in the channel.

Under that premise relaying GitHub comments into Slack is not a mistake, it is compliance — a comment appearing on GitHub reads as something the human cannot see and therefore must be told. It also makes asking them what their own comment meant reasonable. PM knew it was the same person (it wrote "Your comment was on exactly those lines") and narrated anyway.

Two things reinforced it. The wake prompt for every GitHub webhook was the generic `existingTask` ping — `New input received. Check knowledge.log for the update.` — identical to a Slack message, a merge notification and an API trigger, so nothing marked the input as activity on already-delegated work. And PM has no GitHub tooling at all: no diff, no comment anchor, no `get_pr_checks`. It hand-forwarded CI results to the backend agent four separate times in twenty minutes, each with a note that the notification lands on its side rather than the agent's.

## Change

Correct the premise where it lives, rather than adding a rule that argues with it. The user exists where they can see — usually the thread, but possibly a pull request they are reviewing, and what they wrote there needs no repeating. One Channel Decision Logic bullet points GitHub activity at the agent that owns the branch, leaving the thread for state changes and blockers.

Split the wake prompt: review comments, review bodies, PR conversation comments and CI results now wake PM with a new `githubInput` constant that names the branch owner as the recipient. Merge outcomes keep `existingTask` — those genuinely are PM's to announce, and telling it to delegate them would be wrong.

Also corrects the `handleChecksReadyDirect` docstring, which claimed PM inspects checks with `get_pr_checks`.

## Notes

Deliberately not included, having been considered and dropped as unnecessary once the premise is fixed:

- Plumbing `path` / `line` / `diff_hunk` through the webhook so PM can resolve a comment's anchor. The repo agent already has `get_review_threads`; PM does not need the anchor because it should not be resolving the comment.
- Routing review events to the repo agent directly instead of through PM. PM stays the wake target so it keeps its view of the task; only the response duty moves.
- Prose in `prompts/repo-agent.md` about replying on threads. That hardened against PM issuing reply-suppression orders, which the premise fix removes at the source.

`githubInput` tells PM to hand the input to the branch owner without naming which agent that is; PM infers it from `metadata.json`, and did so correctly throughout the task above. If that ever misfires, the lookup already exists in `handleExistingTaskDirect`.

## Verification

`npm run typecheck` clean. 136 tests pass across 16 files (`src/connectors/github`, `src/tasks`). No test asserted on either changed call site; the merge-path assertions on `existingTask` are untouched and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
