### PR TITLE
Credit Archie as a real account, and name the human on its PRs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,11 @@ GITHUB_APP_PRIVATE_KEY_PATH=./secrets/github-private-key.pem
 GITHUB_INSTALLATION_ID=12345678
 GITHUB_WEBHOOK_SECRET=your-webhook-secret
 
+# GitHub account Archie is credited as (USER id, not the App ID)
+ARCHIE_GITHUB_LOGIN=archie-hq
+ARCHIE_GITHUB_USER_ID=302249786
+ARCHIE_GITHUB_NAME=Archie HQ
+
 # MCP Plugin Servers (substituted into plugins/.mcp.json)
 MCP_ATLASSIAN_TOKEN=base64(user@example.com:your-api-token)
 MCP_BUGSNAG_AUTH_TOKEN=your-bugsnag-personal-auth-token

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -143,6 +143,8 @@ Configure these in your `.env` file:
 | `SLACK_SIGNING_SECRET` | Slack signing secret — HTTP webhook mode | `abc123...` |
 | `SLACK_APP_TOKEN` | Slack app-level token — Socket Mode (alternative to signing secret; no inbound webhook URL needed) | `xapp-...` |
 | `GITHUB_APP_ID` | GitHub App ID | `123456` |
+| `ARCHIE_GITHUB_LOGIN` | Account Archie is credited as (optional) | `archie-hq` |
+| `ARCHIE_GITHUB_USER_ID` | That account's numeric user ID, not the App ID | `302249786` |
 | `GITHUB_INSTALLATION_ID` | GitHub App installation ID | `12345678` |
 | `ARCHIE_PLUGINS` | Git URL for plugins repo | `git@github.com:org/archie-plugins.git` |
 | `PORT` | Server port (optional) | `3000` |

--- a/docs/architecture/github-integration.md
+++ b/docs/architecture/github-integration.md
@@ -14,13 +14,37 @@ The client lazily initializes an authenticated Octokit instance via `app.getInst
 
 For git operations (push, fetch), authentication is handled by the `GIT_ASKPASS` environment variable rather than the Octokit client.
 
-### Bot Identity for Commits
+### Identities: acting vs. being credited
 
-The system configures git identity using the GitHub App's bot credentials:
-- Name: `{appSlug}[bot]` (e.g., `archie-hq[bot]`)
-- Email: `{appId}+{appSlug}[bot]@users.noreply.github.com`
+Two distinct identities, because GitHub treats them differently.
 
-This is set once per base repository at server startup via `configureGitIdentity()` in `src/connectors/github/client.ts`. Shared clones inherit this configuration from the base repo.
+**The identity Archie acts as** is the GitHub App installation -- what the API calls and the git transport authenticate with. `getGitHubAppIdentity()` builds it as name `{appSlug}[bot]` / email `{appId}+{appSlug}[bot]@users.noreply.github.com`. It is now only a fallback for the identity below; nothing credits the bot deliberately.
+
+**The identity Archie is credited as** is a real user account (`archie-hq`), built by `getArchieAttributionIdentity()` from `ARCHIE_GITHUB_LOGIN` + `ARCHIE_GITHUB_USER_ID` (+ optional `ARCHIE_GITHUB_NAME`). It lands in three places:
+
+- the **committer** on every commit made in a clone, written once per base repository at server startup by `configureGitIdentity()` (shared clones inherit it) -- and the **author** too on commits `buildCommitAuthorEnv` leaves unattributed, i.e. when no approver was recorded;
+- the **`Co-Authored-By` trailer** on repo-agent commits, written into the agent's `.claude/settings.json` as `attribution.commit` by `setupAgentWorkspace()`;
+- the **attribution footer** on PR bodies.
+
+A user account is required rather than merely nicer: a GitHub App bot cannot be `@mentioned` at all, and its profile is an app page rather than an account. Attribution needs no repository access, so the account can be credited without being granted anything.
+
+The committer and the acting identity are free to differ because git push authenticates with the installation token via `GIT_ASKPASS`, and GitHub does not require the committer to match the pusher. Self-event filtering is unaffected for the same reason: a webhook's `sender` comes from the credential that made the API call, not from any commit's identity, so it is still `{appSlug}[bot]`.
+
+`ARCHIE_GITHUB_USER_ID` must be the account's numeric **user** ID, not the App ID. GitHub resolves the `{id}+{login}@users.noreply.github.com` form by ID and silently drops the credit when the ID disagrees with the login -- it does not fall back to matching the login. The bot form above derives that prefix from `GITHUB_APP_ID`, which is not a user ID, so a trailer built from it resolves to no account at all. When the attribution vars are unset, `getArchieAttributionIdentity()` falls back to the App bot, preserving prior behaviour rather than dropping the trailer.
+
+### PR authorship and attribution
+
+GitHub sets a PR's author from the credential that creates it, and offers no field to override it -- an installation token always yields `{appSlug}[bot]`. So a PR Archie opens on someone's behalf can never *be* theirs on GitHub, and the only place the human can appear is the body.
+
+`create_pull_request` therefore stamps one line at the top of the body via `buildAttributedBody()` in `src/connectors/github/pr-attribution.ts`, rather than leaving it to the agent:
+
+```
+Opened by @archie-hq on behalf of Bandita Parida.
+```
+
+The human is the edit-mode approver (`edit_approved_by`), which is also who repo-agent commits are authored as (`buildCommitAuthorEnv` in `src/agents/commit-author.ts`), so the PR names exactly whoever `git blame` will name -- by their Slack display name, with no GitHub-account lookup. GitHub auto-links the `@login` to Archie's profile.
+
+`update_pr` re-stamps the line when it rewrites a body, and both strip any prior copy (matched on the `<!-- archie-attribution -->` marker) so re-injection replaces rather than stacks.
 
 ## Webhook Handling
 
@@ -266,7 +290,8 @@ The system is designed so that the PM agent is only reactivated for GitHub event
 
 ## Relevant Source Files
 
-- `src/connectors/github/client.ts` -- `GitHubClient` class wrapping `@octokit/app`, `configureGitIdentity()`, `fetchOrigin()`, `getGitHubClient()` singleton; PR ops (`listPRs`, `getPRDetails`, `getPRStatus`, `getPRCardData`, `getPRReviews`, `getReviewThreads`, `getPRComments`, `createPullRequest`, `updatePR`, `addPRComment`, `addReviewComment`, `replyToReviewComment`, `resolveReviewThread` (GraphQL), `requestReReview`, `mergePullRequest`, `closePullRequest`)
+- `src/connectors/github/client.ts` -- `GitHubClient` class wrapping `@octokit/app`, `configureGitIdentity()`, `getGitHubAppIdentity()`, `getArchieAttributionIdentity()`, `fetchOrigin()`, `getGitHubClient()` singleton; PR ops (`listPRs`, `getPRDetails`, `getPRStatus`, `getPRCardData`, `getPRReviews`, `getReviewThreads`, `getPRComments`, `createPullRequest`, `updatePR`, `resolveCommitAuthor`, `addPRComment`, `addReviewComment`, `replyToReviewComment`, `resolveReviewThread` (GraphQL), `requestReReview`, `mergePullRequest`, `closePullRequest`)
+- `src/connectors/github/pr-attribution.ts` -- `buildAttributedBody()`, `stripAttribution()`, `ATTRIBUTION_MARKER`: composes the header/footer naming the human a PR was opened for, and strips prior copies plus Claude Code's default footer
 - `src/connectors/github/events.ts` -- `mountGitHubWebhook()` Express handler, `handleGitHubWebhook()`, `maybeRefreshPrCards()` (in-place PR-card updates), `handleExistingTaskDirect()` (with comment dedup)
 - `src/system/pr-card-format.ts` -- pure PR-card formatting shared by Slack + CLI: `summarizeCi`, `prCardFingerprint`, `prCardSubtitle`, `prCardTitlePlain`, `SLACK_PR_CARD_EMOJI`/`CLI_PR_CARD_EMOJI`
 - `src/connectors/github/webhooks.ts` -- HMAC-SHA256 signature verification, context extraction, deterministic routing (`routeGitHubEvent`, `determineRouteAction`), structured event formatting (`formatGitHubEvent`), merge check debouncing (`handleMergeCheckDirect`)

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -33,6 +33,7 @@ Secrets are injected via the container's environment file plus the mounted
 - `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, `GITHUB_INSTALLATION_ID` — GitHub App identifiers
 - `GITHUB_APP_PRIVATE_KEY_PATH` — path to PEM file (mount under `/app/secrets`)
 - `GITHUB_WEBHOOK_SECRET` — webhook signature verification (PR tools disabled if unset)
