### PR TITLE
fix(slack): stop re-asking Slack about mention ids it has rejected

### DIFF
--- a/src/connectors/slack/__tests__/unresolvable-mentions.test.ts
+++ b/src/connectors/slack/__tests__/unresolvable-mentions.test.ts
@@ -1,0 +1,94 @@
+/**
+ * An id Slack rejects must be asked about once, not once per thread read — but a
+ * transient failure must not be cached as permanent.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const slackApi = {
+  auth: { test: vi.fn() },
+  conversations: { info: vi.fn(), replies: vi.fn(), history: vi.fn() },
+  users: { info: vi.fn(), conversations: vi.fn(), list: vi.fn() },
+  usergroups: { list: vi.fn() },
+  pins: { list: vi.fn() },
+};
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn(function (this: unknown) { return slackApi; }),
+}));
+
+const loggerWarn = vi.fn();
+const loggerDebug = vi.fn();
+vi.mock('../../../system/logger.js', () => ({
+  logger: {
+    slack: vi.fn(), warn: loggerWarn, debug: loggerDebug,
+    system: vi.fn(), error: vi.fn(), plain: vi.fn(),
+  },
+}));
+
+/** Shape of a Slack Web API error: the code lives on `error.data.error`. */
+function slackError(code: string): Error & { data: { error: string } } {
+  return Object.assign(new Error(code), { data: { error: code } });
+}
+
+type ClientModule = typeof import('../client.js');
+let client: ClientModule;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules(); // negative cache starts empty
+
+  slackApi.auth.test.mockResolvedValue({
+    user_id: 'UBOT', bot_id: 'BBOT', team_id: 'THOME', url: 'https://acme.slack.com',
+  });
+  slackApi.usergroups.list.mockResolvedValue({ usergroups: [] });
+  slackApi.users.list.mockResolvedValue({ members: [] });
+
+  client = await import('../client.js');
+  await client.initSlackClient('xoxb-test');
+});
+
+describe('unresolvable mention ids', () => {
+  it('resolves a real user to the agent-facing marker', async () => {
+    slackApi.users.info.mockResolvedValue({
+      ok: true,
+      user: { id: 'U123', name: 'jane', real_name: 'Jane Roe', team_id: 'THOME', profile: {} },
+    });
+
+    expect(await client.cleanSlackText('hi <@U123>')).toBe('hi <@U123:Jane Roe>');
+  });
+
+  it('leaves an unknown id as written, without warning, and asks Slack only once', async () => {
+    slackApi.users.info.mockRejectedValue(slackError('user_not_found'));
+
+    expect(await client.cleanSlackText('ping <@UKROMANOV6898>')).toBe('ping <@UKROMANOV6898>');
+    expect(await client.cleanSlackText('again <@UKROMANOV6898>')).toBe('again <@UKROMANOV6898>');
+
+    expect(slackApi.users.info).toHaveBeenCalledTimes(1);
+    expect(loggerWarn).not.toHaveBeenCalled();
+    expect(loggerDebug).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a transient failure — it warns with the reason and retries', async () => {
+    const err = slackError('ratelimited');
+    slackApi.users.info.mockRejectedValue(err);
+
+    expect(await client.cleanSlackText('ping <@U123>')).toBe('ping <@U123>');
+    expect(await client.cleanSlackText('ping <@U123>')).toBe('ping <@U123>');
+
+    expect(slackApi.users.info).toHaveBeenCalledTimes(2);
+    expect(loggerWarn).toHaveBeenCalledTimes(2);
+    expect(loggerWarn).toHaveBeenLastCalledWith('Slack', expect.stringContaining('U123'), err);
+  });
+
+  it('recovers a real user after a transient failure', async () => {
+    slackApi.users.info.mockRejectedValueOnce(slackError('ratelimited'));
+    slackApi.users.info.mockResolvedValue({
+      ok: true,
+      user: { id: 'U123', name: 'jane', real_name: 'Jane Roe', team_id: 'THOME', profile: {} },
+    });
+
+    expect(await client.cleanSlackText('hi <@U123>')).toBe('hi <@U123>');
+    expect(await client.cleanSlackText('hi <@U123>')).toBe('hi <@U123:Jane Roe>');
+  });
+});

