### PR TITLE
fix(triggers): make a scheduled delivery open and link the task's thread

### DIFF
--- a/docs/architecture/triggers.md
+++ b/docs/architecture/triggers.md
@@ -72,8 +72,18 @@ A one-off schedule auto-pauses after it fires (its condition is consumed). **Res
 `fireTrigger(trigger, context)` (`src/system/trigger-scheduler.ts`) is shared by the scheduler (schedule context) and the Slack dispatch hook (message context):
 
 1. Create a fresh task; set `metadata.triggered_by = trigger.id`.
-2. For a message-context fire, ingest the triggering thread with `Task.append` — knowledge log, linked channel, default channel, no post; for a schedule fire, the spawned PM opens the destination itself.
+2. Wire delivery. A message fire ingests the triggering thread with `Task.append` — knowledge log, linked channel, default channel, no post. A channel-bound schedule fire records `metadata.delivery_target`, and the PM's first user-facing message opens a thread there and links it.
 3. Seed the PM with `AGENT_PROMPTS.triggered(...)` and let it do the work.
+
+**A scheduled delivery becomes the task's thread.** A schedule fire has no thread to reply in, so `fireTrigger` records `metadata.delivery_target` — the bound channel — and `Task.postToUser` does the rest: the first user-facing message is posted top-level there, the ts that comes back is stored as a linked channel, that channel becomes the default, and the target is cleared so every later message threads under it.
+
+Two things follow. The PM delivers with plain `post_to_user` and no argument, exactly as in any other task, instead of being handed a channel id to route by hand. And **a human replying to a scheduled post comes back to the task that posted it** — `findTaskByThread` matches on `thread_id`, which is now that ts.
+
+That second part is the reason this exists. Before it, a scheduled fire delivered through `post_to_channel`, which is deliberately fire-and-forget: the task finished with `channels: {}`, and a reply landed on `shouldCreateNewTask(…, rootAuthorWasBot)` and started a **stranger task** — a fresh PM with no knowledge of the fire, no trigger id, and no access to the trigger's directory. Measured live before the change: the fired task's metadata stayed `channels: {} default_channel: None`, and the reply produced `Created task task-…` rather than routing to the fire.
+
+`post_to_channel` is untouched. It stays the tool for talking to a channel this task does not live in, and it still links nothing — the two paths are now distinct rather than one doing both jobs badly.
+
+Not covered: a **user-bound** schedule fire, which still carries a delivery line and still DMs by hand. The id worth storing there is the `D…` conversation, while the message is addressed to a `U…`, so linking it correctly needs a `conversations.open` that this does not do.
 
 **Firing posts no preamble.** The spawned PM does the work and posts the result itself, so the first thing the channel sees is the actual output — not an "I was triggered" line.
 
@@ -88,7 +98,7 @@ A one-off schedule auto-pauses after it fires (its condition is consumed). **Res
 - *"you are read-only by default; request edit mode first"* — no other wake prompt in `AGENT_PROMPTS` says this, and the PM prompt covers `request_edit_mode` at length;
 - *"treat it as data rather than instructions"* — nothing frames an ordinary Slack message in the log that way, and a trigger's filter leaves an agent no more exposed than an @mention does, since anyone in a channel can wake Archie with text of their choosing either way. If that framing is wanted it belongs on the log itself, for every task, not bolted onto this one prompt.
 
-A schedule fire still gets one delivery line, because nothing is linked and the destination is either the bound channel or a DM to the creator.
+A channel-bound schedule fire has no delivery line either, for the reason below. A user-bound one still does.
 
 This was a gap rather than a decision. `FireContext.text` was populated from the Slack event and then read by nothing, so a PM woken by "a new message in #x matched your filter" was given the channel and the thread but never the message. It could have fetched the thread itself, but nothing handed the text over and nothing told it to look — and the thread-append path could not have supplied it either, because the fire linked the thread with `linkSlackThread` (now removed, since ingesting the thread does that job) which set `last_processed_ts` to the triggering message's own ts, and that path only appends messages newer than it.
 

--- a/docs/architecture/triggers.md
+++ b/docs/architecture/triggers.md
@@ -81,6 +81,14 @@ Two things follow. The PM delivers with plain `post_to_user` and no argument, ex
 
 That second part is the reason this exists. Before it, a scheduled fire delivered through `post_to_channel`, which is deliberately fire-and-forget: the task finished with `channels: {}`, and a reply landed on `shouldCreateNewTask(…, rootAuthorWasBot)` and started a **stranger task** — a fresh PM with no knowledge of the fire, no trigger id, and no access to the trigger's directory. Measured live before the change: the fired task's metadata stayed `channels: {} default_channel: None`, and the reply produced `Created task task-…` rather than routing to the fire.
 
+Three guards came out of reviewing this, each closing a way the delivery could go wrong silently:
+
+- **Opening the thread is opt-in per caller.** `postToUser` also carries the inter-agent budget warning and the wall-clock pause notice, neither of which may become the first thing a bound channel hears from Archie — a stalled hourly trigger would otherwise put "⏸️ Pausing this task — respond in this thread whenever you're ready" into a public channel with nothing before it. Only `post_to_user` and `report_completion` pass `mayOpenThread`.
+- **An unlinked `target.channel` throws** instead of posting nothing and reporting success. That silent drop was pre-existing, but on a task whose `channels` are still empty *every* key is unlinked — and the PM has just been told which channel it delivers to, so passing it as a target was the likeliest wrong move and lost the message with no error.
+- **A task that ends with its destination unused says so.** `warnUnconsumedDeliveryTarget` logs on either ending and drops the target. Delivery is a prompt instruction, not an enforced step: a fire was observed completing green having posted nothing, and nothing in the system noticed.
+
+The claim on the destination is taken before the post, not after, so two concurrent first messages cannot open two threads; it is restored if the post throws. The link is flushed with `save(true)` rather than debounced, because it is the only record tying a message humans can already see back to this task.
+
 `post_to_channel` is untouched. It stays the tool for talking to a channel this task does not live in, and it still links nothing — the two paths are now distinct rather than one doing both jobs badly.
 
 Not covered: a **user-bound** schedule fire, which still carries a delivery line and still DMs by hand. The id worth storing there is the `D…` conversation, while the message is addressed to a `U…`, so linking it correctly needs a `conversations.open` that this does not do.
