### PR TITLE
fix(sandbox): give git-lfs writable scratch on read-only clones

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -10,8 +10,8 @@
  * Session recovery pattern (try with session → reset → retry → give up) written once.
  */
 
-import { join, basename } from 'path';
-import { mkdir, symlink, writeFile } from 'fs/promises';
+import { join, basename, dirname, resolve, sep } from 'path';
+import { mkdir, rm, symlink, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { randomUUID } from 'node:crypto';
 import { query } from '@anthropic-ai/claude-agent-sdk';
@@ -538,6 +538,39 @@ Shared folder: ${sharedPath} [READ-ONLY]
     // mode) plus per-repo read-only/protected paths.
     const readOnlyPaths = [sharedPath, ...repoMounts.map((m) => m.baseObjectsPath), ...pluginReadPaths];
     const cloneGitHeads = repoMounts.map((m) => join(m.clonePath, '.git', 'HEAD'));
+    // git-lfs writes a temp object into `.git/lfs/tmp` whenever its clean filter
+    // runs, which `git status` triggers on an LFS file with stale index stat data.
+    // On a read-only clone that write fails and git exits 128. Symlinked into the
+    // writable workspace instead of added to allowWrite: the clone has to stay in
+    // allowRead, and that ro-bind shadows any rw bind beneath it (verified).
+    // Per agent and per repo; holds only in-flight temp files, so replacing the
+    // dir git-lfs may have made during checkout loses nothing.
+    // Both paths are derived from PM-influenced values (the attached repo id), so
+    // each is resolved and then checked to be inside its intended root before any
+    // fs call — `..` survives the character filter on its own, and resolve() is
+    // what collapses it.
+    const lfsScratchRoot = resolve(workspace, '.lfs-tmp');
+    const taskRoot = resolve(getTaskPath(taskId));
+    const cloneLfsTmp = repoMounts.map((m) => ({
+      link: resolve(m.clonePath, '.git', 'lfs', 'tmp'),
+      target: resolve(lfsScratchRoot, m.github.replace(/[^\w.-]/g, '_')),
+    }));
+    await Promise.all(cloneLfsTmp.map(async ({ link, target }) => {
+      if (!target.startsWith(lfsScratchRoot + sep) || !link.startsWith(taskRoot + sep)) {
+        logger.warn('spawn', `Refusing git-lfs scratch redirect outside its root: ${link} -> ${target}`);
+        return;
+      }
+      try {
+        await mkdir(target, { recursive: true });
+        await rm(link, { recursive: true, force: true });
+        await mkdir(dirname(link), { recursive: true });
+        await symlink(target, link);
+      } catch (error) {
+        // Best-effort: LFS still works for anything not needing scratch space.
+        logger.warn('spawn', `Could not redirect git-lfs scratch for ${link}: ${error}`);
+      }
+    }));
+
     sandboxOpts = {
       cwd,
       denyReadPaths: [WORKDIR],


### PR DESCRIPTION
`git status` exits 128 in an LFS repo for a read-only agent. Fixed by symlinking git-lfs's scratch dir out of the read-only clone.

## The bug

From a prod log (`task-20260817-1854-1ahc24`):

```
Error cleaning Git LFS object: open .../.git/lfs/tmp/3829252116: read-only file system
fatal: e2e/snapshots/.../allBadges-badgeCategory-special.png: clean filter 'lfs' failed
```

git-lfs writes a temp object into `.git/lfs/tmp` whenever its clean filter runs, and `git status` triggers that filter on an LFS file whose index stat data is stale. On a read-only clone the write fails and takes git down with it.

Both conditions are needed, which is why it looked intermittent. Confirmed in a synthetic LFS repo:

| tmp dir | index stat | `git status` |
| --- | --- | --- |
| writable | stale | exit 0 |
| **unwritable** | **stale** | **exit 128**, `clean filter 'lfs' failed` |

Affects `sweatcoin-mobile` and `sweatcoin-backend`. Worse than a failed command: the workaround seen in prod was to bypass the LFS filters, which then reported **279 unmodified PNGs as modified**, since git compares the smudged binary against the stored pointer.

## The fix

```
link:   <clone>/.git/lfs/tmp                   ← read-only mount
target: <workspace>/.lfs-tmp/<repo>            ← writable mount
rm(link); symlink(target, link)
```

`.git/lfs/tmp` becomes a symlink pointing out of the clone. git-lfs opens the same path as always; the kernel resolves the symlink and the write lands in the agent workspace, which is already in `allowWritePaths`. The read-only mount is never written to.

Two things make it work: the symlink is created in the unsandboxed app process during spawn, so it needs no write permission inside the sandbox; and bwrap restricts *mounts*, so a write through a symlink is evaluated against the workspace mount.

**Adding `<clone>/.git/lfs/tmp` to `allowWritePaths` was tried first and verified not to work** — a read-only agent still got `TOUCH_EXIT=1`. The clone must stay in `allowReadPaths`, and that ro-bind shadows any rw bind beneath it.

Config can't do this either: `git lfs env` shows `TempDir` and `LfsStorageDir` both derived from `lfs.storage`, with no separate tmp knob. Repointing `lfs.storage` would move the objects too, and those are hardlinked to the base cache (same inode, 65 links) — trading this bug for real disk duplication.

## Verification

`npm run typecheck` clean; suite **1121 passed, 5 skipped**.

Live via `archie-e2e`, read-only agent on `sweatco/sweatcoin-mobile`:

| Probe | Result |
| --- | --- |
| `touch .git/lfs/tmp/probe` | **`TOUCH_EXIT=0`** |
| `git lfs env` | `TempDir` resolves through the symlink |
| `touch ./package.json` | **exit 1** — `Read-only file system` |
| `echo x >> ./package.json` | **exit 1** — `Read-only file system` |

Scratch writable, write boundary intact. Baseline on `main` gives `TOUCH_EXIT=1`.

**Not covered:** I could not induce the natural stale-stat condition inside a read-only agent (it cannot touch its own working tree; prod's staleness came from clone/resume timing). Mechanism proven in isolation and precondition proven fixed live, but a read-only agent hitting the original 128 and then succeeding is not directly demonstrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
