### PR TITLE
fix(sandbox): let node-gyp find its devdir and the Node headers

### DIFF
--- a/src/agents/__tests__/sandbox.test.ts
+++ b/src/agents/__tests__/sandbox.test.ts
@@ -34,10 +34,10 @@ describe('buildManagedNetworkPolicy', () => {
       ...base,
       allowedNetworkDomains: [...TRUSTED_PACKAGE_REGISTRY_DOMAINS],
     });
-    expect(policy.sandbox.network.allowedDomains).toEqual([
-      'registry.npmjs.org',
-      'registry.yarnpkg.com',
-    ]);
+    // Compared against the input, not a copy of it: this test is about the policy
+    // passing through what it is handed. The allowlist's actual contents are
+    // pinned separately, so growing the constant does not fail this.
+    expect(policy.sandbox.network.allowedDomains).toEqual([...TRUSTED_PACKAGE_REGISTRY_DOMAINS]);
   });
 
   it('always sets allowManagedDomainsOnly — the allowlist is not enforced without it', () => {
@@ -73,6 +73,42 @@ describe('buildPackageManagerCacheEnv', () => {
     const env = buildPackageManagerCacheEnv();
     expect(env.YARN_GLOBAL_FOLDER).toBe(`${CACHES_DIR}/yarn-global`);
     expect(env.COREPACK_HOME).toBe(`${CACHES_DIR}/corepack`);
+  });
+
+  it('allowlists nodejs.org, without which node-gyp cannot fetch headers', () => {
+    // The devdir redirect alone is not enough: node-gyp downloads
+    // node-vX-headers.tar.gz from nodejs.org, and with only the two registries
+    // allowlisted that 403s and every native build still fails.
+    expect(TRUSTED_PACKAGE_REGISTRY_DOMAINS).toContain('nodejs.org');
+  });
+
+  it('keeps the egress allowlist to package-supply hosts only', () => {
+    // Guards the boundary this constant exists to hold: each entry is a package
+    // or toolchain source, never a general-purpose host that could serve as an
+    // exfiltration channel.
+    expect(TRUSTED_PACKAGE_REGISTRY_DOMAINS).toEqual([
+      'registry.npmjs.org',
+      'registry.yarnpkg.com',
+      'nodejs.org',
+    ]);
+  });
+
+  it('redirects node-gyp\'s devdir, so native addons can actually build', () => {
+    // Without this node-gyp falls back to $HOME/.cache/node-gyp, which does not
+    // exist in the image and sits outside allowWrite — so every native build
+    // died on ENOENT. It stayed hidden because a failed OPTIONAL postinstall is
+    // only a warning: the install still exits 0.
+    const env = buildPackageManagerCacheEnv();
+    expect(env.npm_config_devdir).toBe(`${CACHES_DIR}/node-gyp`);
+  });
+
+  it('leaves the node-gyp devdir overridable from a repo\'s own package.json', () => {
+    // node-gyp reads npm_config_* but lets npm_package_config_node_gyp_* win.
+    // Setting only the former keeps a repo able to override; setting the latter
+    // here would silently outrank the repo's own config.
+    expect(Object.keys(buildPackageManagerCacheEnv())).not.toContain(
+      'npm_package_config_node_gyp_devdir',
+    );
   });
 
   it('shares one cache across agents and tasks rather than scoping it per workspace', () => {

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -37,10 +37,20 @@ export interface SandboxOptions {
 /**
  * Trusted public package registries that repo build sandboxes may reach when a
  * human has approved edit mode — just enough egress to run `npm`/`yarn` installs
- * and regenerate lockfiles. Deliberately minimal: these two hosts cover npm
- * (tarballs serve from registry.npmjs.org) and Yarn 4 (default
- * registry.yarnpkg.com). Listing the hostnames also permits DNS resolution for
+ * and regenerate lockfiles. Deliberately minimal: npm (tarballs serve from
+ * registry.npmjs.org), Yarn 4 (default registry.yarnpkg.com), and nodejs.org,
+ * which node-gyp fetches the Node headers from before it can compile a native
+ * addon — without it every native build fails on `403 response downloading
+ * node-vX-headers.tar.gz`. Listing the hostnames also permits DNS resolution for
  * them, so no separate DNS rule is needed.
+ *
+ * nodejs.org is a static download host: no upload endpoint and no user content to
+ * echo back, so it is a weaker exfiltration channel than registry.npmjs.org
+ * already on this list, where `npm publish` would carry data out. It adds no
+ * meaningful code-execution reach either, since an agent can already install and
+ * run arbitrary packages from the registry. node-gyp verifies what it downloads
+ * against SHASUMS256.txt, which defeats tampering in transit but not a compromise
+ * of the host itself — the same trust already extended to the registry.
  *
  * This list is intentionally a hardcoded constant — NOT plugin- or PM-settable —
  * so the egress surface can't be widened from a hot-reloaded plugins change or a
@@ -49,6 +59,7 @@ export interface SandboxOptions {
 export const TRUSTED_PACKAGE_REGISTRY_DOMAINS = [
   'registry.npmjs.org',
   'registry.yarnpkg.com',
+  'nodejs.org',
 ];
 
 // ---- Sandbox config (OS-level, Bash only) ----
@@ -198,6 +209,15 @@ export function buildManagedNetworkPolicy(opts: SandboxOptions) {
  * Repos that pin `packageManager` also let Corepack fetch the pinned release into
  * `COREPACK_HOME` (`~/.cache/node/corepack`), which is likewise unwritable.
  *
+ * `npm_config_devdir` covers node-gyp, the same failure one layer down: it keeps
+ * the Node headers it compiles native addons against in a "devdir", defaulting to
+ * `$HOME/.cache/node-gyp` — a path that does not exist in the image and is not in
+ * allowWrite, so every native build died on ENOENT. It stayed hidden because npm
+ * and yarn treat a failed OPTIONAL postinstall as a warning and still exit 0.
+ * node-gyp reads `npm_config_*` straight from the env; that prefix is deprecated
+ * in npm v11 for `npm_package_config_node_gyp_*`, which deliberately outranks it —
+ * so setting the old one leaves a repo free to override from its own package.json.
+ *
  * Observed live: the mobile repo pins yarn 4.12.0, and `yarn install` failed
  * instantly on the global-folder ENOENT while yarn 1 in the same sandbox worked
  * fine — which is why this covers both generations rather than just the cache.
@@ -209,6 +229,7 @@ export function buildPackageManagerCacheEnv(): Record<string, string> {
     YARN_CACHE_FOLDER: resolve(cacheRoot, 'yarn'),
     YARN_GLOBAL_FOLDER: resolve(cacheRoot, 'yarn-global'),
     COREPACK_HOME: resolve(cacheRoot, 'corepack'),
+    npm_config_devdir: resolve(cacheRoot, 'node-gyp'),
   };
 }
 


### PR DESCRIPTION
Fixes two of the three things blocking native addon builds in the sandbox. Follow-up to #283, from a gap that PR's live run surfaced.

**Native builds still do not work after this** — a third cause is outside its scope, see the end.

## 1. devdir pointed at an unwritable `$HOME`

node-gyp keeps the Node headers it compiles native addons against in a "devdir". With none configured it falls back to `envPaths('node-gyp').cache` — `$HOME/.cache/node-gyp` (`node-gyp/bin/node-gyp.js`). That path does not exist in the image and `$HOME` is not in `allowWrite`, so the mkdir failed with `ENOENT` (not `EROFS`, because the missing parent is `.cache`, not the leaf).

Same class as the npm/yarn `EROFS` that `2b23da0` fixed. `npm_config_devdir` points it at the shared cache instead.

Why that env var: node-gyp scans `npm_config_*` from the environment and maps them onto its own options (`node-gyp/lib/node-gyp.js`), so it works even though npm is not setting it. The prefix is deprecated in npm v11 for `npm_package_config_node_gyp_*`, which deliberately **outranks** it — so setting the old one leaves a repo free to override the devdir from its own `package.json`. A test pins that choice.

## 2. nodejs.org was not on the egress allowlist

With the devdir fixed the download still failed:

```
gyp http GET https://nodejs.org/download/release/v24.19.0/node-v24.19.0-headers.tar.gz
gyp http 403 ...
gyp ERR! configure error
```

Added `nodejs.org` to `TRUSTED_PACKAGE_REGISTRY_DOMAINS`. That constant is documented as deliberately minimal, so the reasoning is on the record:

- **Exfiltration** — a static download host: no upload endpoint, no API, no user content echoed back. Weaker than `registry.npmjs.org` already on the list, where `npm publish` would carry data out.
- **Code execution** — no meaningful addition; an agent can already install and run arbitrary packages from the registry.
- **Integrity** — node-gyp verifies downloads against `SHASUMS256.txt`. That defeats tampering in transit, though not a compromise of the host itself — the same trust already extended to the registry.
- **Trust tier** — OpenJS Foundation, HTTPS, comparable to the registries. Not a general-purpose host.

Considered and rejected: seeding the headers into the image at build time. It avoids touching the allowlist, but only covers the image's own Node version — a repo needing a different ABI would 403 again.

## Why nobody noticed any of this

npm and yarn treat a failed *optional* postinstall as a warning and still exit 0. On `sweatcoin-frontend`, `@newrelic/native-metrics` and `@contrast/fn-inspect` silently fell back to JS. A repo with a *required* native dependency would have failed outright.

## Verification

`npm run typecheck` clean; suite **1125 passed, 5 skipped**.

Live on `sweatcoin-frontend` (yarn 4.5.3, edit mode approved) via `archie-e2e`:

| Claim | Evidence |
| --- | --- |
| devdir resolves to the shared cache | `devdir=/workdir/caches/node-gyp` |
| Headers now download | `gyp http 200`; **no 403 in any log** (grepped yarn log + both build logs) |
| Headers land on disk | devdir holds `24.19.0/{include,installVersion}`, 2726 header files incl. `include/node/node.h` |
| Egress boundary intact | egress check passes both directions; `npm install: ok` |

One trap worth recording: `ls -d node_modules/<pkg>/build` **succeeds** for both packages even on failure, because those dirs hold only gyp-generated files (`Makefile`, `config.gypi`, `*.target.mk`) and no compiled `.node`. Presence of `build/` is not evidence of a successful build.

## Still broken: no C toolchain in the image

```
gyp ERR! stack Error: not found: make
```

`make`, `gcc`, `g++` and `cc` are all absent from the image (`python3` is present). So configure now succeeds and the compile step fails.

Fixing that means adding a build toolchain to the image — an image-size and runtime-attack-surface decision rather than a sandbox one, so it is deliberately not bundled here. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
