### PR TITLE
fix(git): untrack workdir and claude-data, ignore the symlink form too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ secrets/oauth/
 secrets/*-credentials.json
 
 # Runtime data
-workdir/
-claude-data/
+workdir
+claude-data
 *.log
 
 # OS

--- a/claude-data
+++ b/claude-data
@@ -1,1 +1,0 @@
-/Users/khmelev/Projects/swc/archie-hq/claude-data

--- a/workdir
+++ b/workdir
@@ -1,1 +1,0 @@
-/Users/khmelev/Projects/swc/archie-hq/workdir


### PR DESCRIPTION
## Problem

`workdir` and `claude-data` are tracked in `main` as symlinks, each pointing at its own absolute path:

```
120000 82d2052…  workdir      → /Users/khmelev/Projects/swc/archie-hq/workdir
120000 6339c57…  claude-data  → /Users/khmelev/Projects/swc/archie-hq/claude-data
```

Git records a symlink as mode `120000` with the target as blob content, so every checkout, reset or worktree operation faithfully recreates a self-referential link. The consequences on a fresh checkout of `main`:

- `realpath workdir` → `Too many levels of symbolic links`
- `docker compose up` fails with `error while creating mount source path '.../claude-data/.claude.json': mkdir .../claude-data: file exists`
- The `archie-e2e` harness cannot boot at all

Observed live today: the links were recreated twice within a minute during ordinary branch operations, and whatever real directory sat at either path was gone afterwards. Runtime data at those paths is not tracked, so nothing about it is recoverable from git — only the symlink was ever stored.

## Cause

Both paths were already in `.gitignore`, as `workdir/` and `claude-data/`. A pattern with a trailing slash matches **directories only**, and git does not treat a symlink as a directory — so the symlink form was never ignored, and a `git add -A` picked it up. Once tracked, `.gitignore` no longer applies at all.

## Change

Drop the trailing slashes so both the directory and the symlink form are ignored, and untrack the two entries (`git update-index --force-remove`, index only — the real directories on disk are untouched).

The symlink form itself is not the mistake: pointing a worktree's `workdir` and `claude-data` at the main checkout's copies is the documented setup in the `archie-e2e` skill, because `workdir` is ~20G and is designed for concurrent access by many containers. It simply must never be committed.

## Verification

After the change, `git check-ignore -v workdir claude-data` resolves both to the new patterns, `git status` is clean with the real directories present, and `npx tsx tools/e2e/boot.ts` reaches a healthy attested instance on the repaired checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
