### PR TITLE
feat: optional model gateway — run agents on non-Anthropic models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,31 @@ ARCHIE_LIVE_STATUS=true
 # ARCHIE_MAX_MODE_MODEL=claude-fable-5
 # ARCHIE_MAX_MODE_EFFORT=max
 
+# Model gateway (run agents on non-Anthropic models via a self-hosted,
+# Anthropic-format gateway — the `litellm` service in docker-compose.yml).
+# Leave ARCHIE_MODEL_GATEWAY_URL unset to talk to api.anthropic.com directly;
+# everything below is then inert. See docker/litellm/ for the gateway config.
+# ARCHIE_MODEL_GATEWAY_URL=http://litellm:4000
+# ARCHIE_MODEL_GATEWAY_TOKEN=sk-archie-gateway
+#
+# Fleet mode: repoint the CLI's model aliases, which is what every query() call
+# site here resolves through. Omit all three to route only agents whose own
+# model names a non-Anthropic provider (e.g. PM stays on Claude).
+# ARCHIE_MODEL_GATEWAY_ALIAS_OPUS=openai/gpt-5.6-sol
+# ARCHIE_MODEL_GATEWAY_ALIAS_SONNET=openai/gpt-5.6-terra
+# ARCHIE_MODEL_GATEWAY_ALIAS_HAIKU=openai/gpt-5.6-luna
+#
+# The CLI does not know a gateway model's limits: it assumes 200K context and
+# caps output at 32000. Declare the upstream's real numbers (a bare integer, or
+# `model=tokens,model=tokens` for mixed tiers). Query the gateway's /model/info
+# for them.
+# ARCHIE_MODEL_GATEWAY_CONTEXT_TOKENS=922000
+# ARCHIE_MODEL_GATEWAY_MAX_OUTPUT_TOKENS=128000
+#
+# Provider key the gateway forwards with, plus the client key it accepts.
+# OPENAI_API_KEY=sk-proj-...
+# LITELLM_MASTER_KEY=sk-archie-gateway
+
 # Working directory (all state lives here: plugins, repos, sessions)
 # Default: ./workdir
 # ARCHIE_WORKDIR=./workdir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,46 @@
 #
 # ngrok (in separate terminal):
 #   ngrok http 3000
-#   Then update Slack app URL to: https://xxxx.ngrok.io/slack/events
+#   Then update Slack app Request URL to: https://xxxx.ngrok.io/webhooks/slack
+#   (the runtime logs the live path at boot: "Slack webhook: POST /webhooks/slack")
 
 services:
+  # Model gateway: speaks the Anthropic Messages API and translates to whichever
+  # upstream serves the requested model, so agents can run on non-Claude models
+  # with no change to the spawned CLI. Inert unless ARCHIE_MODEL_GATEWAY_URL is
+  # set — archie talks to api.anthropic.com directly when it is unset.
+  #
+  # Reachable from archie as http://litellm:4000. Do NOT use
+  # host.docker.internal: measured unreachable from a container on this host.
+  #
+  # Pinned deliberately: the streaming hook in docker/litellm relies on
+  # /v1/messages reaching async_post_call_streaming_iterator_hook as raw SSE.
+  # Re-run a live task after changing this tag.
+  litellm:
+    # Never starts unless the profile is active, so a plain `docker compose up`
+    # runs archie alone and this is inert for anyone not experimenting. Enable
+    # with COMPOSE_PROFILES=model-gateway in .env (or --profile model-gateway).
+    profiles: ["model-gateway"]
+    # Same image production runs — config and hook baked in, no bind mounts.
+    build:
+      context: ./docker/litellm
+    image: archie-model-gateway:local
+    # The arm64 LiteLLM base crashes on start (SIGILL) on Apple Silicon; the
+    # amd64 one runs fine under emulation and is native on amd64 hosts.
+    platform: linux/amd64
+    restart: unless-stopped
+    # Only the two variables the gateway needs — NOT env_file: .env, which would
+    # hand it every Slack and GitHub secret Archie holds.
+    environment:
+      # Empty defaults, not `:?` — compose interpolates inactive-profile
+      # services too, so a required-variable form would break `up` for
+      # every deployment that is not running the gateway.
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-}
+    # Not published to the host: only archie needs to reach it.
+    expose:
+      - "4000"
+
   archie:
     build:
       context: .

--- a/docker/litellm/Dockerfile
+++ b/docker/litellm/Dockerfile
@@ -1,0 +1,16 @@
+# Self-contained model gateway: the config and the streaming hook are baked in,
+# so production runs this with no bind mounts (the repo checkout does not exist
+# on the VM).
+#
+# Pin to a digest before relying on this in production. `main-stable` moves, and
+# archie_visible_close.py depends on /v1/messages reaching
+# async_post_call_streaming_iterator_hook as raw SSE — re-run a live task after
+# any base bump.
+FROM ghcr.io/berriai/litellm:main-stable
+
+COPY config.yaml /app/config.yaml
+COPY archie_visible_close.py /app/archie_visible_close.py
+
+# LiteLLM honours PORT, which would collide with archie's when both read the
+# same env file, so the port is fixed here.
+CMD ["--config", "/app/config.yaml", "--port", "4000"]

