### PR TITLE
chore(env): drop deployment-specific MCP keys from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,14 +76,12 @@ ARCHIE_GITHUB_LOGIN=archie-hq
 ARCHIE_GITHUB_USER_ID=302249786
 ARCHIE_GITHUB_NAME=Archie HQ
 
-# MCP Plugin Servers (substituted into plugins/.mcp.json)
-MCP_ATLASSIAN_TOKEN=base64(user@example.com:your-api-token)
-MCP_BUGSNAG_AUTH_TOKEN=your-bugsnag-personal-auth-token
-MCP_BUGSNAG_PROJECT_API_KEY=your-bugsnag-project-api-key
-MCP_TEAMCITY_URL=https://your-teamcity-instance.com
-MCP_TEAMCITY_TOKEN=tc_your-api-token
-MCP_FIREBASE_SERVICE_ACCOUNT_PATH=/path/to/firebase-service-account-key.json
-MCP_ROLLBAR_ACCESS_TOKEN=your-rollbar-post-server-item-access-token
+# MCP Plugin Servers
+# Any `${MCP_*}` placeholder in your plugins repo's `.mcp.json` is substituted
+# from the environment at load time. Which keys you need is entirely a property
+# of your plugins — the engine reads none of them by name, so none are listed
+# here. Declare the ones your servers reference (e.g. MCP_FOO_TOKEN=...) in your
+# own `.env`, and document them alongside the plugins that consume them.
 
 # OAuth-based MCP servers
 # Generate the key once and append it directly to .env so the value

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -168,7 +168,7 @@ ANTHROPIC_API_KEY=sk-ant-...           # Claude API key
 # PORT=3000                            # Default: 3000
 ```
 
-See [`.env.example`](../../.env.example) for the full list, including per-MCP plugin tokens (Atlassian, Bugsnag, TeamCity, Firebase, Rollbar) that get substituted into `plugins/.mcp.json`.
+See [`.env.example`](../../.env.example) for the full list. Your plugins repo may need additional `MCP_*` keys of its own — every `${MCP_*}` placeholder in `plugins/.mcp.json` is substituted from the environment at load time — but those belong to the plugins, not to the engine, so they aren't listed here.
 
 Without Slack credentials, the server runs in **CLI-only mode**.
 Without GitHub App credentials, **PR tools are disabled** but agents can still read/write code, commit, and push via SSH. To enable PR tools, follow the **[GitHub App Setup guide](github-setup.md)** — it covers creating the App, the exact repository permissions and webhook events, the private key, installation, and the env vars above.


### PR DESCRIPTION
Follow-up to #272, which was closed with "This is relevant to specific deployment, not to engine" — the same objection applies to the seven vendor MCP keys already sitting in `.env.example`, so this removes them rather than adding more.

The engine reads no `MCP_*` key by name. `src/system/plugin-loader.ts:161` substitutes any `${MCP_*}` placeholder it finds in the plugins repo's `.mcp.json` generically (`connect.ts:53` does the same for the OAuth path), so which keys exist is entirely a property of whichever plugins repo you point `ARCHIE_PLUGINS` at. Nothing in this repo — not the code, not the bundled `examples/plugins/.mcp.json`, whose only server needs no env at all — references `MCP_ATLASSIAN_TOKEN`, `MCP_BUGSNAG_*`, `MCP_TEAMCITY_*`, `MCP_FIREBASE_SERVICE_ACCOUNT_PATH` or `MCP_ROLLBAR_ACCESS_TOKEN`.

What changes:

- `.env.example` — the seven vendor keys are replaced by a comment explaining the substitution mechanism and saying to declare your plugins' own keys in your `.env`. Someone copying the example no longer inherits another deployment's integrations as apparent setup steps.
- `docs/guides/local-development.md` — the sentence pointing at the example named the same five vendors as "per-MCP plugin tokens"; it now describes the mechanism instead.

`ARCHIE_SECRETS_KEY`, `ARCHIE_PUBLIC_URL` and `ARCHIE_SECRETS_DIR` stay — those are the engine's own OAuth vault, read by name in `src/system/oauth/`, not per-integration credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dk87Wyuc7rh2S1sMBv8d9