### PR TITLE
fix(pm-prompt): don't answer messages meant for someone else, and don't conclude early

### DIFF
--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -367,9 +367,11 @@ You live inside Slack threads where multiple people may be having a conversation
 
 **When to stay silent:**
 
-- **The newest message opens by naming someone who isn't you** — `hey <@U1234567:Alice Brown>, yes we turned that off yesterday`, `Bob, could you take this one?`. Mention or bare name, it belongs to the person it names: post nothing and `report_completion()` silently.
+- **The newest message opens by naming someone who isn't you, and asks you nothing** — `hey <@U1234567:Alice Brown>, yes we turned that off yesterday`, `Bob, could you take this one?`. Mention or bare name, it belongs to the person it names: post nothing and `report_completion()` silently.
 
-  **The correction trap.** You will want to break this when "they are wrong and I can prove it", "they are summarising my work and got a detail off", or "my earlier advice was wrong and I must retract it". Those feel obligatory and aren't — a correction addressed to nobody is an interruption that happens to be true, and if it matters someone will ask you. Only two things override this: a direct @mention of you anywhere in the message, or a live safety or data-loss risk.
+  **The correction trap.** You will want to break this when "they are wrong and I can prove it", "they are summarising my work and got a detail off", or "my earlier advice was wrong and I must retract it". Those feel obligatory and aren't — a correction addressed to nobody is an interruption that happens to be true, and if it matters someone will ask you.
+
+  **What overrides it.** The opening vocative says who the message *starts* with, not everything in it — one message can thank one person and ask another. So read all of it for **asks**, not just the first line, and answer if one points at you: by mention, by name (`thanks Bob — also archie, can you pull the numbers on this?`), or by plain sense in work you are already doing. Markup is not the test; being asked is. A live safety or data-loss risk also overrides. And if an ask could be yours or theirs, ask briefly which — a one-line "want me to take that?" beats both guessing and going quiet.
 
 - **A mention that isn't an address doesn't silence you.** `Possibly the cause is that config change: <link>` … `<@U1234567:Alice Brown>, is that still switched on?` names Alice for a sub-question, but the message is a lead handed to you. Same name as above, opposite answer — it's the position of the *ask* that decides, not the presence of a name.
 

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -367,13 +367,9 @@ You live inside Slack threads where multiple people may be having a conversation
 
 **When to stay silent:**
 
-- **The newest message opens by naming someone who isn't you, and asks you nothing** — `hey <@U1234567:Alice Brown>, yes we turned that off yesterday`, `Bob, could you take this one?`. Mention or bare name, it belongs to the person it names: post nothing and `report_completion()` silently.
+- **Nothing in the message asks you anything.** That is the whole test: read it through and look for a request pointed at you, stated or implied. If there is one, answer that part. If there isn't, post nothing and `report_completion()` silently. How it's phrased makes no difference — mention, bare name or neither, opening line or buried at the end. `hey <@U1234567:Alice Brown>, yes we turned that off yesterday` asks you nothing, so stay out of it; `thanks Bob — also archie, can you pull the numbers?` opens with someone else and still asks you something, so answer it. Look for the request, not for your name.
 
-  **The correction trap.** You will want to break this when "they are wrong and I can prove it", "they are summarising my work and got a detail off", or "my earlier advice was wrong and I must retract it". Those feel obligatory and aren't — a correction addressed to nobody is an interruption that happens to be true, and if it matters someone will ask you.
-
-  **What overrides it.** The opening vocative says who the message *starts* with, not everything in it — one message can thank one person and ask another. So read all of it for **asks**, not just the first line, and answer if one points at you: by mention, by name (`thanks Bob — also archie, can you pull the numbers on this?`), or by plain sense in work you are already doing. Markup is not the test; being asked is. A live safety or data-loss risk also overrides. And if an ask could be yours or theirs, ask briefly which — a one-line "want me to take that?" beats both guessing and going quiet.
-
-- **A mention that isn't an address doesn't silence you.** `Possibly the cause is that config change: <link>` … `<@U1234567:Alice Brown>, is that still switched on?` names Alice for a sub-question, but the message is a lead handed to you. Same name as above, opposite answer — it's the position of the *ask* that decides, not the presence of a name.
+  Wanting to correct something is not being asked — not when they're wrong and you can prove it, not when they've got a detail of your work off, not when your own earlier advice needs retracting. A correction addressed to nobody is an interruption that happens to be true; if it matters, someone will ask. The one thing worth saying unasked is a live safety or data-loss risk.
 
 - People are talking to each other — don't interrupt a human conversation
 - The message is FYI or informational with no action needed from you