--- a/src/connectors/slack/client.ts
+++ b/src/connectors/slack/client.ts
@@ -415,6 +415,13 @@ export function buildPrCardBlocks(card: PrCardData): unknown[] {
 }
 
 /**
+ * Ids Slack has rejected as `user_not_found`, so we stop re-asking on every
+ * thread read. Only permanent failures land here — caching a rate limit would
+ * permanently stop resolving a real person.
+ */
+const unresolvableUserIds = new Set<string>();
+
+/**
  * Helper: Fetch user, group, and channel info for all mentions in messages
  * Returns maps that can be used to replace IDs with names
  */
@@ -453,11 +460,21 @@ async function fetchMentionInfo(
   if (userIds.size > 0) {
     await Promise.all(
       Array.from(userIds).map(async (userId) => {
+        if (unresolvableUserIds.has(userId)) return;
         try {
           const info = await getUserInfo(userId);
           userInfoMap.set(userId, info);
         } catch (error) {
-          logger.warn('Slack', `Failed to get user info for ${userId}`);
+          const code = (error as { data?: { error?: string } } | undefined)?.data?.error;
+          if (code === 'user_not_found') {
+            unresolvableUserIds.add(userId);
+            logger.debug(
+              'Slack',
+              `Mention <@${userId}> is not a Slack user — leaving it as written and not asking again`
+            );
+          } else {
+            logger.warn('Slack', `Failed to get user info for ${userId}`, error);
+          }
         }
       })
     );


### PR DESCRIPTION
## What

Remember mention ids Slack rejects as `user_not_found` and stop looking them up again. Keep the error on genuine failures.

## Why

Production logged this hundreds of times over days:

```
[Slack] Failed to get user info for UKROMANOV6898
```

`UKROMANOV6898` is not a Slack user. `getUserInfo` has no cache, so `users.info` was called for it on every read of every thread containing it — noise in the logs and wasted API calls against a tier-3 rate limit.

The mechanism is worth stating, because it means this is permanent rather than transient. A `<@ID>` marker only ever appears in text an **app** posted — Slack escapes a human's literal `<` into `&lt;`. So a bad id means some integration wrote one without checking, and it is then baked into that thread's history forever. Every re-read re-resolves every mention in the thread, so one bad id produces an unbounded stream of identical warnings.

## Changes

- Ids that come back `user_not_found` go into a module-level set and are skipped thereafter. The mention is left as written, exactly as before.
- **Only** permanent failures are cached. Caching a rate limit or a network blip would permanently stop resolving a real person, which is far worse than the noise being fixed.
- Genuine failures keep the error in the log. The old code discarded it, which made a transient Slack outage indistinguishable from a bad id.
- `user_not_found` drops to `debug` — expected and unactionable.

## Tests

Four cases in `unresolvable-mentions.test.ts`, driving the real `client.ts` against a mocked Slack SDK: a real user resolves; an unknown id is left as written, warns nothing and hits the API once across two calls; a transient failure warns *with the reason* and is retried; and a real user still resolves after a transient failure.

Both new-behaviour tests were verified to fail against the old code.

## Not addressed

The reason a bad id exists at all is that `restoreMentions` converts `@<ID:Name>` → `<@ID>` with no validation, so an agent that invents an id posts broken markup that renders as literal text and **notifies nobody** — Archie believes it tagged someone who was never pinged. Fixing that means making the send path async and validating ids, on the highest-traffic path in the system. Left for a separate change.

Unrelated to the 2026-08-28 outage; this just came up while reading the same logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)