+- `ARCHIE_GITHUB_LOGIN`, `ARCHIE_GITHUB_USER_ID`, `ARCHIE_GITHUB_NAME` — the account Archie is *credited* as on commits and PRs, separate from the App it acts as (optional; falls back to the App bot). The user ID must be the account's numeric user ID, not the App ID — see `docs/architecture/github-integration.md`
 - `ARCHIE_PLUGINS` — git URL for the plugins repo, cloned into `$ARCHIE_WORKDIR/plugins` on startup
 - `ARCHIE_PLUGINS_BRANCH` — optional branch override (defaults to repo default)
 - `ARCHIE_WORKDIR` — base working directory (defaults to `./workdir`; production mounts `/workdir`)

--- a/docs/guides/github-setup.md
+++ b/docs/guides/github-setup.md
@@ -77,6 +77,20 @@ GITHUB_WEBHOOK_SECRET=your-webhook-secret              # must match the App's we
 
 The engine authenticates as the installation (`@octokit/app`) and pushes git over HTTPS using a short-lived installation token (`x-access-token`), so no SSH key or personal token is involved for App-driven work.
 
+### Optional: the account Archie is credited as
+
+The App above is the identity Archie *acts* as. The identity it is *credited* as — the `Co-Authored-By` trailer on its commits and the attribution footer on PRs it opens — is a separate, ordinary user account, because a GitHub App bot cannot be `@mentioned` and its profile is an app page rather than an account:
+
+```bash
+ARCHIE_GITHUB_LOGIN=archie-hq                          # the account's login
+ARCHIE_GITHUB_USER_ID=302249786                        # its numeric USER id — not the App ID
+ARCHIE_GITHUB_NAME=Archie HQ                           # display name (optional; defaults to the login)
+```
+
+Read the user ID from `https://api.github.com/users/<login>`. It has to be the account's own ID: GitHub resolves `<id>+<login>@users.noreply.github.com` by ID and credits nobody at all when the ID doesn't match the login. Omit both vars to fall back to the App bot.
+
+The account needs **no repository access** to be credited. Add it as a read-level collaborator (or an org member) only if you want `@archie-hq` to appear in GitHub's mention autocomplete — that list is drawn from collaborators, org members, and thread participants, so a new account is otherwise invisible in it. Mentions of it still work either way on public repos.
+
 ## 6. Verify
 
 - Confirm the daemon is reachable at `https://<your-host>/webhooks/github` and that GitHub's webhook **Recent Deliveries** show `200`s.

--- a/prompts/repo-agent.md
+++ b/prompts/repo-agent.md
@@ -150,6 +150,8 @@ Write:
 4. `create_pull_request(title, body)` with a clear description
 5. Notify pm-agent: "PR #123 created: <url>"
 
+**Don't write an attribution line into the body.** `create_pull_request` adds its own line naming Archie and the person the PR was opened for. Write the description only.
+
 **Don't wait for CI after opening a PR.** The user sees checks live in a self-updating PR card — there's nothing to watch. Never `sleep` or loop on `get_pr_checks` waiting for checks; report the PR and stop. Inspect checks only when asked to fix a specific failure.
 
 ### Handling Reviews

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../connectors/github/client.js', async (importOriginal) => {
     parseCheckRef: actual.parseCheckRef,
     getGitHubClient: vi.fn(),
     fetchOrigin: vi.fn().mockResolvedValue(undefined),
+    getArchieAttributionIdentity: vi.fn(),
   };
 });
 