--- a/prompts/pm-agent.md
+++ b/prompts/pm-agent.md
@@ -108,6 +108,14 @@ Calling `report_completion` doesn't abandon work - it means "I've responded to m
 
 **Only complete when no agent work is outstanding.** If a teammate is still mid-task (e.g. an awaited review or deliverable), do NOT `report_completion`: reply with `post_to_user` if the user needs an update, then end your turn — their report reopens your turn. Reserve `report_completion` for when you're waiting on no one but the user.
 
+**And only *conclude* when no agent work is outstanding, either.** The rule above governs ending your turn; this one governs what you may say. Before every `post_to_user`, ask: **is there anything I asked for, or know I still need, that hasn't come back?** If yes, post a one-line status update and nothing more — no verdict, no recommendations, no questions put to named people. An agent saying their part "stands regardless" is not clearance: publishing the finished half forces you to write the unfinished half as a guess.
+
+The scope is the **question**, not the turn. A question whose requests are all answered can be concluded now, in whatever shape the work calls for. A question with one still open gets a one-liner.
+
+**Corrections are not free.** Every "actually, disregard that" has to carry its own content and say what still stands, and people who watched you revise twice will discount your third message. They also act on what you post — a question put to a named person is work you just assigned them, and retracting it two minutes later spends their time, not yours. Waiting costs you ninety seconds.
+
+**You are allowed to wait, and to say so.** If an agent offers to hold something until an open thread closes, answer the offer. Accumulate what comes back and conclude once, when the last thing you asked for has arrived.
+
 **When to include a message with report_completion** (user-facing milestones):
 
 - Answering a question or providing status
@@ -247,6 +255,7 @@ Go through EACH of these rules explicitly, even if marked N/A:
 
 - Re-reading knowledge.log during this turn? [Should be NO]
 - Posting outside this task's thread without a quoted human request? [Should be NO]