--- a/docker/litellm/archie_visible_close.py
+++ b/docker/litellm/archie_visible_close.py
@@ -1,0 +1,104 @@
+"""Ensures every /v1/messages turn ends with non-empty assistant text.
+
+Claude Code re-prompts any turn it judges produced no visible output. GPT-5.6
+ends turns emitting an empty text block, which triggers that nudge and makes a
+coordinator agent re-post its answer. Injecting is required: the check tests for
+the presence of visible text, so deleting the empty block fixes nothing.
+
+Safe for Archie because user-facing output goes through MCP tools, never the
+assistant text block, so the injected line never reaches Slack.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncGenerator
+
+from litellm.integrations.custom_logger import CustomLogger
+
+VISIBLE_CLOSE_TEXT = "Done."
+
+
+def _sse(event: str, payload: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(payload, separators=(',', ':'))}\n\n"
+
+
+def _closing_text_frames(index: int) -> str:
+    return (
+        _sse("content_block_start", {"type": "content_block_start", "index": index,
+                                     "content_block": {"type": "text", "text": ""}})
+        + _sse("content_block_delta", {"type": "content_block_delta", "index": index,
+                                       "delta": {"type": "text_delta", "text": VISIBLE_CLOSE_TEXT}})
+        + _sse("content_block_stop", {"type": "content_block_stop", "index": index})
+    )
+
+
+class ArchieVisibleClose(CustomLogger):
+    async def async_post_call_streaming_iterator_hook(
+        self,
+        user_api_key_dict: Any,
+        response: Any,
+        request_data: dict,
+    ) -> AsyncGenerator[Any, None]:
+        saw_visible_text = False
+        max_index = -1
+        injected = False
+        emit_bytes = False
+
+        # Strict pass-through: chunks are yielded as they arrive and frames only
+        # appended. Buffering to assemble the stream would stall the client and
+        # trip Claude Code's ~300s silence watchdog during thinking pauses.
+        async for chunk in response:
+            if not isinstance(chunk, (str, bytes)):
+                yield chunk
+                continue
+
+            if isinstance(chunk, bytes):
+                emit_bytes = True
+                text = chunk.decode("utf-8", errors="replace")
+            else:
+                text = chunk
+
+            has_message_delta = False
+
+            for line in text.split("\n"):
+                line = line.strip()
+                if not line.startswith("data:"):
+                    continue
+                body = line[len("data:"):].strip()
+                if not body or body == "[DONE]":
+                    continue
+                try:
+                    event = json.loads(body)
+                except ValueError:
+                    # Frame split across chunks; worst case we append a
+                    # redundant "Done.", which is inert.
+                    continue
+                if not isinstance(event, dict):
+                    continue
+
+                etype = event.get("type")
+                idx = event.get("index")
+                if isinstance(idx, int):
+                    max_index = max(max_index, idx)
+
+                if etype == "content_block_start":
+                    block = event.get("content_block") or {}
+                    if block.get("type") == "text" and (block.get("text") or "").strip():
+                        saw_visible_text = True
+                elif etype == "content_block_delta":
+                    delta = event.get("delta") or {}
+                    if delta.get("type") == "text_delta" and (delta.get("text") or "").strip():
+                        saw_visible_text = True
+                elif etype == "message_delta":
+                    has_message_delta = True
+
+            if has_message_delta and not saw_visible_text and not injected:
+                injected = True
+                frames = _closing_text_frames(max_index + 1)
+                yield frames.encode("utf-8") if emit_bytes else frames
+
+            yield chunk
+
+
+instance = ArchieVisibleClose()

--- a/docker/litellm/config.yaml
+++ b/docker/litellm/config.yaml
@@ -1,0 +1,21 @@
+# LiteLLM model gateway for Archie. Models keep their real ids so Archie's
+# records name the model that answered.
+model_list:
+  - model_name: openai/gpt-5.6-sol
+    litellm_params:
+      model: openai/gpt-5.6-sol
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: openai/gpt-5.6-terra
+    litellm_params:
+      model: openai/gpt-5.6-terra
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: openai/gpt-5.6-luna
+    litellm_params:
+      model: openai/gpt-5.6-luna
+      api_key: os.environ/OPENAI_API_KEY
+
+litellm_settings:
+  # Claude Code sends output_config, context_management, adaptive thinking and
+  # beta tool-schema fields; without this they surface as hard 400s.
+  drop_params: true
+  callbacks: ["archie_visible_close.instance"]

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -129,6 +129,67 @@ The container runs as user `archie` (non-root). The Claude Agent SDK's `bypassPe
 
 On restart, the application automatically recovers in-progress tasks via `recoverActiveTasks()` in `src/tasks/recovery.ts`.
 
+## Model Gateway (optional, off by default)
+
+Agents can run on non-Anthropic models through a self-hosted, Anthropic-format gateway (LiteLLM). The whole feature is gated on `ARCHIE_MODEL_GATEWAY_URL`: unset, `buildModelGatewayEnv()` returns nothing, every `query()` call site is unchanged, and agents talk to `api.anthropic.com` exactly as before. Nothing in `Dockerfile.prod` references the gateway.
+
+### Enabling it
+
+Add to `/etc/archie/archie.env`:
+
+```bash
+ARCHIE_MODEL_GATEWAY_URL=http://litellm:4000
+ARCHIE_MODEL_GATEWAY_TOKEN=<gateway client key>
+ARCHIE_MODEL_GATEWAY_ALIAS_OPUS=openai/gpt-5.6-sol
+ARCHIE_MODEL_GATEWAY_ALIAS_SONNET=openai/gpt-5.6-terra
+ARCHIE_MODEL_GATEWAY_ALIAS_HAIKU=openai/gpt-5.6-luna
+ARCHIE_MODEL_GATEWAY_CONTEXT_TOKENS=922000
+ARCHIE_MODEL_GATEWAY_MAX_OUTPUT_TOKENS=128000
+```
+
+Setting all three `ALIAS_*` variables routes every agent. Omit them to route only agents whose own model names a non-Anthropic provider, leaving the PM on Claude.
+
+The CLI does not know a gateway model's limits — it assumes 200K context and caps output at 32000. Declare the upstream's real numbers (a bare integer, or `model=tokens,model=tokens` for mixed tiers); the gateway's `GET /model/info` reports them.
+
+**Disabling:** remove `ARCHIE_MODEL_GATEWAY_URL` and restart Archie. It takes effect on the next agent spawn; the gateway container can keep running, Archie simply ignores it.
+
+### Running the gateway container
+
+Build and publish the image (it bakes in the config and the streaming hook, so no bind mounts are needed):
+
+```bash
+docker build -t <registry>/archie-model-gateway:<tag> docker/litellm
+```
+
+The default Docker bridge has **no DNS between containers**, so `http://litellm:4000` will not resolve with two plain `docker run` containers. Pick one:
+
+1. **User-defined network** (preferred). `docker network create archie`, then add `--network archie --network-alias litellm` to the gateway and `--network archie` to Archie's `ExecStart`. Requires editing Archie's unit.
+2. **Share Archie's network namespace** (no change to Archie's unit). Run the gateway with `--network container:archie-app` and set `ARCHIE_MODEL_GATEWAY_URL=http://127.0.0.1:4000`. The gateway must start after Archie and dies with it, so add `After=`/`BindsTo=` on Archie's unit.
+3. **Off-box gateway.** Point the URL at another host; no topology change at all.
+
+Gateway unit for option 1:
+
+```ini
+[Service]
+Type=simple
+ExecStart=/usr/bin/docker run --name archie-model-gateway \
+  --network archie --network-alias litellm \
+  -e OPENAI_API_KEY=<provider key> \
+  -e LITELLM_MASTER_KEY=<gateway client key, matches ARCHIE_MODEL_GATEWAY_TOKEN> \
+  <registry>/archie-model-gateway:<tag>
+Restart=always
+RestartSec=10
+```
+
+Give it only these two variables. It does not need — and must not be handed — Archie's env file, which holds the Slack tokens, GitHub App key, and MCP credentials.
+
+### Caveats
+
+- **Cost is not reported for gateway-routed turns.** The SDK prices any model it does not recognise with a first-party Claude rate card, so its figure is wrong rather than missing (measured: an OpenAI model came back priced at Opus 5's rates). Those turns record `cost_unavailable` and are excluded from cost totals; token counts are unaffected.
+- **Version coupling.** The streaming hook in `docker/litellm/` depends on `/v1/messages` reaching LiteLLM's `async_post_call_streaming_iterator_hook` as raw SSE. Pin the base image and re-run a live task after any bump.
+- **`unrecognized_model` diagnostic** appears once per spawn because model ids keep their real provider-prefixed names. That is log noise, not a failure — the alternative (serving the upstream under Claude's ids) hides which model actually answered.
+- **Local development** uses the `model-gateway` Compose profile, so `npm run docker:dev` does not start the gateway. Note a plain `docker compose down` does **not** stop a profile-gated container; use `COMPOSE_PROFILES=model-gateway docker compose down`.
+
 ## Monitoring
 
 ### Health Check

--- a/src/agents/__tests__/model-gateway.test.ts
+++ b/src/agents/__tests__/model-gateway.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for per-agent model-gateway routing: which models route to a
+ * self-hosted Anthropic-format gateway, and the env that points one agent at
+ * it. The `ANTHROPIC_API_KEY: ''` assertion is the load-bearing one — the CLI
+ * reads that variable before ANTHROPIC_AUTH_TOKEN, so a non-empty value sends
+ * the real Anthropic key to the gateway and never sends the gateway credential.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isGatewayModel, buildModelGatewayEnv, isGatewayModelWithoutGateway } from '../model-gateway.js';
+
+const GATEWAY = { ARCHIE_MODEL_GATEWAY_URL: 'http://bifrost:8080/anthropic' };
+
+describe('isGatewayModel', () => {
+  it('routes non-Anthropic provider prefixes to the gateway', () => {
+    expect(isGatewayModel('openai/gpt-5.3-codex')).toBe(true);
+    expect(isGatewayModel('vertex/gemini-3.1-pro')).toBe(true);
+    expect(isGatewayModel('bedrock/meta.llama3-70b')).toBe(true);
+  });
+
+  it('keeps first-party Anthropic models on the direct path', () => {
+    // Bare aliases — what every one of our query() call sites actually sends.
+    expect(isGatewayModel('sonnet')).toBe(false);
+    expect(isGatewayModel('opus')).toBe(false);
+    expect(isGatewayModel('haiku')).toBe(false);
+    // Concrete ids, with and without the anthropic/ prefix.
+    expect(isGatewayModel('claude-opus-5')).toBe(false);
+    expect(isGatewayModel('anthropic/claude-sonnet-5')).toBe(false);
+    expect(isGatewayModel('ANTHROPIC/claude-sonnet-5')).toBe(false);
+  });
+
+  it('ignores the 1M-context marker when deciding the route', () => {
+    // `sonnet[1m]` is the default for every non-PM agent, so this must not
+    // suddenly become a gateway route.
+    expect(isGatewayModel('sonnet[1m]')).toBe(false);
+    expect(isGatewayModel('anthropic/claude-sonnet-5[1m]')).toBe(false);
+    expect(isGatewayModel('openai/gpt-5.3-codex[1m]')).toBe(true);
+  });
+});
+
+describe('buildModelGatewayEnv', () => {
+  it('is a no-op for a Claude agent even when a gateway is configured', () => {
+    expect(buildModelGatewayEnv('sonnet[1m]', GATEWAY)).toEqual({});
+    expect(buildModelGatewayEnv('claude-opus-5', GATEWAY)).toEqual({});
+  });
+
+  it('is a no-op for a gateway model when no gateway is configured', () => {
+    expect(buildModelGatewayEnv('openai/gpt-5.3-codex', {})).toEqual({});
+  });
+
+  it('empties ANTHROPIC_API_KEY so the gateway credential is the one that is sent', () => {
+    const env = buildModelGatewayEnv('openai/gpt-5.3-codex', {
+      ...GATEWAY,
+      ARCHIE_MODEL_GATEWAY_TOKEN: 'gw-token',
+    });
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://bifrost:8080/anthropic');
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('gw-token');
+    // Present AND empty: merely omitting it would leave the caller's real key in place.
+    expect(env).toHaveProperty('ANTHROPIC_API_KEY');
+    expect(env.ANTHROPIC_API_KEY).toBe('');
+  });
+
+  it('omits the auth token when none is configured (gateways may be unauthenticated)', () => {
+    const env = buildModelGatewayEnv('openai/gpt-5.3-codex', GATEWAY);
+    expect(env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
+    expect(env.ANTHROPIC_API_KEY).toBe('');
+  });
+
+  it('declares the real context window and output ceiling when configured', () => {
+    // Unset, the CLI assumes 200K context and caps output at 32000 for an
+    // unrecognised id — a quarter of what a GPT-5.6 tier allows.
+    const env = buildModelGatewayEnv('openai/gpt-5.3-codex', {
+      ...GATEWAY,
+      ARCHIE_MODEL_GATEWAY_CONTEXT_TOKENS: '400000',
+      ARCHIE_MODEL_GATEWAY_MAX_OUTPUT_TOKENS: '128000',
+    });
+    expect(env.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe('400000');
+    expect(env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe('128000');
+    const bare = buildModelGatewayEnv('openai/gpt-5.3-codex', GATEWAY);
+    expect(bare).not.toHaveProperty('CLAUDE_CODE_MAX_CONTEXT_TOKENS');
+    expect(bare).not.toHaveProperty('CLAUDE_CODE_MAX_OUTPUT_TOKENS');
+  });
+
+  it('keys limits off the alias TARGET in fleet mode, not the bare alias', () => {
+    // Call sites pass `sonnet[1m]`, which carries no limits of its own; the
+    // per-model map is written against the model the alias now points at.
+    const env = buildModelGatewayEnv('sonnet[1m]', {
+      ...GATEWAY,
+      ARCHIE_MODEL_GATEWAY_ALIAS_SONNET: 'openai/gpt-5.6-terra',
+      ARCHIE_MODEL_GATEWAY_CONTEXT_TOKENS: 'openai/gpt-5.6-terra=922000,openai/gpt-5.3-codex=400000',
+      ARCHIE_MODEL_GATEWAY_MAX_OUTPUT_TOKENS: 'openai/gpt-5.6-terra=128000',
+    });
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('openai/gpt-5.6-terra');
+    expect(env.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe('922000');
+    expect(env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe('128000');
+  });
+
+  it('routes every agent in fleet mode, including plain Claude aliases', () => {
+    const env = buildModelGatewayEnv('opus', {
+      ...GATEWAY,
+      ARCHIE_MODEL_GATEWAY_ALIAS_OPUS: 'openai/gpt-5.6-sol',
+    });
+    expect(env.ANTHROPIC_BASE_URL).toBe(GATEWAY.ARCHIE_MODEL_GATEWAY_URL);
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('openai/gpt-5.6-sol');
+  });
+});
+
+describe('isGatewayModelWithoutGateway', () => {
+  it('flags the misconfiguration that would otherwise fail opaquely', () => {
+    expect(isGatewayModelWithoutGateway('openai/gpt-5.3-codex', {})).toBe(true);
+    expect(isGatewayModelWithoutGateway('openai/gpt-5.3-codex', GATEWAY)).toBe(false);
+    expect(isGatewayModelWithoutGateway('sonnet[1m]', {})).toBe(false);
+  });
+});

--- a/src/agents/__tests__/task-usage.test.ts
+++ b/src/agents/__tests__/task-usage.test.ts
@@ -443,3 +443,86 @@ describe('SECURITY: taskId path-injection guard', () => {
     expect(report.cost).toBeUndefined();
   });
 });
+
+// =============================================================================
+// Gateway-routed turns — cost is EXCLUDED, never estimated and never $0.00.
+//
+// The SDK prices a model it does not recognise with a first-party Claude rate
+// card: measured live, an OpenAI model behind an Anthropic-format gateway came
+// back priced at Opus 5's rates (exact to the cent-fraction on two different
+// models, ~18x over list for gpt-4o-mini). spawn.ts therefore writes
+// `cost_unavailable: true` instead of that figure, and these tests pin the
+// read-side contract — including that "excluded" never degrades into "free".
+// =============================================================================
+
+describe('gateway-routed cost exclusion', () => {
+  it('reports cost unavailable — not $0.00 — when every turn ran on a gateway model', async () => {
+    const taskId = 'task-20260101-1200-gw1';
+    await writeTranscript(projectsDir(taskId, 'backend'), 'sess-1.jsonl', [
+      assistantLine({ id: 'g1', usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } }),
+    ]);
+    await writeUsage(taskId, [
+      { query_nonce: 'G1', agentKey: 'backend', cost_unavailable: true },
+      { query_nonce: 'G2', agentKey: 'backend', cost_unavailable: true },
+    ]);
+
+    const report = await aggregateTaskUsage(taskId);
+    // The whole point: absent, so it renders "unavailable". A grand of 0 here
+    // would assert the task was free.
+    expect(report.cost).toBeUndefined();
+    expect(report.agents.find((a) => a.agentKey === 'backend')?.cost).toBeUndefined();
+    expect(report.costUnmeasuredTurns).toBe(2);
+    // Tokens are unaffected — only the dollar conversion is untrustworthy.
+    expect(report.grand.input_tokens).toBe(10);
+
+    const text = formatTaskUsageReport(report);
+    expect(text).toContain('Cost: unavailable');
+    expect(text).not.toContain('$0.00');
+    expect(text).toContain('gateway model the SDK cannot price');
+  });
+
+  it('a fabricated figure on a gateway record is ignored even if one is present', async () => {
+    const taskId = 'task-20260101-1200-gw2';
+    await writeTranscript(projectsDir(taskId, 'backend'), 'sess-1.jsonl', [
+      assistantLine({ id: 'g2', usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } }),
+    ]);
+    // Defensive: an older record, or one written before the flag existed, may
+    // still carry the bogus number. The flag must win over the value.
+    await writeUsage(taskId, [
+      { query_nonce: 'G1', agentKey: 'backend', cost_unavailable: true, total_cost_usd: 0.19408 },
+    ]);
+
+    const report = await aggregateTaskUsage(taskId);
+    expect(report.cost).toBeUndefined();
+    expect(report.costUnmeasuredTurns).toBe(1);
+  });
+
+  it('a mixed task still reports the measurable agent, excluding only the gateway one', async () => {
+    const taskId = 'task-20260101-1200-gw3';
+    await writeTranscript(projectsDir(taskId, 'pm'), 'sess-1.jsonl', [
+      assistantLine({ id: 'm1', usage: { input_tokens: 4, output_tokens: 2, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } }),
+    ]);
+    await writeTranscript(projectsDir(taskId, 'backend'), 'sess-1.jsonl', [
+      assistantLine({ id: 'm2', usage: { input_tokens: 6, output_tokens: 3, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } }),
+    ]);
+    // PM on Claude (measured), backend on a gateway model (excluded) — the
+    // per-agent routing case, which is the one we actually intend to run.
+    await writeUsage(taskId, [
+      { query_nonce: 'P1', agentKey: 'pm', total_cost_usd: 0.30 },
+      { query_nonce: 'G1', agentKey: 'backend', cost_unavailable: true },
+    ]);
+
+    const report = await aggregateTaskUsage(taskId);
+    expect(report.cost?.grand).toBeCloseTo(0.30, 10);
+    // Counts only measurable records, so the gap disclosure stays honest.
+    expect(report.cost?.costRecordedTurns).toBe(1);
+    expect(report.costUnmeasuredTurns).toBe(1);
+    expect(report.agents.find((a) => a.agentKey === 'pm')?.cost).toBeCloseTo(0.30, 10);
+    expect(report.agents.find((a) => a.agentKey === 'backend')?.cost).toBeUndefined();
+
+    const text = formatTaskUsageReport(report);
+    expect(text).toContain('backend');
+    expect(text).toContain('cost: unavailable');
+    expect(text).toContain('gateway model the SDK cannot price');
+  });
+});

--- a/src/agents/model-gateway.ts
+++ b/src/agents/model-gateway.ts
@@ -1,0 +1,100 @@
+/**
+ * Routes agents through a self-hosted Anthropic-format LLM gateway (LiteLLM).
+ *
+ * Gateway models keep honest provider-prefixed ids (`openai/gpt-5.6-sol`), so
+ * everything Archie records names the model that answered. The CLI then treats
+ * them as unrecognised, which costs only a log line: effort, thinking and
+ * context_management are sent identically, while the context window and output
+ * ceiling are declared explicitly below.
+ *
+ * Fleet mode (any ALIAS_* set) routes every agent by repointing the CLI's alias
+ * table. Otherwise only models with a non-Anthropic prefix route, leaving the
+ * PM on Claude.
+ */
+
+const ALIASES = [
+  ['opus', 'ARCHIE_MODEL_GATEWAY_ALIAS_OPUS', 'ANTHROPIC_DEFAULT_OPUS_MODEL'],
+  ['sonnet', 'ARCHIE_MODEL_GATEWAY_ALIAS_SONNET', 'ANTHROPIC_DEFAULT_SONNET_MODEL'],
+  ['haiku', 'ARCHIE_MODEL_GATEWAY_ALIAS_HAIKU', 'ANTHROPIC_DEFAULT_HAIKU_MODEL'],
+] as const;
+
+const stripMarker = (model: string): string => model.replace(/\[1m\]\s*$/i, '').trim();
+
+export function isGatewayModel(model: string): boolean {
+  const base = stripMarker(model);
+  const slash = base.indexOf('/');
+  if (slash <= 0) return false;
+  return base.slice(0, slash).toLowerCase() !== 'anthropic';
+}
+
+/** Bare integer, or a `model=tokens` map for mixed tiers. */
+function tokenLimit(spec: string | undefined, model: string): string | undefined {
+  const trimmed = spec?.trim();
+  if (!trimmed) return undefined;
+  if (/^\d+$/.test(trimmed)) return trimmed;
+
+  const wanted = stripMarker(model);
+  for (const pair of trimmed.split(',')) {
+    const eq = pair.indexOf('=');
+    if (eq <= 0) continue;
+    if (pair.slice(0, eq).trim() !== wanted) continue;
+    const value = pair.slice(eq + 1).trim();
+    if (/^\d+$/.test(value)) return value;
+  }
+  return undefined;
+}
+
+function aliasOverrides(env: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [, ourVar, cliVar] of ALIASES) {
+    const value = env[ourVar]?.trim();
+    if (value) out[cliVar] = value;
+  }
+  return out;
+}
+
+/** In fleet mode the agent's string is a bare alias, so limits key off its target. */
+function effectiveModel(model: string, aliases: Record<string, string>): string {
+  const base = stripMarker(model).toLowerCase();
+  for (const [alias, , cliVar] of ALIASES) {
+    if (base === alias && aliases[cliVar]) return aliases[cliVar];
+  }
+  return model;
+}
+
+export function buildModelGatewayEnv(
+  model: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const url = env.ARCHIE_MODEL_GATEWAY_URL?.trim();
+  if (!url) return {};
+
+  const aliases = aliasOverrides(env);
+  const fleetMode = Object.keys(aliases).length > 0;
+  if (!fleetMode && !isGatewayModel(model)) return {};
+
+  const target = fleetMode ? effectiveModel(model, aliases) : model;
+  const token = env.ARCHIE_MODEL_GATEWAY_TOKEN?.trim();
+  const contextTokens = tokenLimit(env.ARCHIE_MODEL_GATEWAY_CONTEXT_TOKENS, target);
+  const maxOutputTokens = tokenLimit(env.ARCHIE_MODEL_GATEWAY_MAX_OUTPUT_TOKENS, target);
+
+  return {
+    ANTHROPIC_BASE_URL: url,
+    // Must be emptied, not omitted: the CLI reads it before ANTHROPIC_AUTH_TOKEN,
+    // so a non-empty value sends the real Anthropic key to the gateway.
+    ANTHROPIC_API_KEY: '',
+    ...(token ? { ANTHROPIC_AUTH_TOKEN: token } : {}),
+    ...aliases,
+    ...(contextTokens ? { CLAUDE_CODE_MAX_CONTEXT_TOKENS: contextTokens } : {}),
+    // Verify from the request's `max_tokens`; modelUsage.maxOutputTokens keeps
+    // reporting the CLI's table value even when this override is in force.
+    ...(maxOutputTokens ? { CLAUDE_CODE_MAX_OUTPUT_TOKENS: maxOutputTokens } : {}),
+  };
+}
+
+export function isGatewayModelWithoutGateway(
+  model: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isGatewayModel(model) && !env.ARCHIE_MODEL_GATEWAY_URL?.trim();
+}

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -21,6 +21,7 @@ import { isRepoAgent, isPmAgent } from '../types/agent.js';
 import { buildCommitAuthorEnv } from './commit-author.js';
 import { coreSkillPaths } from './core-skills.js';
 import { resolveAgentModel, resolveAgentEffort } from './model-label.js';
+import { buildModelGatewayEnv, isGatewayModelWithoutGateway } from './model-gateway.js';
 import {
   createBaseAgentMcpServer,
   createRepoToolsMcpServer,
@@ -274,6 +275,20 @@ export async function spawnAgent(agent: Agent, task: Task): Promise<void> {
   const model = resolveAgentModel(def, maxMode);
   const effort = resolveAgentEffort(def, maxMode);
   const tools = def.tools;
+  // Agents on a non-Anthropic model talk to a self-hosted Anthropic-format
+  // gateway instead of api.anthropic.com; every Claude agent is untouched (the
+  // spread below is empty for them). See model-gateway.ts.
+  const modelGatewayEnv = buildModelGatewayEnv(model);
+  // Non-empty env == this agent actually routes through the gateway. Drives the
+  // cost-recording decision at the `result` event below.
+  const routesThroughGateway = Object.keys(modelGatewayEnv).length > 0;
+  if (isGatewayModelWithoutGateway(model)) {
+    logger.warn(
+      def.id,
+      `model '${model}' names a non-Anthropic provider but ARCHIE_MODEL_GATEWAY_URL is unset — ` +
+        'the request will go to the Anthropic API and fail on an unknown model',
+    );
+  }
 
   const pluginPaths = def.pluginPath ? [def.pluginPath] : [];
   const pluginReadPaths = [...pluginPaths, ...(def.pluginDataPath ? [def.pluginDataPath] : [])];
@@ -735,6 +750,10 @@ Shared folder: ${sharedPath} [READ-ONLY]
       // through the in-process logging proxy so we can measure its real context
       // breakdown. No-op (key absent) when the probe is disabled or not listening.
       ...(getProbeBaseUrl() ? { ANTHROPIC_BASE_URL: getProbeBaseUrl()! } : {}),
+      // Model gateway (see model-gateway.ts). Spread AFTER the probe so an
+      // explicitly configured gateway wins over the debug proxy; empty for
+      // every agent on a Claude model.
+      ...modelGatewayEnv,
       ...(useClaudeDirs ? {
         CLAUDE_CONFIG_DIR: claudeConfigDir,
         CLAUDE_CODE_TMPDIR: claudeTmpDir,
@@ -956,7 +975,14 @@ Shared folder: ${sharedPath} [READ-ONLY]
                 session_id: event.session_id,
                 subtype: event.subtype,
                 num_turns: event.num_turns,
-                total_cost_usd: event.total_cost_usd,
+                // A gateway-routed agent's cost is NOT recorded: the SDK prices
+                // an unrecognised model with a first-party Claude rate card, so
+                // `total_cost_usd` arrives confidently wrong rather than absent.
+                // Persisting it would poison the cost column that task-usage.ts
+                // documents as the SDK's own figure. See model-gateway.ts.
+                ...(routesThroughGateway
+                  ? { cost_unavailable: true as const }
+                  : { total_cost_usd: event.total_cost_usd }),
                 modelUsage: (event as any).modelUsage,
                 usage: (event as any).usage,
               });

--- a/src/agents/task-usage.ts
+++ b/src/agents/task-usage.ts
@@ -73,12 +73,23 @@ export interface TaskUsageReport {
   /** Distinct main-agent `end_turn` turns (drives the cost gap disclosure). */
   transcriptTurns: number;
   agents: AgentUsage[];
-  /** SDK-reported cost, present only when usage.jsonl exists. */
+  /**
+   * SDK-reported cost, present only when at least one turn was actually
+   * measurable. Absent when usage.jsonl is missing AND when every record in it
+   * is unmeasurable (a task whose only agent ran on a gateway model) — a
+   * `grand: 0` there would assert the task was free.
+   */
   cost?: {
     grand: number;
-    /** Total usage.jsonl record count. */
+    /** Measurable usage.jsonl record count (excludes gateway-routed turns). */
     costRecordedTurns: number;
   };
+  /**
+   * Turns deliberately excluded from cost because their model cannot be priced
+   * (gateway-routed). Distinguishes "we declined to guess" from "never logged"
+   * in the gap disclosure. Optional so existing report fixtures stay valid.
+   */
+  costUnmeasuredTurns?: number;
 }
 
 /** Minimal shape of the fields we read from a usage.jsonl record. */
@@ -86,6 +97,13 @@ interface UsageRecordLite {
   query_nonce?: string;
   agentKey?: string;
   total_cost_usd?: number;
+  /**
+   * Written by spawn.ts for a gateway-routed turn, whose SDK cost figure is
+   * fabricated from a first-party rate card. Such records are excluded here
+   * rather than reduced, so they can never contribute a number — nor a `0`,
+   * which would read as "cost nothing".
+   */
+  cost_unavailable?: boolean;
 }
 
 /** Reduces all usage records sharing one query_nonce to a single cost. */
@@ -259,7 +277,15 @@ async function collectTokens(taskId: string): Promise<{
 async function collectCost(
   taskId: string,
   reduce: NonceReducer,
-): Promise<{ grand: number; perAgent: Map<string, number>; costRecordedTurns: number } | undefined> {
+): Promise<
+  | {
+      grand: number;
+      perAgent: Map<string, number>;
+      costRecordedTurns: number;
+      costUnmeasuredTurns: number;
+    }
+  | undefined
+> {
   // (a) INLINE allowlist barrier: reject an unsafe taskId before a path is
   // built — an unsafe id reports no cost (undefined), like a missing file.
   if (!/^task-\d{8}-\d{4}-[a-z0-9]+$/.test(taskId)) return undefined;
@@ -290,11 +316,17 @@ async function collectCost(
     // File vanished/unreadable after the existsSync check — treat as empty.
   }
 
+  // Drop unmeasurable records BEFORE grouping. Reducing them would yield 0 for
+  // their nonce and register the agent in `perAgent` with a $0.00 cost —
+  // asserting "free" for exactly the turns whose price we refuse to guess.
+  const unmeasured = records.filter((r) => r.cost_unavailable === true).length;
+  const measured = records.filter((r) => r.cost_unavailable !== true);
+
   // Group by query_nonce; a record missing one is its own singleton group
   // (defensive only — this greenfield file always carries a nonce).
   const groups = new Map<string, UsageRecordLite[]>();
   let singleton = 0;
-  for (const r of records) {
+  for (const r of measured) {
     const nonce = typeof r.query_nonce === 'string' && r.query_nonce
       ? r.query_nonce
       : `__no-nonce-${singleton++}`;
@@ -314,7 +346,7 @@ async function collectCost(
     perAgent.set(agentKey, (perAgent.get(agentKey) ?? 0) + cost);
   }
 
-  return { grand, perAgent, costRecordedTurns: records.length };
+  return { grand, perAgent, costRecordedTurns: measured.length, costUnmeasuredTurns: unmeasured };
 }
 
 /**
@@ -356,7 +388,14 @@ export async function aggregateTaskUsage(
     grand,
     transcriptTurns,
     agents,
-    cost: cost ? { grand: cost.grand, costRecordedTurns: cost.costRecordedTurns } : undefined,
+    // `costRecordedTurns > 0` and not merely `cost` — usage.jsonl can exist yet
+    // hold nothing measurable, and reporting `$0.0000` there would be the same
+    // false "free" assertion the per-agent branch above guards against.
+    cost:
+      cost && cost.costRecordedTurns > 0
+        ? { grand: cost.grand, costRecordedTurns: cost.costRecordedTurns }
+        : undefined,
+    costUnmeasuredTurns: cost?.costUnmeasuredTurns ?? 0,
   };
 }
 
@@ -417,11 +456,18 @@ export function formatTaskUsageReport(report: TaskUsageReport): string {
   }
 
   const recordedTurns = report.cost?.costRecordedTurns ?? 0;
+  const unmeasured = report.costUnmeasuredTurns ?? 0;
   if (recordedTurns < report.transcriptTurns) {
     lines.push('');
     lines.push(
       `Cost covers ${recordedTurns} of ${report.transcriptTurns} turns; ` +
         'the rest predate cost logging or ended without a result event — excluded.',
+    );
+  }
+  if (unmeasured > 0) {
+    lines.push(
+      `${unmeasured} turn(s) ran on a gateway model the SDK cannot price, so their ` +
+        'cost is excluded rather than estimated — token counts above still include them.',
     );
   }
 

--- a/src/connectors/slack/pin-summary.ts
+++ b/src/connectors/slack/pin-summary.ts
@@ -8,6 +8,7 @@ import { createHash } from 'node:crypto';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { z, toJSONSchema } from 'zod';
 import { logger } from '../../system/logger.js';
+import { buildModelGatewayEnv } from '../../agents/model-gateway.js';
 
 /** Pins at or below this length are indexed verbatim — no model call. */
 export const VERBATIM_MAX = 200;
@@ -117,6 +118,10 @@ Respond with JSON only.`;
           ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
           ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
           PATH: process.env.PATH,
+          // Model gateway: this call site passes a bare alias, so a global
+          // (full-takeover) gateway swap reaches it through the CLI's alias
+          // table. No-op unless ARCHIE_MODEL_GATEWAY_URL is set.
+          ...buildModelGatewayEnv('haiku'),
         },
         tools: [],
         maxTurns: 2,

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -86,6 +86,10 @@ Respond with JSON only.`;
           ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
           ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
           PATH: process.env.PATH,
+          // Model gateway: this call site passes a bare alias, so a global
+          // (full-takeover) gateway swap reaches it through the CLI's alias
+          // table. No-op unless ARCHIE_MODEL_GATEWAY_URL is set.
+          ...buildModelGatewayEnv('haiku'),
         },
         tools: [],
         maxTurns: 2,
@@ -203,6 +207,7 @@ async function callPerplexity(preset: string, input: string): Promise<Perplexity
 // ============================================================================
 
 import { BedrockRuntimeClient, ApplyGuardrailCommand } from '@aws-sdk/client-bedrock-runtime';
+import { buildModelGatewayEnv } from '../agents/model-gateway.js';
 
 let bedrockClient: BedrockRuntimeClient | null = null;
 let guardrailWarningLogged = false;

--- a/src/memory/extractor.ts
+++ b/src/memory/extractor.ts
@@ -9,6 +9,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk';
 import { loadPrompt } from '../utils/prompt-loader.js';
 import { logger } from '../system/logger.js';
 import type { ExtractionResult, MemoryUpdate, EntityUpdate } from './types.js';
+import { buildModelGatewayEnv } from '../agents/model-gateway.js';
 
 // ============================================================================
 // Types
@@ -246,6 +247,10 @@ export async function runExtraction(
           ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
           ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
           PATH: process.env.PATH,
+          // Model gateway: this call site passes a bare alias, so a global
+          // (full-takeover) gateway swap reaches it through the CLI's alias
+          // table. No-op unless ARCHIE_MODEL_GATEWAY_URL is set.
+          ...buildModelGatewayEnv('sonnet'),
         },
         stderr: (data: string) => {
           logger.debug('memory', `extraction stderr: ${data.trim()}`);

--- a/src/memory/housekeeping.ts
+++ b/src/memory/housekeeping.ts
@@ -32,6 +32,7 @@ import { logger } from '../system/logger.js';
 import { recordHousekeepingNote } from './lifecycle.js';
 import { parseLastTouched as parseLastTouchedFromAnnotations, stripLastTouched as stripLastTouchedFromAnnotations, appendLastTouched as appendLastTouchedFromAnnotations } from './annotations.js';
 import type { EntityRecord } from './types.js';
+import { buildModelGatewayEnv } from '../agents/model-gateway.js';
 
 const TOUCHED_RE = /<!--\s*touched:\s*(\d{4}-\d{2}-\d{2})\s*-->/;
 const TRACE_DISTANCE_THRESHOLD = 0.4;
@@ -275,6 +276,10 @@ async function runHousekeeperAgent(fileContent: string): Promise<string> {
         ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
         ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
         PATH: process.env.PATH,
+        // Model gateway: this call site passes a bare alias, so a global
+        // (full-takeover) gateway swap reaches it through the CLI's alias
+        // table. No-op unless ARCHIE_MODEL_GATEWAY_URL is set.
+        ...buildModelGatewayEnv('sonnet'),
       },
       stderr: (data: string) => {
         logger.debug('memory', `housekeeping stderr: ${data.trim()}`);

--- a/src/system/triage.ts
+++ b/src/system/triage.ts
@@ -15,6 +15,7 @@ import { messageBody } from "../connectors/slack/message-body.js";
 import { SESSIONS_DIR } from "./workdir.js";
 import { processAgentEventForLogging, logger } from "./logger.js";
 import { loadPrompt } from "../utils/prompt-loader.js";
+import { buildModelGatewayEnv } from '../agents/model-gateway.js';
 
 /**
  * Slack triage schema - allows Slack-specific actions
@@ -63,6 +64,10 @@ async function runTriage<T extends z.ZodType>(
         ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
         ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
         PATH: process.env.PATH,
+        // Model gateway: this call site passes a bare alias, so a global
+        // (full-takeover) gateway swap reaches it through the CLI's alias
+        // table. No-op unless ARCHIE_MODEL_GATEWAY_URL is set.
+        ...buildModelGatewayEnv('haiku'),
       },
       allowedTools: ["Glob", "Grep", "Read"],
       outputFormat: {

--- a/src/tasks/persistence.ts
+++ b/src/tasks/persistence.ts
@@ -792,7 +792,20 @@ export interface TaskUsageRecord {
   session_id?: string;
   subtype: string;
   num_turns: number;
-  total_cost_usd: number;
+  /**
+   * Omitted when the SDK's figure cannot be trusted — see `cost_unavailable`.
+   * Absent means "not measured", never "cost nothing".
+   */
+  total_cost_usd?: number;
+  /**
+   * Set when this turn ran on a model the SDK cannot price, so no cost was
+   * recorded. The SDK prices any model it does not recognise with a first-party
+   * Claude rate card (measured: an OpenAI model behind a gateway came back
+   * priced at Opus 5's rates, ~18x over list for gpt-4o-mini), which is a
+   * confidently wrong number rather than a missing one. Read-time aggregation
+   * excludes these records instead of summing a fiction.
+   */
+  cost_unavailable?: true;
   modelUsage: Record<string, unknown>;
   usage: unknown;
 }

--- a/src/tasks/title-generator.ts
+++ b/src/tasks/title-generator.ts
@@ -12,6 +12,7 @@ import { z, toJSONSchema } from 'zod';
 import type { SlackThread } from '../types/index.js';
 import { messageBody, shouldRedact, REDACTION_PLACEHOLDER } from '../connectors/slack/message-body.js';
 import { logger } from '../system/logger.js';
+import { buildModelGatewayEnv } from '../agents/model-gateway.js';
 
 const TitleSchema = z.object({
   title: z.string(),
@@ -102,6 +103,10 @@ Respond with JSON only.`;
           ...(process.env.NODE_USE_SYSTEM_CA ? { NODE_USE_SYSTEM_CA: process.env.NODE_USE_SYSTEM_CA } : {}),
           ...(process.env.NODE_EXTRA_CA_CERTS ? { NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS } : {}),
           PATH: process.env.PATH,
+          // Model gateway: this call site passes a bare alias, so a global
+          // (full-takeover) gateway swap reaches it through the CLI's alias
+          // table. No-op unless ARCHIE_MODEL_GATEWAY_URL is set.
+          ...buildModelGatewayEnv('haiku'),
         },
         tools: [],
         maxTurns: 2,


### PR DESCRIPTION
Adds opt-in support for running agents on non-Anthropic models through a self-hosted, Anthropic-format gateway (LiteLLM). **Off by default and verified inert**; nothing in the production path references it.

## Why this shape

Claude Code speaks the Anthropic Messages API, so a gateway that translates it is the only lever — the CLI ships as a compiled binary, and `ANTHROPIC_BASE_URL` is the documented seam. Three gateways were measured against the same assertion (does a tool-call turn come back with `stop_reason: tool_use`?):

| | works with gpt-5.6 | `stop_reason` | config |
|---|---|---|---|
| **LiteLLM** | yes | correct | declarative, survives restarts |
| Bifrost | yes | **`end_turn`** ([#3638](https://github.com/maximhq/bifrost/issues/3638), open since May) | SQLite store overrides the file |
| claude-code-router | never completes a request | untested | dashboard-driven |

Bifrost's mislabelled `stop_reason` made the PM post the same answer three times in a live Slack thread. claude-code-router forwards `max_tokens` where gpt-5.x requires `max_completion_tokens`, so it never produced a completion. Hence LiteLLM, despite being the heaviest.

## Design decisions worth reviewing

**Honest model ids.** Gateway models keep their real names (`openai/gpt-5.6-sol`), so everything Archie records names the model that answered. Serving the upstream under Claude's own ids would put the CLI on its recognised path, and was measured: `effort`, `thinking` and `context_management` are sent identically either way, and the only real difference — a 32000 output cap — is fixable with an env var. The cost of honesty is one `[claude-code:unrecognized_model]` log line per spawn; the cost of the alternative was not being able to tell which model ran.

**Cost is excluded, not recorded.** The SDK prices an unrecognised model with a first-party Claude rate card, so its figure is wrong rather than absent — exact to the cent-fraction against Opus 5's card on two different models, ~18x over list for gpt-4o-mini. Those turns record `cost_unavailable`. The read side drops them *before* nonce grouping, because reducing them yields `$0.00`, which asserts "free" for exactly the turns whose price we refuse to guess.

**A streaming hook in the gateway.** GPT-5.6 ends turns emitting an empty text block; Claude Code re-prompts any turn it judges produced no visible output, and the PM answers that nudge by re-posting its result. The hook appends a minimal text block when a turn produced none. Injection rather than deletion is required — the check tests for the *presence* of visible text. Safe because user-facing output goes through MCP tools, so the injected line never reaches Slack.

## Verified live

Booted from this branch against a real Slack workspace, driving full PM → specialist tasks:

- **Gateway on:** all three tiers exercised (`sol`/`terra`/`luna`), `max_tokens: 128000` on all 20 captured requests, `contextWindow: 922000`, **0 nudges**, one answer, honest ids throughout.
- **Gateway off** (vars removed): agents ran on `claude-opus-5`, `total_cost_usd = 0.473` recorded normally, `cost_unavailable` absent. Identical to pre-change behaviour.
- Compose gated off: `config` clean and only `archie` starts. Gated on: both services start.
- Gateway container confirmed to see **none** of Archie's Slack/GitHub/MCP secrets.
- 1554 tests pass; `tsc --noEmit` clean.

## Scope of verification

One prompt shape, one task type. **Not exercised:** edit mode, subagents, a large repo change on a non-Claude model, or behaviour near the context limit. Treat this as R&D-ready, not production-proven.

## Known limits

- Cost unavailable for gateway turns. The gateway's `GET /model/info` carries real per-token prices if we want it computed properly later.
- The hook is coupled to LiteLLM's streaming-hook contract; pin the base image and re-run a live task after any bump.
- LiteLLM's arm64 image crashes on Apple Silicon, so compose pins `platform: linux/amd64`.
- The model list lives in `docker/litellm/config.yaml`, so changing models means editing a file rather than an env var.
- Enabling in production needs a network topology choice (the default bridge has no inter-container DNS) — documented, not automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)