@@ -102,7 +110,7 @@ A channel-bound schedule fire has no delivery line either, for the reason below.
 
 This was a gap rather than a decision. `FireContext.text` was populated from the Slack event and then read by nothing, so a PM woken by "a new message in #x matched your filter" was given the channel and the thread but never the message. It could have fetched the thread itself, but nothing handed the text over and nothing told it to look — and the thread-append path could not have supplied it either, because the fire linked the thread with `linkSlackThread` (now removed, since ingesting the thread does that job) which set `last_processed_ts` to the triggering message's own ts, and that path only appends messages newer than it.
 
-**The seed states no destination.** `AGENT_PROMPTS.triggered` deliberately says nothing about where the result goes, because `fireTrigger` already appended a delivery line to the prompt it passes in and it is the only thing that knows the fire kind. The template used to close with "post the result to the bound channel", which on a message fire sat two paragraphs under a delivery line telling the agent to reply in the triggering thread — one message, two contradictory destinations.
+**The seed states no destination.** `AGENT_PROMPTS.triggered` says nothing about where the result goes, because for every binding a human can currently create there is nothing to say: a message fire replies in its linked thread and a channel-bound schedule fire posts to the user, whose destination the task already carries. `buildTriggerSeed` owns the one exception (a user-bound fire's DM line). The template used to close with "post the result to the bound channel", which on a message fire sat two paragraphs under a delivery line telling the agent to reply in the triggering thread — one message, two contradictory destinations.
 
 ## Persistent per-trigger directory
 

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -346,8 +346,14 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
       `Status: ${metadata.status}`,
     ];
     if (channelEntries.length === 0) {
+      // A `delivery_target` means there IS somewhere to post, it just has no thread yet:
+      // the first post_to_user opens one there and links it (Task.postToUser). Saying
+      // "nowhere to reply" here is what made a scheduled fire deliver nothing — the PM read
+      // the line, concluded post_to_user had no destination, and finished silently.
       contextLines.push(
-        'Channel(s): none — there is nowhere to reply in this task; finish with report_completion() (no message).'
+        metadata.delivery_target
+          ? `Channel(s): none linked yet — this task delivers to #${metadata.delivery_target.channel_name}. Post there with post_to_user (no target): the first message opens a thread and links it, so replies come back to this task.`
+          : 'Channel(s): none — there is nowhere to reply in this task; finish with report_completion() (no message).'
       );
     } else {
       contextLines.push(`Channel(s): ${channelEntries.map(([id, ch]) => renderChannel(id, ch)).join(', ')}`);

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -38,8 +38,7 @@ import {
   getChannelInfo,
   getUserInfo,
   listWorkspaceChannels,
-  fetchChannelIsPrivate,
-} from '../connectors/slack/client.js';
+  fetchChannelIsPrivate, formatSlackChannelDisplay } from '../connectors/slack/client.js';
 import { readCanvas } from '../connectors/slack/canvas-read.js';
 import {
   collectCanvasFileAllowlist,
@@ -441,7 +440,7 @@ function createPostToUserTool(agent: Agent, task: Task) {
       task.touch();
       let newChannelKey: string | null;
       try {
-        newChannelKey = await task.postToUser(args.message, agentName, args.target);
+        newChannelKey = await task.postToUser(args.message, agentName, args.target, { mayOpenThread: true });
       } catch (e) {
         return ok(formatSlackSendError(e));
       }
@@ -640,6 +639,17 @@ function createRequestEditModeTool(agent: Agent, task: Task) {
         return ok('Edit mode request already sent — task is pausing pending user approval.');
       }
 
+      // An approval card needs a thread to land in. On a task whose destination is recorded
+      // but not yet opened (a scheduled trigger fire before its first post), there is none:
+      // the card would go to the console log and the task would then pause waiting for an
+      // approval nobody can give. Deliver first — that opens the thread.
+      if (!args.channel && !task.metadata.default_channel && task.metadata.delivery_target) {
+        return ok(
+          `This task has no thread yet — it delivers to ${formatSlackChannelDisplay(task.metadata.delivery_target.channel_name)}. ` +
+          'Post there with post_to_user first (that opens the thread), then request approval.'
+        );
+      }
+
       // Validate an explicit target before posting so a bad key surfaces as
       // actionable feedback instead of silently dropping to the CLI log. The
       // task is left running so the agent can retry with a valid channel.
@@ -721,6 +731,17 @@ function createRequestMaxModeTool(agent: Agent, task: Task) {
       // end. Skip a duplicate approval post if the tool fires twice.
       if (agent.pendingTeardown) {
         return ok('Max mode request already sent — task is pausing pending user approval.');
+      }
+
+      // An approval card needs a thread to land in. On a task whose destination is recorded
+      // but not yet opened (a scheduled trigger fire before its first post), there is none:
+      // the card would go to the console log and the task would then pause waiting for an
+      // approval nobody can give. Deliver first — that opens the thread.
+      if (!args.channel && !task.metadata.default_channel && task.metadata.delivery_target) {
+        return ok(
+          `This task has no thread yet — it delivers to ${formatSlackChannelDisplay(task.metadata.delivery_target.channel_name)}. ` +
+          'Post there with post_to_user first (that opens the thread), then request approval.'
+        );
       }
 
       // Validate an explicit target before posting so a bad key surfaces as
@@ -815,7 +836,7 @@ function createReportCompletionTool(agent: Agent, task: Task) {
           );
         }
         try {
-          await task.postToUser(args.message, agentName);
+          await task.postToUser(args.message, agentName, undefined, { mayOpenThread: true });
         } catch (err) {
           // Surface the error to the agent so it can retry (e.g. split the
           // message). Do NOT record completion — it only proceeds after a

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -412,6 +412,7 @@ function createPostToUserTool(agent: Agent, task: Task) {
   return tool(
     'post_to_user',
     'Send a message to the user in this task. Without target, posts to the default channel — wherever this task already lives (use that almost always). ' +
+    'On a task that has no thread yet (a scheduled automation), the first message opens one in the destination the automation was set up for, and replies to it come back to this task. ' +
     'Use target.channel only to reach another thread ALREADY linked to this task. ' +
     'If this task lives in a channel thread, bring someone in by @mentioning them in that thread. ' +
     'To say something in a channel that is NOT part of this task (exploration/outreach), use `post_to_channel` — it deliberately does not link to this task. ' +
@@ -426,7 +427,9 @@ function createPostToUserTool(agent: Agent, task: Task) {
     async (args) => {
       const agentName = agent.def.id as AgentName;
       const hasTarget = !!args.target?.channel;
-      if (!hasTarget && Object.keys(task.metadata.channels).length === 0) {
+      // `delivery_target` counts as somewhere to post: a schedule-fired trigger task has
+      // no thread yet, and posting is what creates one (see Task.postToUser).
+      if (!hasTarget && Object.keys(task.metadata.channels).length === 0 && !task.metadata.delivery_target) {
         return ok(
           'No channel is linked to this task, so there is nowhere to post. ' +
           'Call report_completion() without a message to finish silently.'
@@ -805,7 +808,7 @@ function createReportCompletionTool(agent: Agent, task: Task) {
         ? findMutedTarget(task.metadata.channels, task.metadata.default_channel)
         : null;
       if (args.message && !mutedDefault) {
-        if (Object.keys(task.metadata.channels).length === 0) {
+        if (Object.keys(task.metadata.channels).length === 0 && !task.metadata.delivery_target) {
           return ok(
             'Cannot post a completion message — no channel linked to this task. ' +
             'Call report_completion() without a message to finish silently.'

--- a/src/system/__tests__/trigger-scheduler.test.ts
+++ b/src/system/__tests__/trigger-scheduler.test.ts
@@ -150,9 +150,6 @@ describe('buildTriggerSeed', () => {
     expect(seed).not.toContain('bot-test"');
   });
 
-  it('adds exactly one delivery line to a schedule fire, and nothing more', () => {
-    expect(buildTriggerSeed(trigger(channelBinding), { kind: 'schedule' }).split('\n\n')).toHaveLength(2);
-  });
 
   // The triggering thread is the task's default channel by the time this runs, and that is
   // where post_to_user goes on its own, so a delivery line here would restate a default.
@@ -160,10 +157,17 @@ describe('buildTriggerSeed', () => {
     expect(buildTriggerSeed(trigger(channelBinding), messageFire)).toBe('Summarise what changed.');
   });
 
-  it('names the bound channel for a channel-bound schedule fire', () => {
+  // A channel-bound schedule fire routes through post_to_user like everything else: the
+  // fire recorded `delivery_target`, and the first post opens a thread there and links it.
+  // So there is no channel id to hand the PM, and no delivery line at all.
+  it('gives a channel-bound schedule fire no delivery line either', () => {
     const seed = buildTriggerSeed(trigger(channelBinding), { kind: 'schedule' });
-    expect(seed).toContain('#bot-test');
-    expect(seed).toContain('Slack channel ID C0BL');
+    expect(seed).toBe('Summarise what changed.');
+    expect(seed).not.toContain('C0BL');
+  });
+
+  it('adds exactly one line for the DM case, which cannot take that path yet', () => {
+    expect(buildTriggerSeed(trigger({ type: 'user', user_id: 'U123ABC' }), { kind: 'schedule' }).split('\n\n')).toHaveLength(2);
   });
 
   it('DMs the creator for a user-bound schedule fire', () => {

--- a/src/system/trigger-scheduler.ts
+++ b/src/system/trigger-scheduler.ts
@@ -336,33 +336,37 @@ async function tickTrigger(trigger: Trigger, now: Date): Promise<void> {
  */
 /**
  * The instruction a fired trigger wakes its PM with: the trigger's own action prompt, plus
- * a delivery line when — and only when — the PM would not otherwise know where to go.
+ * a delivery line only when the PM would otherwise have nowhere to route.
  *
- * A schedule fire needs one: no channel is linked, so the destination is either the bound
- * channel or a DM to the creator. A message fire needs none: `Task.append` linked the
- * triggering thread as the task's default channel, and `post_to_user` routes there by
- * default, so a line saying "reply in the thread" only restates what already happens.
+ * Two of the three shapes need nothing. A message fire has the triggering thread linked as
+ * its default channel; a channel-bound schedule fire has `delivery_target` recorded, and
+ * `post_to_user` opens a thread there on the first message and links it. Both are just
+ * "post to the user", which is what the PM does in any other task.
+ *
+ * A user-bound schedule fire is the exception and still carries a line — see the comment
+ * at the branch for why DM delivery cannot take the same path yet.
  *
  * A message fire's message is not mentioned here either. `Task.append` has written it to
  * knowledge.log, which the PM reads at the start of every turn (prompts/pm-agent.md) and
  * which is the only place a delegated specialist can see it.
  *
- * Delivery is decided here rather than in the prompt template because this is the only
- * place that knows the fire kind. Pure, so all three shapes are assertable — `fireTrigger`
- * itself creates tasks.
+ * Pure, so every shape is assertable — `fireTrigger` itself creates tasks.
  */
 export function buildTriggerSeed(trigger: Trigger, context: FireContext): string {
   const parts = [trigger.action.prompt];
 
-  // A message fire needs no delivery line: `Task.append` linked the triggering thread as
-  // the task's default channel, and that is where `post_to_user` routes with no argument.
-  // A schedule fire has no linked channel, so it has to be told where to go.
-  if (context.kind === 'message') {
-    // nothing to add
-  } else if (trigger.binding.type === 'user') {
+  // Neither a message fire nor a channel-bound schedule fire needs a delivery line. A
+  // message fire has the triggering thread linked as its default channel; a channel-bound
+  // schedule fire has `delivery_target` set, and posting to the user opens a thread there
+  // and links it. Both land on `post_to_user` with no argument — what the PM reaches for in
+  // any other task, rather than a channel id it has to route by hand.
+  //
+  // A user-bound schedule fire still needs telling. DM delivery does not go through that
+  // path: the id to store would be the `U…` the message was addressed to, while a reply
+  // arrives on a `D…` channel, so linking it correctly needs a `conversations.open` that
+  // this does not do.
+  if (context.kind === 'schedule' && trigger.binding.type === 'user') {
     parts.push(`Deliver the result to the user as a direct message (Slack user ID ${trigger.binding.user_id}).`);
-  } else {
-    parts.push(`Deliver the result by posting it to the channel #${trigger.binding.channel_name} (Slack channel ID ${trigger.binding.channel_id}).`);
   }
 
   return parts.join('\n\n');
@@ -405,6 +409,14 @@ export async function fireTrigger(trigger: Trigger, context: FireContext): Promi
   // fire has no thread; the PM opens the destination itself.
   if (context.kind === 'message') {
     await task.append(context.thread);
+  } else if (trigger.binding.type === 'channel') {
+    // No thread to reply in, so record where the first user-facing message goes.
+    // `Task.postToUser` posts there and links the thread it creates, which is what makes a
+    // reply to a scheduled delivery come back to this task instead of starting a new one.
+    task.metadata.delivery_target = {
+      channel_id: trigger.binding.channel_id,
+      channel_name: trigger.binding.channel_name,
+    };
   }
   task.debouncedSave();
 

--- a/src/tasks/__tests__/delivery-target.test.ts
+++ b/src/tasks/__tests__/delivery-target.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for `delivery_target` — the first user-facing message on a task that has no thread
+ * yet opens one and links it.
+ *
+ * This is the whole point of the field, and it is not a pure decision: the thread id comes
+ * back from the post, so the link can only be asserted by driving `postToUser` with the
+ * Slack call stubbed. Only `postSlackMessage` is replaced; everything else in the client
+ * stays real, so the channel key and url are built the way production builds them.
+ *
+ * `WORKDIR` is read at module-import time, so the env var is set before the dynamic
+ * imports and the modules are pulled in inside the tests.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+let root: string;
+const POSTED_TS = '1787084582.563519';
+const postSlackMessage = vi.fn(async (_args: { channel: string; threadTs?: string }) => POSTED_TS as string | undefined);
+
+vi.mock('../../connectors/slack/client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../connectors/slack/client.js')>()),
+  postSlackMessage: (args: { channel: string; threadTs?: string }) => postSlackMessage(args),
+}));
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'archie-delivery-'));
+  process.env.ARCHIE_WORKDIR = root;
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.ARCHIE_WORKDIR;
+});
+
+async function taskWithDeliveryTarget() {
+  const { Task } = await import('../task.js');
+  const task = await Task.create();
+  task.metadata.delivery_target = { channel_id: 'C0BL', channel_name: 'bot-test' };
+  return task;
+}
+
+describe('postToUser with a pending delivery target', () => {
+  it('posts top-level, links the thread it created, and makes it the default channel', async () => {
+    postSlackMessage.mockClear();
+    const task = await taskWithDeliveryTarget();
+
+    const key = await task.postToUser('the scheduled result', 'pm-agent');
+
+    // Top-level: no threadTs, or it would reply into a thread that does not exist yet.
+    expect(postSlackMessage).toHaveBeenCalledTimes(1);
+    const arg = postSlackMessage.mock.calls[0][0];
+    expect(arg.channel).toBe('C0BL');
+    expect(arg.threadTs).toBeUndefined();
+
+    expect(key).toBe(`slack:C0BL:${POSTED_TS}`);
+    expect(task.metadata.default_channel).toBe(key);
+    expect(task.metadata.channels[key!]).toMatchObject({
+      type: 'slack',
+      channel_id: 'C0BL',
+      channel_name: 'bot-test',
+      thread_id: POSTED_TS,
+      last_processed_ts: POSTED_TS,
+    });
+  });
+
+  // The link is what makes a reply come back to this task: findTaskByThread matches on
+  // thread_id, so the ts of the message just posted has to be stored as one.
+  it('stores the posted ts as thread_id, which is what findTaskByThread matches', async () => {
+    const task = await taskWithDeliveryTarget();
+    await task.postToUser('the scheduled result', 'pm-agent');
+    // The link is persisted through the debounce; flush it so the on-disk scan can see it.
+    // In production the fired task is active, so the in-memory branch of the lookup hits
+    // first and this timing does not arise.
+    await task.save(true);
+    const { findTaskByThread } = await import('../persistence.js');
+    expect(await findTaskByThread(POSTED_TS)).toBe(task.taskId);
+  });
+
+  it('clears the target, so the next message threads instead of opening another', async () => {
+    postSlackMessage.mockClear();
+    const task = await taskWithDeliveryTarget();
+
+    await task.postToUser('first', 'pm-agent');
+    expect(task.metadata.delivery_target).toBeUndefined();
+
+    const second = await task.postToUser('second', 'pm-agent');
+    expect(second).toBeNull();
+    expect(Object.keys(task.metadata.channels)).toHaveLength(1);
+    expect(postSlackMessage.mock.calls[1][0].threadTs).toBe(POSTED_TS);
+  });
+
+  it('leaves the message sent but unlinked when no ts comes back, rather than inventing one', async () => {
+    // Dry-run mode returns undefined. A fabricated thread id would strand every later post
+    // on a key Slack does not know.
+    postSlackMessage.mockClear();
+    postSlackMessage.mockResolvedValueOnce(undefined);
+    const task = await taskWithDeliveryTarget();
+
+    expect(await task.postToUser('the scheduled result', 'pm-agent')).toBeNull();
+    expect(task.metadata.channels).toEqual({});
+    expect(task.metadata.default_channel).toBeNull();
+  });
+
+  it('is not consulted once a default channel exists', async () => {
+    postSlackMessage.mockClear();
+    const task = await taskWithDeliveryTarget();
+    await task.postToUser('first', 'pm-agent');
+    const key = task.metadata.default_channel;
+
+    task.metadata.delivery_target = { channel_id: 'COTHER', channel_name: 'elsewhere' };
+    await task.postToUser('second', 'pm-agent');
+
+    expect(task.metadata.default_channel).toBe(key);
+    expect(postSlackMessage.mock.calls[1][0].channel).toBe('C0BL');
+    expect(task.metadata.delivery_target).toEqual({ channel_id: 'COTHER', channel_name: 'elsewhere' });
+  });
+});

--- a/src/tasks/__tests__/delivery-target.test.ts
+++ b/src/tasks/__tests__/delivery-target.test.ts
@@ -17,12 +17,21 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 let root: string;
-const POSTED_TS = '1787084582.563519';
-const postSlackMessage = vi.fn(async (_args: { channel: string; threadTs?: string }) => POSTED_TS as string | undefined);
+// A unique ts per post, as Slack gives: several tests link a thread in the same temp
+// workdir, and a shared constant would make the on-disk `findTaskByThread` scan ambiguous.
+let seq = 0;
+let POSTED_TS = '';
+const postSlackMessage = vi.fn(async (_args: { channel: string; threadTs?: string }) => {
+  POSTED_TS = `1787084582.${String(++seq).padStart(6, '0')}`;
+  return POSTED_TS as string | undefined;
+});
 
 vi.mock('../../connectors/slack/client.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../connectors/slack/client.js')>()),
   postSlackMessage: (args: { channel: string; threadTs?: string }) => postSlackMessage(args),
+  // Real one calls conversations.info, so it needs an initialised Slack client. The DM /
+  // group-DM rejection it performs is asserted where it belongs, in the client's own tests.
+  assertPostableChannel: async () => {},
 }));
 
 beforeAll(() => {
@@ -47,7 +56,7 @@ describe('postToUser with a pending delivery target', () => {
     postSlackMessage.mockClear();
     const task = await taskWithDeliveryTarget();
 
-    const key = await task.postToUser('the scheduled result', 'pm-agent');
+    const key = await task.postToUser('the scheduled result', 'pm-agent', undefined, { mayOpenThread: true });
 
     // Top-level: no threadTs, or it would reply into a thread that does not exist yet.
     expect(postSlackMessage).toHaveBeenCalledTimes(1);
@@ -70,7 +79,7 @@ describe('postToUser with a pending delivery target', () => {
   // thread_id, so the ts of the message just posted has to be stored as one.
   it('stores the posted ts as thread_id, which is what findTaskByThread matches', async () => {
     const task = await taskWithDeliveryTarget();
-    await task.postToUser('the scheduled result', 'pm-agent');
+    await task.postToUser('the scheduled result', 'pm-agent', undefined, { mayOpenThread: true });
     // The link is persisted through the debounce; flush it so the on-disk scan can see it.
     // In production the fired task is active, so the in-memory branch of the lookup hits
     // first and this timing does not arise.
@@ -83,13 +92,14 @@ describe('postToUser with a pending delivery target', () => {
     postSlackMessage.mockClear();
     const task = await taskWithDeliveryTarget();
 
-    await task.postToUser('first', 'pm-agent');
+    await task.postToUser('first', 'pm-agent', undefined, { mayOpenThread: true });
+    const rootTs = POSTED_TS; // the ts the second post must thread under
     expect(task.metadata.delivery_target).toBeUndefined();
 
-    const second = await task.postToUser('second', 'pm-agent');
+    const second = await task.postToUser('second', 'pm-agent', undefined, { mayOpenThread: true });
     expect(second).toBeNull();
     expect(Object.keys(task.metadata.channels)).toHaveLength(1);
-    expect(postSlackMessage.mock.calls[1][0].threadTs).toBe(POSTED_TS);
+    expect(postSlackMessage.mock.calls[1][0].threadTs).toBe(rootTs);
   });
 
   it('leaves the message sent but unlinked when no ts comes back, rather than inventing one', async () => {
@@ -99,7 +109,7 @@ describe('postToUser with a pending delivery target', () => {
     postSlackMessage.mockResolvedValueOnce(undefined);
     const task = await taskWithDeliveryTarget();
 
-    expect(await task.postToUser('the scheduled result', 'pm-agent')).toBeNull();
+    expect(await task.postToUser('the scheduled result', 'pm-agent', undefined, { mayOpenThread: true })).toBeNull();
     expect(task.metadata.channels).toEqual({});
     expect(task.metadata.default_channel).toBeNull();
   });
@@ -107,14 +117,93 @@ describe('postToUser with a pending delivery target', () => {
   it('is not consulted once a default channel exists', async () => {
     postSlackMessage.mockClear();
     const task = await taskWithDeliveryTarget();
-    await task.postToUser('first', 'pm-agent');
+    await task.postToUser('first', 'pm-agent', undefined, { mayOpenThread: true });
     const key = task.metadata.default_channel;
 
     task.metadata.delivery_target = { channel_id: 'COTHER', channel_name: 'elsewhere' };
-    await task.postToUser('second', 'pm-agent');
+    await task.postToUser('second', 'pm-agent', undefined, { mayOpenThread: true });
 
     expect(task.metadata.default_channel).toBe(key);
     expect(postSlackMessage.mock.calls[1][0].channel).toBe('C0BL');
     expect(task.metadata.delivery_target).toEqual({ channel_id: 'COTHER', channel_name: 'elsewhere' });
+  });
+
+  // Opening the task's thread is opt-in per caller. The inter-agent budget warning and the
+  // wall-clock pause notice also call postToUser, and neither may become the first thing a
+  // bound channel hears from Archie — nor the thread the task then links.
+  it('does not open a thread for a caller that did not ask to', async () => {
+    postSlackMessage.mockClear();
+    const task = await taskWithDeliveryTarget();
+
+    expect(await task.postToUser('an incidental system notice', 'system')).toBeNull();
+
+    expect(postSlackMessage).not.toHaveBeenCalled();
+    expect(task.metadata.channels).toEqual({});
+    expect(task.metadata.delivery_target).toEqual({ channel_id: 'C0BL', channel_name: 'bot-test' });
+  });
+
+  // The claim happens before the await, so two concurrent first posts cannot both pass the
+  // guard and open two roots.
+  it('claims the target before posting, so concurrent first posts open one thread', async () => {
+    postSlackMessage.mockClear();
+    const task = await taskWithDeliveryTarget();
+
+    const keys = await Promise.all([
+      task.postToUser('a', 'pm-agent', undefined, { mayOpenThread: true }),
+      task.postToUser('b', 'pm-agent', undefined, { mayOpenThread: true }),
+    ]);
+
+    expect(postSlackMessage).toHaveBeenCalledTimes(1);
+    expect(keys.filter(Boolean)).toHaveLength(1);
+    expect(Object.keys(task.metadata.channels)).toHaveLength(1);
+  });
+
+  it('restores the target when the post throws, so a transient failure costs nothing', async () => {
+    postSlackMessage.mockClear();
+    postSlackMessage.mockRejectedValueOnce(new Error('slack exploded'));
+    const task = await taskWithDeliveryTarget();
+
+    await expect(task.postToUser('x', 'pm-agent', undefined, { mayOpenThread: true })).rejects.toThrow('slack exploded');
+    expect(task.metadata.delivery_target).toEqual({ channel_id: 'C0BL', channel_name: 'bot-test' });
+    expect(task.metadata.channels).toEqual({});
+  });
+
+  // The target is consumed even when no ts comes back, so a malformed Slack response cannot
+  // turn every later message into another top-level post.
+  it('does not re-open a root after a post that returned no ts', async () => {
+    postSlackMessage.mockClear();
+    postSlackMessage.mockResolvedValueOnce(undefined);
+    const task = await taskWithDeliveryTarget();
+
+    await task.postToUser('first', 'pm-agent', undefined, { mayOpenThread: true });
+    expect(task.metadata.delivery_target).toBeUndefined();
+
+    await task.postToUser('second', 'pm-agent', undefined, { mayOpenThread: true });
+    expect(postSlackMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('postToUser with an unlinked target key', () => {
+  // It used to post nothing and return null, which post_to_user reported as
+  // 'Message posted.' — and on a task whose channels are still empty, EVERY key is
+  // unlinked, so the most likely wrong argument lost the message silently.
+  it('throws instead of silently reporting success', async () => {
+    const task = await taskWithDeliveryTarget();
+    await expect(
+      task.postToUser('x', 'pm-agent', { channel: 'slack:C0BL:9999.0000' }),
+    ).rejects.toThrow('is not linked to this task');
+  });
+});
+
+describe('complete() with an unconsumed delivery target', () => {
+  // A fire that recorded a destination and never posted used to complete green with the
+  // channel hearing nothing and no line in the log.
+  it('warns and drops the target', async () => {
+    const task = await taskWithDeliveryTarget();
+    // `activate()` is private and `sendMessage` would spawn a real agent; complete() only
+    // needs the task to look active, and this task has no agents or timers to tear down.
+    (task as unknown as { isActive: boolean }).isActive = true;
+    await task.complete();
+    expect(task.metadata.delivery_target).toBeUndefined();
   });
 });

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -57,7 +57,7 @@ import { scheduleIdleCheck } from './recovery.js';
 import { scanAgentDefs, getAgentDef, getVisiblePeerIdsForSender, synthesizeDynamicAgentDef } from '../agents/registry.js';
 import type { AttachedRepo } from '../types/task.js';
 import { syncPlugins } from '../system/plugin-sync.js';
-import { postSlackMessage, postSlackFiles, postInteractiveToThread, postInteractiveToThreads, updateMessage, deleteMessage, buildPrCardBlocks, addReaction, removeReaction, getMessageReactions, buildThreadUrl, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay } from '../connectors/slack/client.js';
+import { postSlackMessage, postSlackFiles, postInteractiveToThread, postInteractiveToThreads, updateMessage, deleteMessage, buildPrCardBlocks, addReaction, removeReaction, getMessageReactions, buildThreadUrl, isExternalUser, formatSlackChannelRef, formatSlackChannelDisplay, assertPostableChannel } from '../connectors/slack/client.js';
 import { basename } from 'path';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { logger } from '../system/logger.js';
@@ -425,18 +425,28 @@ export class Task {
   }
 
   /**
-   * Post a message to the user.
+   * Post a message to the user. Returns the channel key when this call linked a new
+   * channel (see `mayOpenThread`), null otherwise.
    *
    * Targeting modes:
-   * - No target: post to default_channel only
-   * - target.channel: post to a specific already-linked thread
+   * - No target: post to default_channel; or, with `mayOpenThread`, open the task's
+   *   thread at `delivery_target` if it has none yet
+   * - target.channel: post to a specific already-linked thread; throws if it is not linked
    *
-   * Opening new DMs/threads is intentionally not supported — the PM reaches
-   * other channels via the task-decoupled `post_to_channel` explore tool, which
-   * deliberately does NOT link them to this task. Always returns null (the
-   * return type is kept for call-site compatibility).
+   * `mayOpenThread` is opt-in per caller, and only the two tools that deliver a
+   * user-facing result pass it. Incidental system messages — the inter-agent budget
+   * warning, the wall-clock pause notice — must NOT be able to become the first thing a
+   * bound channel hears from Archie, nor the thread the task then links.
+   *
+   * The PM still reaches channels this task does not live in via `post_to_channel`, which
+   * deliberately links nothing.
    */
-  async postToUser(message: string, agentName?: string, target?: PostTarget): Promise<string | null> {
+  async postToUser(
+    message: string,
+    agentName?: string,
+    target?: PostTarget,
+    opts?: { mayOpenThread?: boolean },
+  ): Promise<string | null> {
     const sender = agentName || 'system';
     // Grey footer (task id + PM model) appended to every user-facing message:
     // a Slack `context` block, and the same string on the `message` event so the
@@ -446,7 +456,13 @@ export class Task {
     // Specific existing channel
     if (target?.channel) {
       const ch = this.metadata.channels[target.channel];
-      if (ch?.type === 'slack') {
+      // An unlinked key used to post nothing and return null, which the caller reported to
+      // the agent as success. That silent drop is reachable for every key on a task whose
+      // channels are still empty, so it throws instead and the tool surfaces it.
+      if (!ch) {
+        throw new Error(`Channel ${target.channel} is not linked to this task`);
+      }
+      if (ch.type === 'slack') {
         await postSlackMessage({ channel: ch.channel_id, threadTs: ch.thread_id, text: message, footer });
         this.logOutgoingMessage(sender, message, Task.formatSlackDest(ch).display, ch, footer);
       }
@@ -463,14 +479,30 @@ export class Task {
     // post just created, so a human replying to it comes back to THIS task instead of
     // starting a stranger one. Distinct from `post_to_channel`, which stays deliberately
     // fire-and-forget for talking to channels this task does not live in.
-    if (!defaultCh && this.metadata.delivery_target) {
-      const { channel_id, channel_name } = this.metadata.delivery_target;
-      const ts = await postSlackMessage({ channel: channel_id, text: message, footer });
+    if (!defaultCh && this.metadata.delivery_target && opts?.mayOpenThread) {
+      // Claim the target BEFORE awaiting, so two concurrent first posts cannot both pass
+      // this guard and open two roots. Restored if the post throws, so a transient Slack
+      // failure does not cost the task its destination.
+      const targetChannel = this.metadata.delivery_target;
+      delete this.metadata.delivery_target;
+      const { channel_id, channel_name } = targetChannel;
+      let ts: string | undefined;
+      try {
+        // The cross-channel tool refuses DMs and group DMs before posting; this path is
+        // reached from a trigger binding rather than from an agent argument, but the
+        // binding is LLM-supplied at proposal time and never checked against Slack.
+        await assertPostableChannel(channel_id);
+        ts = await postSlackMessage({ channel: channel_id, text: message, footer });
+      } catch (err) {
+        this.metadata.delivery_target = targetChannel;
+        throw err;
+      }
       if (!ts) {
         // Dry run, or Slack returned no ts. The message is out; there is just nothing to
-        // link, and inventing a thread id would strand every later post on a bad key.
-        logger.warn('task', `postToUser on task ${this.taskId} delivered to ${channel_name} but got no ts back — thread not linked`);
-        this.logOutgoingMessage(sender, message, `#${channel_name}`, undefined, footer);
+        // link, and inventing a thread id would strand every later post on a bad key. The
+        // target stays claimed so the next message does not open a second root.
+        logger.warn('task', `postToUser on task ${this.taskId} delivered to ${formatSlackChannelDisplay(channel_name)} but got no ts back — thread not linked`);
+        this.logOutgoingMessage(sender, message, formatSlackChannelDisplay(channel_name), undefined, footer);
         return null;
       }
       const key = `slack:${channel_id}:${ts}`;
@@ -484,8 +516,10 @@ export class Task {
       };
       this.metadata.channels[key] = channel;
       this.metadata.default_channel ??= key;
-      delete this.metadata.delivery_target;
-      this.debouncedSave();
+      // Flushed rather than debounced: this record is the only thing tying a message humans
+      // can already see and reply to back to this task. Losing it in a 500 ms crash window
+      // brings back the stranger-task routing AND posts a duplicate root on recovery.
+      await this.save(true);
       this.logOutgoingMessage(sender, message, Task.formatSlackDest(channel).display, channel, footer);
       return key;
     }
@@ -951,6 +985,8 @@ export class Task {
     // the final message. Best-effort; must never block teardown.
     await this.resurfacePrCards().catch((e) => logger.warn('task', 'PR card resurface failed on stop', e));
 
+    this.warnUnconsumedDeliveryTarget();
+
     this.isActive = false;
     activeTasks.delete(this.taskId);
     this.clearTaskTimeout();
@@ -995,6 +1031,8 @@ export class Task {
     // PM has yielded the turn — (re)post any changed PR cards so they land under
     // the final message. Best-effort; must never block teardown.
     await this.resurfacePrCards().catch((e) => logger.warn('task', 'PR card resurface failed on complete', e));
+
+    this.warnUnconsumedDeliveryTarget();
 
     this.isActive = false;
     activeTasks.delete(this.taskId);
@@ -1646,6 +1684,22 @@ export class Task {
    * Activate the task — start timeout, mark in_progress.
    * Called lazily on first sendMessage().
    */
+  /**
+   * A task that recorded a delivery destination and never used it ends with the channel
+   * having heard nothing. That was silent — a fire completing green while its automation
+   * produced no message, observed live. Warn on either ending, and drop the target so it
+   * does not linger on a finished task as a destination nothing will ever consume.
+   */
+  private warnUnconsumedDeliveryTarget(): void {
+    if (!this.metadata.delivery_target) return;
+    logger.warn(
+      'task',
+      `Task ${this.taskId} ended without delivering to ${formatSlackChannelDisplay(this.metadata.delivery_target.channel_name)} — its recorded destination was never used`,
+    );
+    delete this.metadata.delivery_target;
+    this.debouncedSave();
+  }
+
   private activate(): void {
     this.isActive = true;
     // A fresh activation (new task or reopen of a parked one) starts a new cycle —

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -457,6 +457,39 @@ export class Task {
     const defaultCh = this.metadata.default_channel
       ? this.metadata.channels[this.metadata.default_channel]
       : null;
+
+    // First delivery on a task that has nowhere to reply yet — a schedule-fired trigger
+    // task. Post top-level to the destination the fire recorded, then link the thread that
+    // post just created, so a human replying to it comes back to THIS task instead of
+    // starting a stranger one. Distinct from `post_to_channel`, which stays deliberately
+    // fire-and-forget for talking to channels this task does not live in.
+    if (!defaultCh && this.metadata.delivery_target) {
+      const { channel_id, channel_name } = this.metadata.delivery_target;
+      const ts = await postSlackMessage({ channel: channel_id, text: message, footer });
+      if (!ts) {
+        // Dry run, or Slack returned no ts. The message is out; there is just nothing to
+        // link, and inventing a thread id would strand every later post on a bad key.
+        logger.warn('task', `postToUser on task ${this.taskId} delivered to ${channel_name} but got no ts back — thread not linked`);
+        this.logOutgoingMessage(sender, message, `#${channel_name}`, undefined, footer);
+        return null;
+      }
+      const key = `slack:${channel_id}:${ts}`;
+      const channel: SlackChannel = {
+        type: 'slack',
+        thread_id: ts,
+        channel_id,
+        channel_name,
+        last_processed_ts: ts,
+        url: buildThreadUrl(channel_id, ts) ?? undefined,
+      };
+      this.metadata.channels[key] = channel;
+      this.metadata.default_channel ??= key;
+      delete this.metadata.delivery_target;
+      this.debouncedSave();
+      this.logOutgoingMessage(sender, message, Task.formatSlackDest(channel).display, channel, footer);
+      return key;
+    }
+
     if (!defaultCh) {
       logger.warn('task', `postToUser called on task ${this.taskId} with no default channel — message dropped`);
       return null;

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -343,6 +343,14 @@ export interface TaskMetadata {
   };
   triggered_by?: string;             // Trigger ID that spawned this task (set by fireTrigger). Blocks the task from creating triggers.
   pending_trigger_id?: string;       // Trigger ID proposed by this task, awaiting approve/deny (read by handleTriggerApproval/Denial)
+  /**
+   * Where this task must deliver its first user-facing message when it starts with no
+   * linked channel — set by `fireTrigger` for a schedule fire, whose task has no thread
+   * to reply in. `postToUser` posts there top-level, links the thread it just created,
+   * and clears this. Absent on every other task: a task that already lives in a thread
+   * has a default channel instead.
+   */
+  delivery_target?: { channel_id: string; channel_name: string };
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
**Stacked on #292** — base is `fix/trigger-message-context`, because it restructures the same fire path. Merge #292 first and this retargets to `main` cleanly.

## The problem, measured live

A schedule fire has no thread to reply in, so the PM delivered through `post_to_channel`, which is deliberately fire-and-forget. Before this change, on a live instance:

- fired task after a successful delivery: `channels: {}`, `default_channel: None`
- the tool's own result: `Message posted to C0BL50N2600 (new thread ts: 1787084582.563519). Not linked to this task.`
- a human reply in that thread: `[System] Created task task-20260818-2025-mxwntp` — a **stranger task**. Fresh PM, no trigger id, no `triggered_by`, no access to the trigger's directory. The thread got linked *there* instead.
- the PM also had to invent the mandate `post_to_channel` demands (`"Trigger instruction from the user who set up trigger trg-…"`), because there is no human in that task's thread to quote.

## The change

`fireTrigger` records `metadata.delivery_target` for a channel-bound schedule fire. `Task.postToUser` acts on it: posts top-level there, stores the returned ts as a linked channel, makes it the default, clears the target so later messages thread under it. `findTaskByThread` matches on `thread_id`, so replies come back to the task that posted. The tool's `New channel linked: …` return path was already written for exactly this and previously had no way to fire.

**`post_to_channel` is untouched** — still the tool for a channel this task does not live in, still links nothing. The two jobs are now separate paths instead of one path doing both badly.

## The load-bearing part was the PM's context, not the prompt

First live attempt: target recorded correctly, and the PM still delivered nothing. Its own reasoning, verbatim:

> "Task metadata says 'Channel(s): none — there is nowhere to reply in this task; finish with report_completion() (no message).'"
> "There is no channel linked to this task, so `post_to_user` has no destination."

That context line was telling it to give up. With a delivery target it now names the destination and says the first post opens the thread.

## Live verification, after

Same probe trigger, same channel:

| | before | after |
|---|---|---|
| tool the PM chose | `post_to_channel` (after ToolSearch) | `post_to_user`, no target |
| tool result | "Not linked to this task." | "New channel linked: slack:C0BL50N2600:1787086486.442039" |
| fired task metadata | `channels: {}` / `default_channel: None` | `default_channel: slack:C0BL50N2600:1787086486.442039`, `delivery_target: null` |
| human reply in the thread | `Created task task-20260818-2025-mxwntp` | **`Resumed pm-agent for task task-20260818-2054-wt8m06`** — the fired task, no new task |

The reply was injected as a signed event through `/webhooks/slack` (bot tokens cannot post as a human). The bot's root message and the thread were real; the reply itself was synthetic, so the **routing decision** is what this verifies — not the ingest of the reply's text, which `Task.append` skips because the message does not exist in Slack.

## Also

- `post_to_user` and `report_completion(message)` no longer refuse when `channels` is empty but a delivery target is set
- 5 new unit tests in `src/tasks/__tests__/delivery-target.test.ts`: top-level post (no `threadTs`), the linked channel's exact shape, `findTaskByThread` resolving the posted ts, target cleared so the second message threads, no-ts leaves it sent-but-unlinked rather than inventing an id, and the target being ignored once a default channel exists
- `buildTriggerSeed` drops the channel-id delivery line for channel-bound schedule fires — delivery is `post_to_user` like everywhere else. The user-bound (DM) case keeps its line and is unchanged: the id worth storing is the `D…` conversation while the message is addressed to a `U…`, so linking it needs a `conversations.open` this does not do
- `npm run build` clean, `npx vitest run` 1168 passed