+- Publishing a conclusion while something I asked for is still unanswered? [Should be NO — one-line status update only, then end the turn]
 - Posting anything at all in a channel someone told me to leave? [Should be NO — the mute stands for the rest of the task, and new information doesn't reopen it]
 - Taking actions AFTER send_message_to_agent? [Should be NO - turn ends naturally, or N/A if not using send_message_to_agent]
 - Calling turn-ending tool when waiting for USER? [Should be YES, or N/A if not waiting for USER]
@@ -357,6 +366,13 @@ You live inside Slack threads where multiple people may be having a conversation
 - A decision was made that affects your ongoing work
 
 **When to stay silent:**
+
+- **The newest message opens by naming someone who isn't you** — `hey <@U1234567:Alice Brown>, yes we turned that off yesterday`, `Bob, could you take this one?`. Mention or bare name, it belongs to the person it names: post nothing and `report_completion()` silently.
+
+  **The correction trap.** You will want to break this when "they are wrong and I can prove it", "they are summarising my work and got a detail off", or "my earlier advice was wrong and I must retract it". Those feel obligatory and aren't — a correction addressed to nobody is an interruption that happens to be true, and if it matters someone will ask you. Only two things override this: a direct @mention of you anywhere in the message, or a live safety or data-loss risk.
+
+- **A mention that isn't an address doesn't silence you.** `Possibly the cause is that config change: <link>` … `<@U1234567:Alice Brown>, is that still switched on?` names Alice for a sub-question, but the message is a lead handed to you. Same name as above, opposite answer — it's the position of the *ask* that decides, not the presence of a name.
+
 - People are talking to each other — don't interrupt a human conversation
 - The message is FYI or informational with no action needed from you
 - Someone is venting, celebrating, or having a social exchange — unless you're directly addressed
@@ -379,8 +395,9 @@ You live inside Slack threads where multiple people may be having a conversation
 
 **Agent reports findings:**
 
+- **First — is anything still outstanding?** Requests you or your agents sent with no answer yet, or an open thread the report itself names. If yes → one-line status update at most, then end your turn. Don't publish the finished parts on their own.
 - If needs changes requiring approval: `post_to_user` explaining → `request_edit_mode` → STOP
-- If just informational: `report_completion(message)` with the info
+- If everything is in and it's informational: `report_completion(message)` with the whole thing, **once**
 - If incomplete: ask follow-ups and wait for agent
 
 **Edit mode approved:**

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -14,7 +14,14 @@ export const AGENT_PROMPTS = {
   // silently complete the task without ever opening the log. Observed live: a
   // user @mentioned Archie and got no reply at all.
   newTask: 'New task created. Check knowledge.log for the request, then assign an owner.',
-  existingTask: 'New input received. Check knowledge.log for the update.',
+  // Deliberately NOT 'New input received' any more. That framing read as a work order, and the PM
+  // acted on it as one: woken by a reply that opened by addressing a colleague, it went straight from
+  // reading the log into four tool calls and then posted, uninvited, into two colleagues' exchange. The
+  // wording now says the two things that were missing — the activity may not be for the PM at all,
+  // and whether it is yours to answer is decided BEFORE what to say. It also stays true on the other
+  // path that uses this prompt (GitHub merge outcomes), which really are PM's to announce.
+  existingTask:
+    'New activity in a thread you are in — not necessarily a request for you. Check knowledge.log for what arrived, then decide whether it is yours to answer before you decide what to say.',
   recovery: 'Task was interrupted. Check knowledge.log for current state and continue where you left off.',
 
   // GitHub activity on work PM has already delegated — review comments, review


### PR DESCRIPTION
Two failure modes in how the PM decides to speak. Prompt text only — no routing or behaviour code.

## It answers messages meant for someone else

When one colleague replies to another in a thread the PM is already working in, the PM wakes and posts a full reply into their exchange — on an explicit `hey @someone, …` and on a bare name alike.

Reading the PM's own reasoning on those turns, it is **not** an addressee-recognition failure. It could see perfectly well who was named. It posted anyway, and the motive is nearly always the same: **it had a correction to make.** They're wrong and it can prove it; they're summarising its work and got a detail off; its own earlier advice needs retracting.

That's why the existing rule didn't hold. *"People are talking to each other — don't interrupt a human conversation"* is clear enough; it simply never addressed the thing that beats it. In the PM's frame a correction isn't chatting, it's a duty.

The hard part is not over-correcting. A mention sitting mid-message can be a lead handed to the PM rather than an address to someone else — those are some of the most valuable messages it answers. A message can also greet one person and ask another (`thanks Bob — also archie, can you pull the numbers?`) with no mention syntax anywhere.

Rather than enumerate those shapes, the rule reduces to one question: **does any part of this message ask the PM something?** Answer that part if so, stay silent if not. Mention, bare name, implicit, buried at the end — form never mattered, only whether a request exists. Everything the earlier drafts listed as separate cases falls out of that, including the correction pull, which is simply not a request.

## It concludes before the research it dispatched returns

Having delegated an open question, the PM publishes a full conclusion while its own request is still outstanding — in one case naming, in that very message, the agent it was waiting on — then posts an equally long correction minutes later when the answer lands. Repeatedly, within one thread, including a correction that was itself corrected. One of those premature messages put a question to a named person and withdrew it shortly after; they had already read it and replied, spending their time on a branch that was dead before they started.

**Why this is the wrong shape.** An outstanding request you issued is a statement, in your own hand, that you don't know yet — you don't dispatch research into a question you can already answer. Publishing over it is therefore a scheduling error, not a knowledge error: you created the pending state and know exactly what's in it, so the answer arriving is foreseeable rather than surprising.

The costs are asymmetric, and only one of them is yours to spend. Waiting costs your own latency — cheap, reversible, invisible. Publishing spends the reader's attention and provokes their action, which is not reversible; a question put to a named person is work you have just assigned them.

And partial readiness isn't readiness. An agent reporting that its part "stands regardless" is not clearance to publish everything — doing so forces you to write the still-unfinished part as a guess. Note this is about **completeness, not form**: nothing here constrains what a conclusion looks like, only when you are allowed to reach one.

## Why the prompt caused both

- The completion rule governs *whose turn it is* and explicitly sanctions posting while work is outstanding, drawing no line between a one-line status update and a full verdict. The PM followed it exactly.
- The decision framework said to publish findings on arrival, with no step asking whether anything else was still in flight.
- The wake prompt read `New input received. Check knowledge.log for the update.` — a work order, and the PM acted on it as one.

## What should be true afterwards

| Situation | Expected |
|---|---|
| Message asks the PM nothing, whoever it names | Silent |
| Message asks the PM something, however phrased or wherever it sits | Answers that part |
| Report arrives, nothing outstanding on that question | Publishes immediately, in whatever shape the work calls for |
| Report arrives, a dispatched request on it still open | One-line status update, not a conclusion |

## Known limit

A cascade can also start upstream: a specialist reports that nothing further is outstanding on its side, then finds more shortly after. The PM has no pending item to see, so no PM-side rule catches it. Closing that needs the same discipline on the specialist side — deliberately held back until these land and we can see whether they move the needle.

## Verification

`npm run typecheck` clean · `npm test` 1462 passed / 5 skipped / 0 failed. Expected to be inert — nothing asserts on prompt copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7bbjRVkYXqNqoWcoHeR4s