@@ -67,7 +68,7 @@ vi.mock('../registry.js', () => ({
 
 // ---- Helpers ----
 
-import { getGitHubClient } from '../../connectors/github/client.js';
+import { getGitHubClient, getArchieAttributionIdentity } from '../../connectors/github/client.js';
 import { isAutoMergeRepo } from '../registry.js';
 
 const mockGitHubClient = {
@@ -716,5 +717,60 @@ describe('findBranchStateByPR', () => {
   it('returns undefined when no branch_states', () => {
     const attached: AttachedRepo = { github: 'org/backend' };
     expect(findBranchStateByPR(attached, 42)).toBeUndefined();
+  });
+});
+
+/**
+ * PR attribution: the body is the only place the human behind a PR can appear,
+ * because GitHub sets the author from the credential that opens it. These cover
+ * the wiring — who gets named, and that a body rewrite doesn't drop the line.
+ */
+describe('PR attribution', () => {
+  const ARCHIE = { name: 'Archie HQ', email: 'x', mention: '@archie-hq' };
+  const APPROVER = { id: 'U1', name: 'Bandita Parida', email: 'b.parida@sweatco.in' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getGitHubClient).mockReturnValue(mockGitHubClient as any);
+    vi.mocked(getArchieAttributionIdentity).mockReturnValue(ARCHIE as any);
+    vi.mocked(isAutoMergeRepo).mockReturnValue(true);
+    mockGitHubClient.createPullRequest.mockResolvedValue({ pr_number: 42, pr_url: 'https://gh/pr/42' });
+  });
+
+  /** The body create_pull_request actually sent to GitHub. */
+  const sentBody = () => mockGitHubClient.createPullRequest.mock.calls[0][4] as string;
+
+  it('names the approver, using their Slack display name', () => {
+    const tool = getRepoTool(makeAgent(), makeTask({ edit_approved_by: APPROVER }), 'create_pull_request');
+
+    return tool({ title: 'T', body: 'Description.' }, {}).then(() => {
+      expect(sentBody()).toContain('Opened by @archie-hq on behalf of Bandita Parida.');
+      expect(sentBody()).toContain('Description.');
+    });
+  });
+
+  it('names nobody when no approver was recorded', async () => {
+    // CLI approvals and pre-feature tasks have no edit_approved_by.
+    const tool = getRepoTool(makeAgent(), makeTask(), 'create_pull_request');
+    await tool({ title: 'T', body: 'Description.' }, {});
+
+    expect(sentBody()).toContain('Opened by @archie-hq.');
+    expect(sentBody()).not.toContain('on behalf of');
+  });
+
+  it('re-stamps attribution when update_pr rewrites the body', async () => {
+    const tool = getRepoTool(makeAgent(), makeTask({ edit_approved_by: APPROVER }), 'update_pr');
+    await tool({ pr_number: 42, body: 'Rewritten.' }, {});
+
+    const patched = mockGitHubClient.updatePR.mock.calls[0][2].body as string;
+    expect(patched).toContain('Opened by @archie-hq on behalf of Bandita Parida.');
+    expect(patched).toContain('Rewritten.');
+  });
+
+  it('leaves the body untouched when update_pr changes only the title', async () => {
+    const tool = getRepoTool(makeAgent(), makeTask({ edit_approved_by: APPROVER }), 'update_pr');
+    await tool({ pr_number: 42, title: 'New title' }, {});
+
+    expect(mockGitHubClient.updatePR.mock.calls[0][2].body).toBeUndefined();
   });
 });

--- a/src/agents/__tests__/pr-tools.test.ts
+++ b/src/agents/__tests__/pr-tools.test.ts
@@ -744,7 +744,7 @@ describe('PR attribution', () => {
     const tool = getRepoTool(makeAgent(), makeTask({ edit_approved_by: APPROVER }), 'create_pull_request');
 
     return tool({ title: 'T', body: 'Description.' }, {}).then(() => {
-      expect(sentBody()).toContain('Opened by @archie-hq on behalf of Bandita Parida.');
+      expect(sentBody()).toContain('Opened by @archie-hq on behalf of **Bandita Parida**.');
       expect(sentBody()).toContain('Description.');
     });
   });
@@ -763,7 +763,7 @@ describe('PR attribution', () => {
     await tool({ pr_number: 42, body: 'Rewritten.' }, {});
 
     const patched = mockGitHubClient.updatePR.mock.calls[0][2].body as string;
-    expect(patched).toContain('Opened by @archie-hq on behalf of Bandita Parida.');
+    expect(patched).toContain('Opened by @archie-hq on behalf of **Bandita Parida**.');
     expect(patched).toContain('Rewritten.');
   });
 

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -46,7 +46,7 @@ import {
   createRecoverableInputGenerator,
 } from './message-queue.js';
 import { setupSharedClone, cloneExists, type CloneCheckout } from '../connectors/github/repo-clone.js';
-import { configureGitIdentity, getGitHubAppIdentity } from '../connectors/github/client.js';
+import { configureGitIdentity, getArchieAttributionIdentity } from '../connectors/github/client.js';
 import { buildChannelCanvasPromptSection } from '../connectors/slack/channel-canvas.js';
 import { buildChannelPinsPromptSection } from '../connectors/slack/channel-pins.js';
 import { resolvePeopleFromTranscript } from '../connectors/slack/client.js';
@@ -138,12 +138,17 @@ async function setupAgentWorkspace(taskId: string, agent: Agent): Promise<string
   // Write .claude/settings.json (picked up by the SDK via settingSources: ['project']).
   //
   // attribution.commit replaces Claude Code's default commit trailer: we swap the
-  // harness-default "Co-Authored-By: Claude <model>" line for Archie (the GitHub
-  // App bot) so commits credit Archie as co-author, not the model. sessionUrl:false
-  // drops the Claude-Session trailer too. When the bot identity isn't configured
-  // the empty string simply hides the trailer. Plugin hooks are merged in when set.
+  // harness-default "Co-Authored-By: Claude <model>" line for Archie so commits
+  // credit Archie as co-author, not the model. sessionUrl:false drops the
+  // Claude-Session trailer too. When no identity is configured the empty string
+  // simply hides the trailer. Plugin hooks are merged in when set.
+  //
+  // The identity is the attribution account, not the App bot: the bot form's
+  // numeric prefix comes from GITHUB_APP_ID rather than a user ID, so GitHub
+  // resolved the trailer to no account at all and Archie's co-authorship was
+  // invisible. See getArchieAttributionIdentity().
   const settingsPath = join(claudeDir, 'settings.json');
-  const archie = getGitHubAppIdentity();
+  const archie = getArchieAttributionIdentity();
   const settings: Record<string, unknown> = {
     attribution: {
       commit: archie ? `Co-Authored-By: ${archie.name} <${archie.email}>` : '',

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -17,7 +17,8 @@ import type { AgentName, FindingType, AttachedRepo, SlackThreadMessage } from '.
 import type { Task } from '../tasks/task.js';
 import type { Agent } from './agent.js';
 import { getVisiblePeerIdsForSender, findAgentDefsContainingRepo, synthesizeDynamicAgentDef, isAutoMergeRepo } from './registry.js';
-import { getGitHubClient, parseCheckRef } from '../connectors/github/client.js';
+import { getGitHubClient, parseCheckRef, getArchieAttributionIdentity } from '../connectors/github/client.js';
+import { buildAttributedBody } from '../connectors/github/pr-attribution.js';
 import { gitExec } from '../connectors/github/repo-clone.js';
 import { hydrateBranchState, findBranchStateByPR, assignPrNumber } from '../connectors/github/branch-state.js';
 import { taskBranchName } from '../connectors/github/branch-naming.js';
@@ -1232,6 +1233,21 @@ function createPushBranchTool(agent: Agent, task: Task) {
   );
 }
 
+/**
+ * Stamp the attribution line onto a PR body: who opened it, and for whom.
+ *
+ * The human is the edit-mode approver, which is also who repo-agent commits are
+ * authored as (`buildCommitAuthorEnv`) — so the PR names exactly whoever
+ * `git blame` will name. Their Slack display name is used as-is.
+ */
+function attributePrBody(task: Task, body: string): string {
+  return buildAttributedBody(
+    body,
+    task.metadata.edit_approved_by?.name ?? null,
+    getArchieAttributionIdentity()?.mention ?? null,
+  );
+}
+
 function createPullRequestTool(agent: Agent, task: Task) {
   return tool(
     'create_pull_request',
@@ -1258,7 +1274,8 @@ function createPullRequestTool(agent: Agent, task: Task) {
       const entry = agent.def.repo!.repos.find((r) => r.github === github);
       const base = state?.base_branch || entry?.baseBranch || 'main';
 
-      const result = await client.createPullRequest(github, head, base, args.title, args.body);
+      const body = attributePrBody(task, args.body);
+      const result = await client.createPullRequest(github, head, base, args.title, body);
 
       if (state) {
         // Reset per-PR markers when this branch's pr_number changes — a reused
@@ -1720,9 +1737,11 @@ function createUpdatePRTool(agent: Agent, task: Task) {
       if (!resolved.ok) return err(resolved.error);
       const client = getGitHubClient();
       if (!client) throw new Error('GitHub client not configured');
+      // Re-stamp attribution: a body rewrite would otherwise drop the line naming
+      // the human this PR was opened for.
       await client.updatePR(resolved.github, args.pr_number, {
         title: args.title,
-        body: args.body,
+        body: args.body === undefined ? undefined : attributePrBody(task, args.body),
         base: args.base,
       });
       return ok(`Updated PR #${args.pr_number} (${resolved.github})`);

--- a/src/connectors/github/__tests__/git-identity.test.ts
+++ b/src/connectors/github/__tests__/git-identity.test.ts
@@ -13,7 +13,7 @@ import { promisify } from 'util';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { configureGitIdentity } from '../client.js';
+import { configureGitIdentity, getArchieAttributionIdentity } from '../client.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -24,7 +24,7 @@ const BOT_EMAIL = `${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com`;
 
 let tmpDir: string;
 let repoPath: string;
-let savedEnv: { id?: string; slug?: string; workdir?: string };
+let savedEnv: { id?: string; slug?: string; workdir?: string; login?: string; userId?: string; name?: string };
 
 /**
  * Read a key from the repo's own config, or null when unset. Scoped to
@@ -44,9 +44,17 @@ beforeEach(async () => {
     id: process.env.GITHUB_APP_ID,
     slug: process.env.GITHUB_APP_SLUG,
     workdir: process.env.ARCHIE_WORKDIR,
+    login: process.env.ARCHIE_GITHUB_LOGIN,
+    userId: process.env.ARCHIE_GITHUB_USER_ID,
+    name: process.env.ARCHIE_GITHUB_NAME,
   };
   process.env.GITHUB_APP_ID = APP_ID;
   process.env.GITHUB_APP_SLUG = APP_SLUG;
+  // Each attribution test sets what it needs; start from unconfigured so a
+  // developer's own .env can't satisfy an assertion.
+  delete process.env.ARCHIE_GITHUB_LOGIN;
+  delete process.env.ARCHIE_GITHUB_USER_ID;
+  delete process.env.ARCHIE_GITHUB_NAME;
 
   // Lock cleanup is confined to the workdir, so the fixture repo lives inside
   // one — `tmpDir` stands in for ARCHIE_WORKDIR.
@@ -64,17 +72,46 @@ afterEach(async () => {
   else process.env.GITHUB_APP_SLUG = savedEnv.slug;
   if (savedEnv.workdir === undefined) delete process.env.ARCHIE_WORKDIR;
   else process.env.ARCHIE_WORKDIR = savedEnv.workdir;
+  if (savedEnv.login === undefined) delete process.env.ARCHIE_GITHUB_LOGIN;
+  else process.env.ARCHIE_GITHUB_LOGIN = savedEnv.login;
+  if (savedEnv.userId === undefined) delete process.env.ARCHIE_GITHUB_USER_ID;
+  else process.env.ARCHIE_GITHUB_USER_ID = savedEnv.userId;
+  if (savedEnv.name === undefined) delete process.env.ARCHIE_GITHUB_NAME;
+  else process.env.ARCHIE_GITHUB_NAME = savedEnv.name;
 
   await fs.promises.rm(tmpDir, { recursive: true, force: true });
 });
 
 describe('configureGitIdentity', () => {
-  it('writes the bot identity into a fresh clone', async () => {
+  it('writes the attribution account into a fresh clone', async () => {
+    // The committer is Archie being *credited*, not Archie authenticating — push
+    // auth is the installation token, and GitHub doesn't require the committer to
+    // match the pusher. So this is the account, not the App bot whose synthetic
+    // address resolves to nobody.
+    process.env.ARCHIE_GITHUB_LOGIN = 'archie-hq';
+    process.env.ARCHIE_GITHUB_USER_ID = '302249786';
+    process.env.ARCHIE_GITHUB_NAME = 'Archie HQ';
+
+    const name = await configureGitIdentity(repoPath);
+
+    expect(name).toBe('Archie HQ');
+    expect(await readConfig(repoPath, 'user.name')).toBe('Archie HQ');
+    expect(await readConfig(repoPath, 'user.email')).toBe('302249786+archie-hq@users.noreply.github.com');
+  });
+
+  it('falls back to the bot identity when no account is configured', async () => {
     const name = await configureGitIdentity(repoPath);
 
     expect(name).toBe(BOT_NAME);
     expect(await readConfig(repoPath, 'user.name')).toBe(BOT_NAME);
     expect(await readConfig(repoPath, 'user.email')).toBe(BOT_EMAIL);
+  });
+
+  it('returns null and writes nothing when neither identity is configured', async () => {
+    delete process.env.GITHUB_APP_ID;
+
+    expect(await configureGitIdentity(repoPath)).toBeNull();
+    expect(await readConfig(repoPath, 'user.name')).toBeNull();
   });
 
   it('drops a leftover config.lock and completes the write', async () => {
@@ -98,11 +135,67 @@ describe('configureGitIdentity', () => {
 
     expect(fs.existsSync(lockPath)).toBe(true);
   });
+});
 
-  it('returns null and writes nothing when the app env is absent', async () => {
+/**
+ * The identity Archie is *credited* as, which is not the identity it acts as.
+ *
+ * The numeric prefix is the whole point: GitHub resolves
+ * `<id>+<login>@users.noreply.github.com` by ID, and credits nobody when the ID
+ * disagrees with the login. The bot form derives it from GITHUB_APP_ID, which is
+ * not a user ID, so every Co-Authored-By line Archie wrote resolved to no account.
+ */
+describe('getArchieAttributionIdentity', () => {
+  const USER_ID = '302249786';
+
+  it('builds a noreply address from the account\'s user ID', () => {
+    process.env.ARCHIE_GITHUB_LOGIN = 'archie-hq';
+    process.env.ARCHIE_GITHUB_USER_ID = USER_ID;
+    process.env.ARCHIE_GITHUB_NAME = 'Archie HQ';
+
+    expect(getArchieAttributionIdentity()).toEqual({
+      name: 'Archie HQ',
+      email: `${USER_ID}+archie-hq@users.noreply.github.com`,
+      mention: '@archie-hq',
+    });
+  });
+
+  it('uses the login as the display name when no name is given', () => {
+    process.env.ARCHIE_GITHUB_LOGIN = 'archie-hq';
+    process.env.ARCHIE_GITHUB_USER_ID = USER_ID;
+
+    expect(getArchieAttributionIdentity()?.name).toBe('archie-hq');
+  });
+
+  it('falls back to the App bot when the account is not configured', () => {
+    // A deployment without the new vars keeps its prior behaviour rather than
+    // losing the commit trailer altogether.
+    expect(getArchieAttributionIdentity()).toEqual({
+      name: BOT_NAME,
+      email: BOT_EMAIL,
+      mention: BOT_NAME,
+    });
+  });
+
+  it('falls back to the bot rather than emitting an address with a non-numeric ID', () => {
+    // An address built from a login-shaped "id" looks right and credits nobody —
+    // exactly the silent failure this function exists to correct. Prefer the
+    // fallback, which is at least visibly the bot.
+    process.env.ARCHIE_GITHUB_LOGIN = 'archie-hq';
+    process.env.ARCHIE_GITHUB_USER_ID = 'archie-hq';
+
+    expect(getArchieAttributionIdentity()?.email).toBe(BOT_EMAIL);
+  });
+
+  it('falls back to the bot when the login is missing', () => {
+    process.env.ARCHIE_GITHUB_USER_ID = USER_ID;
+
+    expect(getArchieAttributionIdentity()?.email).toBe(BOT_EMAIL);
+  });
+
+  it('returns null when neither the account nor the App is configured', () => {
     delete process.env.GITHUB_APP_ID;
 
-    expect(await configureGitIdentity(repoPath)).toBeNull();
-    expect(await readConfig(repoPath, 'user.name')).toBeNull();
+    expect(getArchieAttributionIdentity()).toBeNull();
   });
 });

--- a/src/connectors/github/__tests__/pr-attribution.test.ts
+++ b/src/connectors/github/__tests__/pr-attribution.test.ts
@@ -14,11 +14,11 @@ import { buildAttributedBody, stripAttribution, ATTRIBUTION_MARKER } from '../pr
 const MENTION = '@archie-hq';
 
 describe('buildAttributedBody', () => {
-  it('names Archie and the human above the description', () => {
+  it('names Archie and the human in an alert above the description', () => {
     const out = buildAttributedBody('## The report\n\nSomething broke.', 'Bandita Parida', MENTION);
 
     expect(out).toBe(
-      `${ATTRIBUTION_MARKER}\nOpened by @archie-hq on behalf of Bandita Parida.\n\n## The report\n\nSomething broke.`,
+      `${ATTRIBUTION_MARKER}\n> [!NOTE]\n> Opened by @archie-hq on behalf of **Bandita Parida**.\n\n## The report\n\nSomething broke.`,
     );
   });
 
@@ -26,7 +26,7 @@ describe('buildAttributedBody', () => {
     // CLI approvals and pre-feature tasks have no edit_approved_by.
     const out = buildAttributedBody('Body.', null, MENTION);
 
-    expect(out).toBe(`${ATTRIBUTION_MARKER}\nOpened by @archie-hq.\n\nBody.`);
+    expect(out).toBe(`${ATTRIBUTION_MARKER}\n> [!NOTE]\n> Opened by @archie-hq.\n\nBody.`);
   });
 
   it('leaves the body alone when no identity is configured', () => {
@@ -47,7 +47,7 @@ describe('buildAttributedBody', () => {
     const first = buildAttributedBody('Body.', 'Bandita Parida', MENTION);
     const second = buildAttributedBody(first, 'Egor Khmelev', MENTION);
 
-    expect(second).toContain('on behalf of Egor Khmelev.');
+    expect(second).toContain('on behalf of **Egor Khmelev**.');
     expect(second).not.toContain('Bandita');
   });
 
@@ -61,7 +61,7 @@ describe('buildAttributedBody', () => {
 
   it('leaves no blank description behind when the agent wrote none', () => {
     expect(buildAttributedBody('', 'Bandita Parida', MENTION)).toBe(
-      `${ATTRIBUTION_MARKER}\nOpened by @archie-hq on behalf of Bandita Parida.`,
+      `${ATTRIBUTION_MARKER}\n> [!NOTE]\n> Opened by @archie-hq on behalf of **Bandita Parida**.`,
     );
   });
 });
@@ -71,9 +71,10 @@ describe('stripAttribution', () => {
     expect(stripAttribution('## Report\n\nDetail.')).toBe('## Report\n\nDetail.');
   });
 
-  it('does not eat a line the author wrote themselves', () => {
-    // Only the line directly under the marker belongs to us.
-    const body = 'Opened by someone else, apparently.\n\nProse.';
+  it('does not eat a blockquote the author wrote themselves', () => {
+    // Only the quote directly under the marker belongs to us — an unmarked alert
+    // or quote of the author's own must survive.
+    const body = '> [!WARNING]\n> Do not merge before Friday.\n\nProse.';
 
     expect(stripAttribution(body)).toBe(body);
   });

--- a/src/connectors/github/__tests__/pr-attribution.test.ts
+++ b/src/connectors/github/__tests__/pr-attribution.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the PR attribution line.
+ *
+ * The line exists because GitHub sets a PR's author from the credential that opens
+ * it, so a PR Archie opens for someone can only name them in the body. These cover
+ * the two ways that went wrong before: the human being absent (left to the model,
+ * which named the Slack requester in prose or not at all), and Claude Code's
+ * harness footer crediting the coding tool.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildAttributedBody, stripAttribution, ATTRIBUTION_MARKER } from '../pr-attribution.js';
+
+const MENTION = '@archie-hq';
+
+describe('buildAttributedBody', () => {
+  it('names Archie and the human above the description', () => {
+    const out = buildAttributedBody('## The report\n\nSomething broke.', 'Bandita Parida', MENTION);
+
+    expect(out).toBe(
+      `${ATTRIBUTION_MARKER}\nOpened by @archie-hq on behalf of Bandita Parida.\n\n## The report\n\nSomething broke.`,
+    );
+  });
+
+  it('invents no human when no approver was recorded', () => {
+    // CLI approvals and pre-feature tasks have no edit_approved_by.
+    const out = buildAttributedBody('Body.', null, MENTION);
+
+    expect(out).toBe(`${ATTRIBUTION_MARKER}\nOpened by @archie-hq.\n\nBody.`);
+  });
+
+  it('leaves the body alone when no identity is configured', () => {
+    expect(buildAttributedBody('Body.', 'Bandita Parida', null)).toBe('Body.');
+  });
+
+  it('replaces rather than stacks when re-applied to its own output', () => {
+    // update_pr re-stamps every body rewrite, and the agent may pass back a body
+    // it read off the PR — so the operation has to be idempotent.
+    const once = buildAttributedBody('Body.', 'Bandita Parida', MENTION);
+    const twice = buildAttributedBody(once, 'Bandita Parida', MENTION);
+
+    expect(twice).toBe(once);
+    expect(twice.match(/Opened by/g)).toHaveLength(1);
+  });
+
+  it('re-attributes to a different human without leaving the old name behind', () => {
+    const first = buildAttributedBody('Body.', 'Bandita Parida', MENTION);
+    const second = buildAttributedBody(first, 'Egor Khmelev', MENTION);
+
+    expect(second).toContain('on behalf of Egor Khmelev.');
+    expect(second).not.toContain('Bandita');
+  });
+
+  it('keeps the Slack thread link the agent writes into the body', () => {
+    // The prompt still has the agent append the originating thread; attribution
+    // must not eat it.
+    const out = buildAttributedBody('Body.\n\nSlack thread in #liveops: https://slack.example/p1', 'Bandita Parida', MENTION);
+
+    expect(out).toContain('Slack thread in #liveops: https://slack.example/p1');
+  });
+
+  it('leaves no blank description behind when the agent wrote none', () => {
+    expect(buildAttributedBody('', 'Bandita Parida', MENTION)).toBe(
+      `${ATTRIBUTION_MARKER}\nOpened by @archie-hq on behalf of Bandita Parida.`,
+    );
+  });
+});
+
+describe('stripAttribution', () => {
+  it('leaves an unstamped body untouched apart from trimming', () => {
+    expect(stripAttribution('## Report\n\nDetail.')).toBe('## Report\n\nDetail.');
+  });
+
+  it('does not eat a line the author wrote themselves', () => {
+    // Only the line directly under the marker belongs to us.
+    const body = 'Opened by someone else, apparently.\n\nProse.';
+
+    expect(stripAttribution(body)).toBe(body);
+  });
+});

--- a/src/connectors/github/client.ts
+++ b/src/connectors/github/client.ts
@@ -1204,7 +1204,13 @@ export function createGitHubClient(): GitHubClient | null {
 }
 
 /**
- * Get GitHub App bot identity for git commits
+ * The GitHub App bot's name and commit address.
+ *
+ * Only a fallback now — `getArchieAttributionIdentity()` returns this when the
+ * attribution account isn't configured, so a deployment without those vars keeps
+ * its prior behaviour. Nothing credits the bot deliberately: the numeric prefix
+ * below is `GITHUB_APP_ID`, which is not a user ID, so GitHub resolves the
+ * address to no account. See `getArchieAttributionIdentity()`.
  */
 export function getGitHubAppIdentity(): { name: string; email: string } | null {
   const appId = process.env.GITHUB_APP_ID;
@@ -1217,6 +1223,65 @@ export function getGitHubAppIdentity(): { name: string; email: string } | null {
   return {
     name: `${appSlug}[bot]`,
     email: `${appId}+${appSlug}[bot]@users.noreply.github.com`,
+  };
+}
+
+/**
+ * The identity Archie is *credited* as on GitHub: the committer on every commit
+ * (via `configureGitIdentity`), the `Co-Authored-By` trailer on repo-agent commits,
+ * and the attribution block on PR bodies.
+ *
+ * Deliberately separate from `getGitHubAppIdentity()`, which is the identity Archie
+ * *acts* as — the installation its API calls and git transport authenticate with.
+ * Credit points at the real
+ * `archie-hq` user account instead, for two reasons a bot account can't satisfy:
+ * a GitHub App bot cannot be @mentioned at all, and its profile is an app page
+ * rather than an account. Attribution needs no repository access, so this works
+ * without granting the account anything.
+ *
+ * The numeric prefix must be the account's **user** ID. GitHub resolves the
+ * `<id>+<login>@users.noreply.github.com` form by ID and silently drops the credit
+ * when the ID disagrees with the login — it does not fall back to matching the
+ * login. The bot form above synthesizes that prefix from `GITHUB_APP_ID`, which is
+ * not a user ID (for this App: 2605869 vs. the bot user's 253344994), so every
+ * `Co-Authored-By` line Archie has written resolved to no account: PR #264's
+ * co-author comes back from the API with `login: ""`.
+ *
+ * Falls back to the App bot when the attribution account isn't configured, so a
+ * deployment without the new vars keeps its current behaviour instead of losing
+ * the trailer.
+ */
+export interface ArchieIdentity {
+  /** Display name for the commit trailer and footer link text. */
+  name: string;
+  /** noreply address GitHub resolves to the account. */
+  email: string;
+  /** `@mention` form — GitHub auto-links it to the profile. A bot login is left bare; bots aren't mentionable. */
+  mention: string;
+}
+
+export function getArchieAttributionIdentity(): ArchieIdentity | null {
+  const login = process.env.ARCHIE_GITHUB_LOGIN?.trim();
+  const userId = process.env.ARCHIE_GITHUB_USER_ID?.trim();
+
+  // Both are required, and the ID must be numeric: a non-numeric or absent ID
+  // would produce an address that looks right and credits nobody, which is the
+  // exact failure this function exists to correct. Prefer the visibly-degraded
+  // bot fallback over a silent one.
+  if (login && userId && /^[0-9]+$/.test(userId)) {
+    return {
+      name: process.env.ARCHIE_GITHUB_NAME?.trim() || login,
+      email: `${userId}+${login}@users.noreply.github.com`,
+      mention: `@${login}`,
+    };
+  }
+
+  const bot = getGitHubAppIdentity();
+  if (!bot) return null;
+  return {
+    name: bot.name,
+    email: bot.email,
+    mention: bot.name,
   };
 }
 
@@ -1254,12 +1319,21 @@ async function dropOrphanedConfigLock(repoPath: string): Promise<void> {
 }
 
 /**
- * Configure git identity for a repository using GitHub App bot credentials.
- * Should be called once on server startup for each base repo.
- * Worktrees inherit this config from the base repo.
+ * Write Archie's git identity into a repository — the committer on every commit
+ * made there, and the author too on the commits `buildCommitAuthorEnv` leaves
+ * unattributed (no approver recorded: CLI approvals, pre-feature tasks).
+ *
+ * Uses the attribution account rather than the App bot, because both of those
+ * roles are Archie being *credited*, not Archie authenticating. Push auth is the
+ * installation token via `GIT_ASKPASS` and GitHub does not require the committer
+ * to match the pusher, so the two are free to differ — and the App bot's synthetic
+ * address resolves to no account at all (see `getArchieAttributionIdentity`),
+ * which left every commit's committer line unlinked.
+ *
+ * Called once on server startup for each base repo; worktrees inherit the config.
  */
 export async function configureGitIdentity(repoPath: string): Promise<string | null> {
-  const identity = getGitHubAppIdentity();
+  const identity = getArchieAttributionIdentity();
   if (identity) {
     await dropOrphanedConfigLock(repoPath);
     await execAsync(`git config user.name "${identity.name}"`, { cwd: repoPath });

--- a/src/connectors/github/pr-attribution.ts
+++ b/src/connectors/github/pr-attribution.ts
@@ -1,0 +1,53 @@
+/**
+ * The one line Archie stamps onto every PR body it opens: who opened it, for whom.
+ *
+ * GitHub sets a PR's author from the credential that creates it, with no field to
+ * override it — an installation token always yields `<app-slug>[bot]`. So a PR
+ * Archie opens for someone can never *be* theirs on GitHub, and the only place
+ * their name can appear is the body. That was left to the model, which named the
+ * Slack requester in prose or not at all — so the human behind a PR was
+ * recoverable only by opening a commit and reading its author.
+ *
+ * Composed here instead, in `create_pull_request`, so it can't be reworded,
+ * forgotten, or lost to an `update_pr` that rewrites the body.
+ *
+ * The human named is whoever approved edit mode, which is also who the commits are
+ * authored as (`buildCommitAuthorEnv`) — so the PR names exactly whoever
+ * `git blame` will name. Their Slack display name is used as-is.
+ */
+
+/**
+ * Marks the injected line so a re-injection replaces it rather than stacking a
+ * second copy. An HTML comment: invisible in rendered Markdown, and preserved
+ * verbatim through GitHub's API round-trip.
+ */
+export const ATTRIBUTION_MARKER = '<!-- archie-attribution -->';
+
+/** The marker and the single line under it. */
+const LINE_RE = new RegExp(`${ATTRIBUTION_MARKER}\\n[^\\n]*\\n*`, 'g');
+
+/** Drop a previously stamped line, so a rewrite starts clean. Exported for `update_pr`. */
+export function stripAttribution(body: string): string {
+  return body.replace(LINE_RE, '').trim();
+}
+
+/**
+ * Put the attribution line above the description — that's where "whose PR is
+ * this?" gets asked, and GitHub shows a body's opening lines in timelines and
+ * previews.
+ *
+ * `humanName` is null when no approver was recorded (CLI approvals, pre-feature
+ * tasks): the line still names Archie, but nothing invents a human. `mention` is
+ * null only when no identity is configured, leaving the body as the agent wrote it.
+ */
+export function buildAttributedBody(
+  body: string,
+  humanName: string | null,
+  mention: string | null,
+): string {
+  const prose = stripAttribution(body);
+  if (!mention) return prose;
+
+  const line = humanName ? `Opened by ${mention} on behalf of ${humanName}.` : `Opened by ${mention}.`;
+  return [`${ATTRIBUTION_MARKER}\n${line}`, prose].filter(Boolean).join('\n\n');
+}

--- a/src/connectors/github/pr-attribution.ts
+++ b/src/connectors/github/pr-attribution.ts
@@ -23,8 +23,11 @@
  */
 export const ATTRIBUTION_MARKER = '<!-- archie-attribution -->';
 
-/** The marker and the single line under it. */
-const LINE_RE = new RegExp(`${ATTRIBUTION_MARKER}\\n[^\\n]*\\n*`, 'g');
+/**
+ * The marker and the blockquote lines under it. Matches the whole quote rather
+ * than one line because the alert syntax spans two (`> [!NOTE]` then the text).
+ */
+const LINE_RE = new RegExp(`${ATTRIBUTION_MARKER}\\n(?:>[^\\n]*\\n?)*\\n*`, 'g');
 
 /** Drop a previously stamped line, so a rewrite starts clean. Exported for `update_pr`. */
 export function stripAttribution(body: string): string {
@@ -32,9 +35,14 @@ export function stripAttribution(body: string): string {
 }
 
 /**
- * Put the attribution line above the description — that's where "whose PR is
- * this?" gets asked, and GitHub shows a body's opening lines in timelines and
- * previews.
+ * Put the attribution above the description — that's where "whose PR is this?"
+ * gets asked, and GitHub shows a body's opening lines in timelines and previews.
+ *
+ * Rendered as a GitHub Alert (`> [!NOTE]`), which draws a coloured box with an
+ * icon. That is the only way to make a line visually prominent here: GitHub
+ * sanitizes `style` attributes and CSS out of PR bodies, so alerts, blockquotes,
+ * headings and tables are the whole palette. GitHub prints its own "Note" label
+ * above the text and it cannot be renamed or removed.
  *
  * `humanName` is null when no approver was recorded (CLI approvals, pre-feature
  * tasks): the line still names Archie, but nothing invents a human. `mention` is
@@ -48,6 +56,9 @@ export function buildAttributedBody(
   const prose = stripAttribution(body);
   if (!mention) return prose;
 
-  const line = humanName ? `Opened by ${mention} on behalf of ${humanName}.` : `Opened by ${mention}.`;
-  return [`${ATTRIBUTION_MARKER}\n${line}`, prose].filter(Boolean).join('\n\n');
+  const line = humanName
+    ? `Opened by ${mention} on behalf of **${humanName}**.`
+    : `Opened by ${mention}.`;
+  const alert = `${ATTRIBUTION_MARKER}\n> [!NOTE]\n> ${line}`;
+  return [alert, prose].filter(Boolean).join('\n\n');
 }


### PR DESCRIPTION
Two related defects in how Archie attributes its work on GitHub. Both come down to GitHub treating "who may act" and "who gets named" as unrelated things.

## 1. Archie's commit credit resolved to nobody

`getGitHubAppIdentity()` built the address as `{appId}+{appSlug}[bot]@users.noreply.github.com`. GitHub resolves the `<id>+<login>@users.noreply.github.com` form by **user ID**, and silently drops the credit when the ID disagrees with the login — it does not fall back to matching the login. That prefix came from `GITHUB_APP_ID` (`2605869`), not the bot's user ID (`253344994`).

So every `Co-Authored-By` line Archie has ever written credited no account. From #264's API response:

```json
{"email":"2605869+archie-hq[bot]@users.noreply.github.com","login":"","name":"archie-hq[bot]"}
```

`login: ""`. No avatar, no profile link, no contribution.

## 2. A PR Archie opens for someone doesn't say whose it is

GitHub sets a PR's author from the credential that creates it, with no field to override it — an installation token always yields `{appSlug}[bot]`. So the human can only appear in the body, and that was left to the model, which named the Slack requester in prose or not at all.

#264 shows the cost: the body says "Requested by Alex Negru" while the commits are authored by Bandita Parida. The actual owner was recoverable only by opening a commit and reading its author.

## The change

**Split the two identities.** `getGitHubAppIdentity()` stays what Archie *acts* as — what the API and git transport authenticate with. New `getArchieAttributionIdentity()` is what Archie is *credited* as, from `ARCHIE_GITHUB_LOGIN` + `ARCHIE_GITHUB_USER_ID` (+ optional `ARCHIE_GITHUB_NAME`). It carries the committer identity, the co-author trailer, and the PR line.

A real user account rather than the App bot, for two reasons a bot can't satisfy: **a GitHub App bot cannot be @mentioned at all**, and its profile is an app page rather than an account. Credit requires no repository access, so the account can be credited without being granted anything.

**The committer moves too** (`configureGitIdentity`). It is Archie being credited, not authenticating. Safe because push auth is the installation token via `GIT_ASKPASS` and GitHub does not require the committer to match the pusher. Self-event filtering is unaffected for the same reason: a webhook's `sender` comes from the credential that made the API call, so it stays `{appSlug}[bot]` and the loop guard in `webhooks.ts` still matches.

**`create_pull_request` stamps one line itself**, above the description:

```
> [!NOTE]
> Opened by @archie-hq on behalf of **Egor Khmelev**.
```

rendered as a GitHub Alert — a coloured box with an icon, which is as prominent as a PR body gets (GitHub sanitizes `style` attributes and CSS out, so alerts, blockquotes, headings and tables are the whole palette). The trade-off is that GitHub prints its own "Note" label above the text, which can't be renamed.

The human is the edit-mode approver — also who the commits are authored as — so the PR names exactly whoever `git blame` will name. Their Slack display name is used as-is; GitHub auto-links the `@login`. `update_pr` re-stamps on a body rewrite, and both strip a prior copy via an HTML-comment marker, so re-injection replaces rather than stacks.

## Backwards compatibility

Unset `ARCHIE_GITHUB_*` and nothing changes — `getArchieAttributionIdentity()` falls back to the App bot. A **non-numeric** ID also falls back rather than emitting an address that looks correct and credits nobody: the visibly-degraded fallback beats a silent one, which is the whole failure mode being fixed here.

## Verification

Measured on a real PR ([archie-plugins#168](https://github.com/sweatco/archie-plugins/pull/168)) via a live boot-from-branch instance, not inferred.

**What this PR changes, verified:**

| Surface | Result |
|---|---|
| Committer | `Archie HQ <302249786+archie-hq@…>` → `archie-hq` (linked) |
| `Co-Authored-By` | `Archie HQ` → `archie-hq` (linked — the field that came back `""` on #264) |
| PR body header | `> [!NOTE]` alert naming Archie and the human — [rendered here](https://github.com/sweatco/archie-plugins/pull/168) |

**Context, not changed here:**

| Surface | Result |
|---|---|
| Commit author | `Egor Khmelev <egor@sweatco.in>` → `egorkhmelev` (linked) — pre-existing `buildCommitAuthorEnv` behaviour, shown for coherence |
| PR author | `app/archie-hq` — set by the credential that opens the PR, not overridable |

**Not covered by this run:** in production `edit_approved_by` is populated by a Slack approval. The harness enters through CLI/API, where there is no human, so the run supplied the approver directly in the route's request body:

```json
{"type":"edit_mode","approve":true,"approver":{"name":"Egor Khmelev","email":"egor@sweatco.in"}}
```

That exercises everything downstream of `edit_approved_by`, which is where this PR's changes live. It does not exercise Slack populating it — that code is untouched here.

Plus 1182 unit tests passing (21 new), typecheck and build clean.

## Deployment

Set in prod `.env` — the user ID is the account's own, readable from `https://api.github.com/users/<login>`:

```bash
ARCHIE_GITHUB_LOGIN=archie-hq
ARCHIE_GITHUB_USER_ID=302249786
ARCHIE_GITHUB_NAME=Archie HQ
```

Optionally add `archie-hq` as a read-level collaborator if you want it to appear in GitHub's `@` autocomplete. That list is drawn from collaborators, org members, thread participants, and a global search ranked by prominence — a new account with no followers never surfaces in the last one. Mentions of it work regardless on public repos; only the autocomplete needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
