### PR TITLE
fix(triggers): match channel-message author filters against app ids

### DIFF
--- a/docs/architecture/triggers.md
+++ b/docs/architecture/triggers.md
@@ -158,6 +158,22 @@ So a message that both mentions Archie and matches a trigger creates a direct ta
 
 External and guest *humans* are filtered upstream by the author bail-out in `handleSlackEvent`, so they can never fire a trigger. That bail-out is `event.user`-gated and therefore never classifies an **app** post, which carries no `user` — so `dispatchChannelMessageTriggers` gates app posts on the bot's own team itself, dropping one from a foreign workspace before it is rendered or matched. This mirrors the rule thread ingestion and the pin index already draw: drop a bot from a foreign team, keep internal bots.
 
+**The author filter matches the author the payload carries, which for an app is a bot id.** A Slack message's author is not always a user id: an app posting through an incoming webhook (or with `as_user: false`) carries a `bot_id` and no `user` at all, while an app calling `chat.postMessage` with a bot token carries both. So `from_user` is tested against **both** ids, in `messageMatchesTrigger` (`src/system/trigger-match.ts`), and the id that decided the fire is the id handed to `fireTrigger` as `authorId` — one derivation, so the seed cannot name an author the filter did not match on.
+
+This is a correction, and the shape of the bug is worth keeping. The matcher used to compare `from_user` against `event.user` alone. Everything else in the codebase already knew better — `fetchSlackThread` keeps `botId` and renders the author line as `<@B…:Name>`, dispatch's own foreign-app gate reads `bot_id`, `fireTrigger` took `event.user || raw.bot_id` — so an agent reading a channel's history was *shown* the `B…` id as the author and had every reason to write it into the filter. A live trigger did exactly that: it watched #sweatcoin-mobile for an "Expired Feature Flags Report" from `B0A9ZRW2TS9`, was approved, announced and listed as active, and fired zero times across six weeks of reports. Nothing was broken enough to log: the message was routed, rendered and matched against the keyword; only the author comparison silently failed. **A filter that cannot match is indistinguishable from a channel where nothing was posted**, which is why the fix is paired with a validator rather than left to the matcher alone.
+
+`propose_trigger` and `update_trigger` therefore refuse a `from_user` that is not shaped like an author id (`U…`, `W…`, `B…`) — a name, an @handle, or a channel id pasted into the wrong field is rejected at creation with a message saying where to find the right id, instead of producing a trigger that is announced and inert. The validator is deliberately a shape check and not a lookup: resolving the id against Slack would fail closed on an app the bot cannot see, and a trigger refused because of a transient API error is worse than one refused for being unmatchable.
+
+Rendering follows the same principle. `describeCondition` used to say "from a specific person", which told neither the human reading the change notice nor the agent managing the trigger anything they could act on. It now names the author — a `U…` as a mention (a config change is exactly when the watched person should hear about it), a `B…` as its id, since an app cannot be mentioned — and names the watched channel when it differs from the delivery binding, the one case a listing could not otherwise express.
+
+## Reading a trigger
+
+`list_triggers` renders one summary line per trigger — `<when> → <what>`, deliberately short, because the common ask is "what's set up here". `get_trigger(id)` returns the stored record: every condition as stored (watched channel id, keyword, author id and what kind of id it is), the full internal `action.prompt`, the binding, and who created and approved it.
+
+The split exists because an agent that can only read the summary cannot manage what it is already allowed to delete. It cannot say which sender is filtered, cannot quote the instruction that runs — and, since `update_trigger` **replaces the condition list wholesale**, cannot edit one condition without silently dropping the filters it never saw. Visibility (below) is the gate on *which* triggers an agent may touch; withholding fields from a trigger that has already passed that gate protects nobody, because the same agent may rewrite or delete it outright. `get_trigger` is gated by exactly the same `triggerVisibleFrom` check as the rest of the surface, and refuses a `pending` proposal like `list_triggers` and `update_trigger` do, so the read tool cannot become the one way to see one.
+
+The action prompt is returned in full rather than clipped. Clipping it is what made the summary insufficient in the first place, and a prompt long enough to be a problem here is already seeded into a PM turn on every fire, so it is bounded by construction.
+
 ## Confirmation gate (channel-agnostic)
 
 Trigger creation reuses the edit-mode approval mechanism, which is already channel-agnostic:
@@ -208,7 +224,8 @@ Every **configuration change** — created/enabled, edited, paused/resumed, dele
 | `src/agents/trigger-data.ts` | The two pure pieces of the persistent directory: the sandbox grant, and the prompt block that announces the path and lists its contents |
 | `src/system/trigger-scheduler.ts` | In-memory index, 60s tick, cron math, `fireTrigger`, announcements |
 | `src/system/trigger-visibility.ts` | Pure visibility decision (privacy injected) |
-| `src/agents/tools.ts` | PM tools: `propose_trigger`, `list_triggers`, `update_trigger`, `delete_trigger` |
+| `src/system/trigger-match.ts` | Pure channel-message match decision — author-id shape, the `contains`/`from_user` predicate |
+| `src/agents/tools.ts` | PM tools: `propose_trigger`, `list_triggers`, `get_trigger`, `update_trigger`, `delete_trigger` |
 | `src/tasks/task.ts` | `handleTriggerApproval` / `handleTriggerDenial`; `openHomeThread` (opens and adopts the task's own thread in its home channel) and `linkSlackThread` |
 | `src/connectors/slack/channel-ids.ts` | `taskSlackChannelLabels` / `taskSlackChannelIds` — the one derivation of which channels a task's standing context and capabilities cover, home channel included |
 | `src/connectors/slack/events.ts` | Approve/Deny buttons + channel-message dispatch hook |

--- a/skills/triggers/SKILL.md
+++ b/skills/triggers/SKILL.md
@@ -10,7 +10,7 @@ You are setting up or managing a **trigger** — a persistent rule that makes Ar
 ### Two kinds of trigger
 
 - **Schedule** — fires on a repeating cadence (hourly, daily, weekdays, weekly at a time) or **once** at a future moment.
-- **Channel-message** — fires when a new top-level message is posted in a watched channel, optionally only when the message contains some text or comes from a specific person.
+- **Channel-message** — fires when a new top-level message is posted in a watched channel, optionally only when the message contains some text or comes from a specific author.
 
 Each trigger **delivers** its result to a **channel** (Archie posts there). Delivering to a person's DM is a planned follow-up and isn't supported yet — set triggers up to post in a channel.
 
@@ -26,6 +26,8 @@ Don't propose a trigger until you have:
 2. **When / what to watch** —
    - Schedule: the cadence or the one-off time, **and the timezone** (confirm it if you're not sure — "9am" is meaningless without one).
    - Channel-message: which channel, and any filter (a keyword, a specific sender).
+
+     A sender filter is an **id**, never a name or an @handle. Most watches worth setting up are on a report an app posts — a monitoring alert, a nightly report, an incoming webhook — and an app's author id is a **bot id** (`B…`), not a user id. Both forms work; use whichever the message's author actually is. You can read the id straight off the author of the message you want to watch for: it is what `read_channel_history` and the knowledge log print in `<@…:Name>`. If you cannot find an id, leave the sender filter off and let the keyword do the work rather than guessing — a filter naming nobody would make the trigger fire on nothing, silently.
 3. **Where to deliver** — which channel to post the result in. Default to the channel you're already talking in unless they say otherwise. (DM delivery isn't supported yet; if someone asks for a DM, explain it'll post to a channel for now.)
 
 If anything is missing or ambiguous, ask in Slack before proposing.
@@ -44,7 +46,9 @@ You can only see and manage triggers that belong to the space the user is talkin
 - From a **private channel**: that channel's triggers, plus public ones.
 - From a **DM**: that person's own DM triggers, plus public ones.
 
-A private channel's or a DM's triggers are never visible from anywhere else. When someone asks "what's set up here", list everything you can see and narrow it conversationally if they want just one channel or just the schedules. When they ask to pause, resume, edit, or delete one, do it by its id — anything you can see, you can manage. One warning worth giving before you delete: a trigger keeps a directory that its runs use to carry work forward, and deleting the trigger deletes that too. If the automation has been running a while, say so and offer to pause it instead.
+A private channel's or a DM's triggers are never visible from anywhere else. When someone asks "what's set up here", list everything you can see and narrow it conversationally if they want just one channel or just the schedules. When they ask to pause, resume, edit, or delete one, do it by its id — anything you can see, you can manage.
+
+**Listing gives you one summary line per trigger; `get_trigger` gives you the rule.** Read the trigger before you answer a question about what it watches, and always before you edit one. Two reasons, both of which have bitten: the summary says a sender is filtered without saying who, so answering from it means telling the user you cannot see something you can; and an edit that passes `conditions` **replaces the whole list**, so anything you did not restate — a keyword, a sender — is dropped without a word. Read first, then restate everything you mean to keep. One warning worth giving before you delete: a trigger keeps a directory that its runs use to carry work forward, and deleting the trigger deletes that too. If the automation has been running a while, say so and offer to pause it instead.
 
 ### Changes are announced; firing is not
 

--- a/src/agents/__tests__/tool-contract.test.ts
+++ b/src/agents/__tests__/tool-contract.test.ts
@@ -142,6 +142,7 @@ const PM_ORCHESTRATION_TOOLS = [
   'mcp__orchestration-tools__spawn_repo_agent',
   'mcp__orchestration-tools__propose_trigger',
   'mcp__orchestration-tools__list_triggers',
+  'mcp__orchestration-tools__get_trigger',
   'mcp__orchestration-tools__update_trigger',
   'mcp__orchestration-tools__delete_trigger',
 ];

--- a/src/agents/__tests__/trigger-detail.test.ts
+++ b/src/agents/__tests__/trigger-detail.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The read side of trigger management, and the one validation that keeps an author filter honest.
+ *
+ * Two defects are pinned here, both found on the same live trigger. It watched #sweatcoin-mobile for a
+ * report posted by an app, and its `from_user` held that app's `B…` id — the id Archie's own knowledge log
+ * prints as the author of a bot post. Nothing refused it at creation, and `list_triggers` rendered it back
+ * as "from a specific person", so the trigger was announced, listed as active, and never fired, while the
+ * agent asked about it could say neither who was filtered nor what instruction ran.
+ *
+ * Mock shape and handler extraction follow post-to-channel-gate.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Trigger } from '../../types/trigger.js';
+
+vi.mock('../../connectors/github/client.js', () => ({
+  getGitHubClient: vi.fn().mockReturnValue({}),
+  fetchOrigin: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../connectors/github/repo-clone.js', () => ({
+  gitExec: vi.fn().mockResolvedValue(''),
+  setupSharedClone: vi.fn().mockResolvedValue({ clone_path: '/wt', branch: 'feat/x', base_branch: 'main' }),
+  cloneExists: vi.fn().mockResolvedValue(false),
+  isWorktree: vi.fn().mockResolvedValue(false),
+  fetchOrigin: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../tasks/persistence.js', () => ({
+  appendAgentFinding: vi.fn().mockResolvedValue(undefined),
+  getReposPath: vi.fn().mockReturnValue('/sessions/task-123/repos'),
+  isThreadMuted: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('../../system/logger.js', () => ({
+  logger: { agentAction: vi.fn(), agentFinding: vi.fn(), agentToSlack: vi.fn(), system: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+vi.mock('../registry.js', () => ({
+  getAgentIds: vi.fn().mockReturnValue([]),
+  getVisiblePeerIdsForSender: vi.fn().mockReturnValue([]),
+  getAgentDef: vi.fn().mockReturnValue(undefined),
+}));
+
+const { loadTrigger, saveTrigger, countActiveTriggers } = vi.hoisted(() => ({
+  loadTrigger: vi.fn(),
+  saveTrigger: vi.fn().mockResolvedValue(undefined),
+  countActiveTriggers: vi.fn().mockResolvedValue(0),
+}));
+vi.mock('../../system/trigger-store.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../system/trigger-store.js')>();
+  return { ...actual, loadTrigger, saveTrigger, countActiveTriggers };
+});
+
+vi.mock('../../connectors/slack/channel-canvas.js', () => ({
+  ensureChannelCanvas: vi.fn(),
+  buildOtherChannelContextSection: vi.fn().mockResolvedValue(''),
+  collectCanvasFileAllowlist: vi.fn(),
+}));
+vi.mock('../../connectors/slack/channel-pins.js', () => ({ collectPinnedFileAllowlist: vi.fn() }));
+
+import { createOrchestrationMcpServer } from '../tools.js';
+import type { Agent } from '../agent.js';
+import type { Task } from '../../tasks/task.js';
+
+function makeAgent(): Agent {
+  return { def: { id: 'pm-agent', key: 'pm', role: 'PM', expertise: '', pluginName: 'pm', isPm: true }, queue: {} as any, session: { active: false } } as unknown as Agent;
+}
+
+/**
+ * A task with no linked Slack channel resolves to the OPERATOR trigger origin, which sees every trigger.
+ * That is deliberate here: visibility is `trigger-visibility.ts`'s subject and has its own suite — what these
+ * cases are about is what an agent that has already passed the gate is allowed to READ.
+ */
+function makeTask(): Task {
+  return {
+    taskId: 'task-1',
+    isActive: true,
+    metadata: { channels: {}, default_channel: null },
+    touch: vi.fn(), debouncedSave: vi.fn(), save: vi.fn().mockResolvedValue(undefined),
+    postInteractiveToUser: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Task;
+}
+
+function getHandler(name: string, task: Task): (args: Record<string, unknown>) => Promise<{ content: { text: string }[] }> {
+  const server = createOrchestrationMcpServer(makeAgent(), task);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = (server.instance as any)._registeredTools ?? Object.fromEntries((server.instance as any)._tools ?? []);
+  const entry = raw[name];
+  const fn = entry.callback ?? entry.handler ?? entry.cb;
+  return (args) => fn(args, {});
+}
+
+function textOf(result: { content: { text: string }[] }): string {
+  return result.content[0].text;
+}
+
+/** The live trigger this suite was written from, reduced to the fields under test. */
+const WATCHER: Trigger = {
+  id: 'trg-20260820-1219-w6751m',
+  status: 'enabled',
+  created_by: 'U03RQQTE1EF',
+  created_at: '2026-08-20T12:19:00.559Z',
+  approved_by: 'U03RQQTE1EF',
+  binding: { type: 'channel', channel_id: 'C05MFQCEN0N', channel_name: 'sweatcoin-mobile' },
+  conditions: [{
+    type: 'channel_message',
+    channel_id: 'C05MFQCEN0N',
+    match: { contains: 'Expired Feature Flags Report', from_user: 'B0A9ZRW2TS9' },
+  }],
+  action: { prompt: 'DEDUPLICATION — CHECK THIS FIRST. Do nothing at all if a report was already produced today.' },
+  summary: 'Flag Release Status report',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadTrigger.mockResolvedValue(null);
+  countActiveTriggers.mockResolvedValue(0);
+});
+
+describe('get_trigger reads back everything an edit has to preserve', () => {
+  it('names the watched channel, the keyword, the author id and the full action prompt', async () => {
+    loadTrigger.mockResolvedValue(WATCHER);
+
+    const out = textOf(await getHandler('get_trigger', makeTask())({ id: WATCHER.id }));
+
+    expect(out).toContain('C05MFQCEN0N');
+    expect(out).toContain('Expired Feature Flags Report');
+    // The whole point: the author filter is a concrete id, not "a specific person".
+    expect(out).toContain('B0A9ZRW2TS9');
+    expect(out).not.toMatch(/a specific person/i);
+    // And the instruction is quoted in full rather than clipped to its first sentence, because an agent
+    // rewriting `action_prompt` replaces all of it.
+    expect(out).toContain(WATCHER.action.prompt);
+    expect(out).toContain('Flag Release Status report');
+    // A `B…` filter is called what it is, so the agent can tell a bot watch from a person watch.
+    expect(out).toMatch(/app\/bot id/i);
+  });
+
+  it('says so when a condition has no filters, rather than leaving the reader to infer it', async () => {
+    loadTrigger.mockResolvedValue({
+      ...WATCHER,
+      conditions: [{ type: 'channel_message', channel_id: 'C05MFQCEN0N' }],
+    } satisfies Trigger);
+
+    const out = textOf(await getHandler('get_trigger', makeTask())({ id: WATCHER.id }));
+
+    expect(out).toMatch(/body filter: none/i);
+    expect(out).toMatch(/author filter: none/i);
+  });
+
+  it('surfaces the cron, timezone and next run of a schedule condition', async () => {
+    loadTrigger.mockResolvedValue({
+      ...WATCHER,
+      conditions: [{ type: 'schedule', cron: '0 9 * * 1-5', tz: 'Europe/London', next_run_at: '2026-09-03T08:00:00.000Z' }],
+    } satisfies Trigger);
+
+    const out = textOf(await getHandler('get_trigger', makeTask())({ id: WATCHER.id }));
+
+    expect(out).toContain('0 9 * * 1-5');
+    expect(out).toContain('Europe/London');
+    expect(out).toContain('2026-09-03T08:00:00.000Z');
+  });
+
+  it('warns that a conditions edit replaces the whole list', async () => {
+    loadTrigger.mockResolvedValue(WATCHER);
+
+    const out = textOf(await getHandler('get_trigger', makeTask())({ id: WATCHER.id }));
+
+    expect(out).toMatch(/REPLACES the whole list/i);
+  });
+
+  it('refuses an id that resolves to nothing', async () => {
+    const out = textOf(await getHandler('get_trigger', makeTask())({ id: 'trg-nope' }));
+    expect(out).toMatch(/No trigger trg-nope found/);
+  });
+
+  // A pending proposal is not yet a trigger anywhere else in this surface (`list_triggers` and
+  // `update_trigger` both filter it out); the read tool must not become the one way to see one.
+  it('refuses a pending proposal', async () => {
+    loadTrigger.mockResolvedValue({ ...WATCHER, status: 'pending' } satisfies Trigger);
+    const out = textOf(await getHandler('get_trigger', makeTask())({ id: WATCHER.id }));
+    expect(out).toMatch(/No trigger .* found/);
+  });
+});
+
+describe('an author filter must be an id a message can actually carry', () => {
+  const proposal = (from_user: string) => ({
+    binding: { type: 'channel' as const, channel_id: 'C05MFQCEN0N', channel_name: 'sweatcoin-mobile' },
+    conditions: [{ type: 'channel_message' as const, channel_id: 'C05MFQCEN0N', contains: 'Expired Feature Flags Report', from_user }],
+    action_prompt: 'produce the flag release status report',
+    summary: 'Flag Release Status report',
+  });
+
+  // Refused at the source: an unmatchable filter otherwise produces a trigger that is approved, announced
+  // and listed as active, and then silently never fires — indistinguishable from "nobody posted".
+  it.each(['flagbot', '@flagbot', 'Expired Flags Bot', 'C05MFQCEN0N', 'b0a9zrw2ts9'])(
+    'refuses %j',
+    async (from_user) => {
+      const task = makeTask();
+
+      const out = textOf(await getHandler('propose_trigger', task)(proposal(from_user)));
+
+      expect(out).toMatch(/not a Slack author id/i);
+      expect(task.metadata.pending_trigger_id).toBeUndefined();
+      expect(saveTrigger).not.toHaveBeenCalled();
+    },
+  );
+
+  // The controls. Both id kinds a message's author can be must get through — a `B…` especially, since the
+  // bot id IS the author id for the app posts these watches exist for.
+  it.each(['U03RQQTE1EF', 'W03RQQTE1EF', 'B0A9ZRW2TS9'])('accepts %s', async (from_user) => {
+    const task = makeTask();
+
+    const out = textOf(await getHandler('propose_trigger', task)(proposal(from_user)));
+
+    expect(out).not.toMatch(/not a Slack author id/i);
+    expect(task.metadata.pending_trigger_id).toBeDefined();
+    expect(saveTrigger).toHaveBeenCalled();
+    const saved = saveTrigger.mock.calls[0][0] as Trigger;
+    expect(saved.conditions[0]).toMatchObject({ match: { from_user } });
+  });
+
+  // The same validator has to sit on the edit path, or a rejected filter can simply be applied afterwards.
+  it('refuses an unmatchable filter on update_trigger too', async () => {
+    loadTrigger.mockResolvedValue(WATCHER);
+
+    const out = textOf(await getHandler('update_trigger', makeTask())({
+      id: WATCHER.id,
+      conditions: [{ type: 'channel_message', channel_id: 'C05MFQCEN0N', from_user: 'flagbot' }],
+    }));
+
+    expect(out).toMatch(/not a Slack author id/i);
+    expect(saveTrigger).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -124,6 +124,7 @@ import {
 } from '../system/trigger-scheduler.js';
 import { emitEvent } from '../system/event-bus.js';
 import { triggerVisibleFrom, type TriggerOrigin } from '../system/trigger-visibility.js';
+import { isSlackAuthorId, isAppAuthorId } from '../system/trigger-match.js';
 
 // Re-export branch state helpers for consumers that import from tools.ts
 export { hydrateBranchState, findBranchStateByPR };
@@ -2308,7 +2309,7 @@ const triggerConditionObject = z.object({
   tz: z.string().optional().describe('IANA timezone, e.g. "America/New_York". Defaults to the requesting user\'s timezone.'),
   channel_id: z.string().optional().describe('Channel to watch (required for channel_message).'),
   contains: z.string().optional().describe('Only fire when the new message contains this substring (channel_message).'),
-  from_user: z.string().optional().describe('Only fire for messages from this Slack user ID (channel_message).'),
+  from_user: z.string().optional().describe('Only fire for messages from this author (channel_message). A person\'s user id (`U…`), or — for a report posted by an app, bot or incoming webhook — that app\'s bot id (`B…`), which is the id that appears as the author of its messages. Not a name or @handle.'),
 });
 
 type RawCondition = z.infer<typeof triggerConditionObject>;
@@ -2403,7 +2404,15 @@ function buildConditions(raw: RawCondition[], defaultTz: string): { conditions: 
       if (!c.channel_id) return { error: 'A channel_message condition needs `channel_id`.' };
       const match: { contains?: string; from_user?: string } = {};
       if (c.contains) match.contains = c.contains;
-      if (c.from_user) match.from_user = c.from_user;
+      if (c.from_user) {
+        // Refuse an author filter that cannot name any author. Without this
+        // check the trigger is accepted, announced, and listed as active — and
+        // then never fires, which is indistinguishable from "nobody posted".
+        if (!isSlackAuthorId(c.from_user)) {
+          return { error: `"${c.from_user}" is not a Slack author id. Use the person's user id (\`U…\`) or, for a report posted by an app or webhook, the app's bot id (\`B…\`) — that is the id shown in the author of the message you want to watch for. A name or @handle will not match anything.` };
+        }
+        match.from_user = c.from_user;
+      }
       conditions.push({ type: 'channel_message', channel_id: c.channel_id, ...(Object.keys(match).length ? { match } : {}) });
     } else {
       return { error: `Unknown condition type "${(c as { type: string }).type}".` };
@@ -2513,7 +2522,7 @@ function createProposeTriggerTool(agent: Agent, task: Task) {
 function createListTriggersTool(_agent: Agent, task: Task) {
   return tool(
     'list_triggers',
-    'List the triggers visible from this conversation (per privacy rules). Returns everything visible — filter or narrow it yourself when the user asks for "the ones in this channel", "just the schedules", etc.',
+    'List the triggers visible from this conversation (per privacy rules), one summary line each. Returns everything visible — filter or narrow it yourself when the user asks for "the ones in this channel", "just the schedules", etc. These lines are summaries, not the stored rule: call `get_trigger` for the exact conditions, filters and action prompt before answering a question about what one watches, and always before editing one.',
     {},
     async () => {
       const all = (await listTriggers()).filter((t) => t.status !== 'pending');
@@ -2534,16 +2543,96 @@ function createListTriggersTool(_agent: Agent, task: Task) {
   );
 }
 
+/** Render one stored condition in full — every field the matcher actually reads. */
+function detailCondition(c: TriggerCondition, index: number): string {
+  const head = `  ${index + 1}. `;
+  if (c.type === 'schedule') {
+    const lines = [
+      `${head}${c.cron ? 'a recurring schedule' : 'a one-off schedule'}`,
+      `       cron: ${c.cron ?? '(none — fires once)'}`,
+      `       timezone: ${c.tz}`,
+      `       next run: ${c.next_run_at}`,
+    ];
+    return lines.join('\n');
+  }
+  const lines = [`${head}a new top-level message in <#${c.channel_id}> (${c.channel_id})`];
+  if (c.match?.contains) lines.push(`       body contains (case-insensitive): "${c.match.contains}"`);
+  else lines.push('       body filter: none — any message in that channel');
+  if (c.match?.from_user) {
+    const kind = isAppAuthorId(c.match.from_user)
+      ? 'an app/bot id, matched against the message\'s bot_id'
+      : 'a user id, matched against the message\'s author';
+    lines.push(`       author is: ${c.match.from_user} (${kind})`);
+  } else {
+    lines.push('       author filter: none — anyone in that channel');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * `get_trigger` — the full stored record of one visible trigger.
+ *
+ * This exists because `list_triggers` renders a deliberately short one-liner,
+ * and an agent that can only read the one-liner cannot manage what it can
+ * already delete: it cannot say which sender is filtered, cannot quote the
+ * instruction that runs, and — since `update_trigger` REPLACES the condition
+ * list wholesale — cannot edit one condition without silently dropping the
+ * filters it never saw. Visibility is the gate on WHICH triggers an agent may
+ * touch; withholding fields from a trigger that already passed that gate
+ * protects nobody, since the same agent may rewrite or delete it outright.
+ */
+function createGetTriggerTool(_agent: Agent, task: Task) {
+  return tool(
+    'get_trigger',
+    'Read one trigger in full: every condition exactly as stored (watched channel, keyword filter, author id), the internal action prompt it runs, and its status/binding/history. Use this before editing a trigger — `update_trigger` replaces the whole condition list, so you need to see what is there — and whenever the user asks what a trigger actually watches or does.',
+    {
+      id: z.string().describe('Trigger ID (from list_triggers).'),
+    },
+    async (args) => {
+      const trigger = await loadTrigger(args.id);
+      if (!trigger || trigger.status === 'pending') return ok(`No trigger ${args.id} found.`);
+      const origin = await resolveTriggerOrigin(task);
+      if (!(await triggerVisibleFrom(trigger, origin, makePrivacyResolver()))) {
+        return ok(`Trigger ${args.id} isn't visible from here, so it can't be read from this conversation.`);
+      }
+
+      const where = trigger.binding.type === 'channel'
+        ? `#${trigger.binding.channel_name} (${trigger.binding.channel_id})`
+        : `a DM with <@${trigger.binding.user_id}>`;
+      const by = trigger.created_by && trigger.created_by !== 'unknown' ? `<@${trigger.created_by}>` : 'unknown';
+
+      const lines = [
+        `Trigger ${trigger.id} — ${trigger.status}`,
+        `Name shown to users: ${trigger.summary?.trim() || '(none set — listings fall back to a clip of the action prompt)'}`,
+        `Delivers to: ${where}`,
+        `Created by ${by} at ${trigger.created_at}${trigger.approved_by ? `; approved by <@${trigger.approved_by}>` : ''}`,
+        `Last fired: ${trigger.last_fired_at ?? 'never'}`,
+        '',
+        `Fires when ANY of these match (${trigger.conditions.length}):`,
+        ...trigger.conditions.map((c, i) => detailCondition(c, i)),
+        '',
+        'Action prompt — the internal instruction seeded to a fresh PM task on every fire. It is working text, not a user-facing description: explain it in your own words rather than pasting it into Slack.',
+        '<<<',
+        trigger.action.prompt,
+        '>>>',
+        '',
+        'To change it, use `update_trigger`. `conditions` REPLACES the whole list above — restate every condition and every filter you want to keep, or it is dropped.',
+      ];
+      return ok(lines.join('\n'));
+    },
+  );
+}
+
 function createUpdateTriggerTool(_agent: Agent, task: Task) {
   return tool(
     'update_trigger',
-    'Pause, resume, or edit an existing trigger. You can only manage triggers visible from this conversation. Posts a one-line change notice to the trigger\'s bound channel.',
+    'Pause, resume, or edit an existing trigger. Read it with `get_trigger` first — `conditions` replaces the whole list, so editing blind silently drops filters. You can only manage triggers visible from this conversation. Posts a one-line change notice to the trigger\'s bound channel.',
     {
       id: z.string().describe('Trigger ID (from list_triggers).'),
       status: z.enum(['paused', 'enabled']).optional().describe('"paused" to pause, "enabled" to resume.'),
       action_prompt: z.string().optional().describe('Replace the internal instruction run when the trigger fires (not shown to the user).'),
       summary: z.string().optional().describe('Replace the short, friendly user-facing name. Update this whenever you change action_prompt so the notices stay accurate.'),
-      conditions: z.array(triggerConditionObject).optional().describe('Replace the conditions entirely (same shape as propose_trigger).'),
+      conditions: z.array(triggerConditionObject).optional().describe('REPLACES the condition list entirely (same shape as propose_trigger) — anything you leave out is dropped, including a keyword or author filter you never saw. Call `get_trigger` first and restate every condition you want to keep.'),
     },
     async (args) => {
       const trigger = await loadTrigger(args.id);
@@ -2829,6 +2918,7 @@ export function createOrchestrationMcpServer(agent: Agent, task: Task) {
       createSpawnRepoAgentTool(agent, task),
       createProposeTriggerTool(agent, task),
       createListTriggersTool(agent, task),
+      createGetTriggerTool(agent, task),
       createUpdateTriggerTool(agent, task),
       createDeleteTriggerTool(agent, task),
     ],

--- a/src/connectors/slack/__tests__/trigger-dispatch.test.ts
+++ b/src/connectors/slack/__tests__/trigger-dispatch.test.ts
@@ -112,14 +112,18 @@ import { findTaskByThread } from '../../../tasks/persistence.js';
 
 const CHANNEL = 'C0WATCHED';
 
-function makeTrigger(contains?: string): Trigger {
+function makeTrigger(contains?: string, from_user?: string): Trigger {
   return {
     id: 'trg-20260818-1200-abc123',
     status: 'enabled',
     created_by: 'U_DEV',
     created_at: '2026-08-18T12:00:00.000Z',
     binding: { type: 'channel', channel_id: CHANNEL, channel_name: 'watched' },
-    conditions: [{ type: 'channel_message', channel_id: CHANNEL, ...(contains ? { match: { contains } } : {}) }],
+    conditions: [{
+      type: 'channel_message',
+      channel_id: CHANNEL,
+      ...(contains || from_user ? { match: { ...(contains ? { contains } : {}), ...(from_user ? { from_user } : {}) } } : {}),
+    }],
     action: { prompt: 'look into it' },
     summary: 'watch the deploy bot',
   };
@@ -237,6 +241,78 @@ describe('channel-message trigger dispatch matches the rendered body', () => {
 
     expect(vi.mocked(fireTrigger)).not.toHaveBeenCalled();
     expect(vi.mocked(extractMessageContent)).not.toHaveBeenCalled();
+  });
+});
+
+describe('the author filter matches the author the payload actually carries', () => {
+  // The regression. An app posting through an incoming webhook carries a `bot_id` and NO `user`, and the
+  // author id Archie shows an agent for such a post — in the knowledge log, in `read_channel_history` — is
+  // that `B…`. A filter naming it was therefore the natural thing to write, and it was compared against
+  // `event.user` alone, so it matched nothing: the trigger was approved, announced, listed as active, and
+  // never fired once.
+  it('fires on a `B…` filter when the app post has a bot_id and no user', async () => {
+    vi.mocked(getChannelMessageTriggers).mockReturnValue([makeTrigger('expired feature flags report', 'B_REPORTER')]);
+
+    await deliverAmbientPost({
+      type: 'message',
+      subtype: 'bot_message',
+      channel: CHANNEL,
+      bot_id: 'B_REPORTER',
+      text: '',
+      attachments: [{ text: 'Expired Feature Flags Report — 253.0.0 | Total: 200 flags' }],
+      ts: '1700000000.000700',
+    });
+
+    expect(vi.mocked(fireTrigger)).toHaveBeenCalledTimes(1);
+    // The id that decided the fire is the id the fired task is told about, so a seed naming the author
+    // cannot disagree with the filter that matched.
+    expect(vi.mocked(fireTrigger).mock.calls[0][1].authorId).toBe('B_REPORTER');
+  });
+
+  // The discriminator. Matching on "is a bot post at all" would pass the case above just as well, and would
+  // fire this trigger on every other app in the channel.
+  it('does not fire when a different app posts matching text', async () => {
+    vi.mocked(getChannelMessageTriggers).mockReturnValue([makeTrigger('expired feature flags report', 'B_REPORTER')]);
+
+    await deliverAmbientPost({
+      type: 'message',
+      subtype: 'bot_message',
+      channel: CHANNEL,
+      bot_id: 'B_SOMEONE_ELSE',
+      text: '',
+      attachments: [{ text: 'Expired Feature Flags Report — forwarded by another integration' }],
+      ts: '1700000000.000710',
+    });
+
+    expect(vi.mocked(fireTrigger)).not.toHaveBeenCalled();
+  });
+
+  it('still matches a human `U…` filter, which is the form that always worked', async () => {
+    vi.mocked(getChannelMessageTriggers).mockReturnValue([makeTrigger('deploy failed', 'U_DEV')]);
+
+    await deliverAmbientPost({
+      type: 'message',
+      channel: CHANNEL,
+      user: 'U_DEV',
+      text: 'the deploy failed again',
+      ts: '1700000000.000720',
+    });
+
+    expect(vi.mocked(fireTrigger)).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when a different person posts matching text', async () => {
+    vi.mocked(getChannelMessageTriggers).mockReturnValue([makeTrigger('deploy failed', 'U_DEV')]);
+
+    await deliverAmbientPost({
+      type: 'message',
+      channel: CHANNEL,
+      user: 'U_OTHER',
+      text: 'the deploy failed again',
+      ts: '1700000000.000730',
+    });
+
+    expect(vi.mocked(fireTrigger)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/connectors/slack/events.ts
+++ b/src/connectors/slack/events.ts
@@ -37,7 +37,7 @@ import { getIsShuttingDown } from '../../system/shutdown.js';
 import { findTaskByThread } from '../../tasks/persistence.js';
 import { rawMessageBody } from './message-body.js';
 import { getChannelMessageTriggers, fireTrigger, triggerWhat } from '../../system/trigger-scheduler.js';
-import type { Trigger } from '../../types/trigger.js';
+import { messageMatchesTrigger } from '../../system/trigger-match.js';
 import { generateTaskTitle } from '../../tasks/title-generator.js';
 import { setAssistantThreadTitle } from './title.js';
 import type { SlackThread, SlackAuthor } from '../../types/task.js';
@@ -922,6 +922,8 @@ export async function handleSlackEvent(event: {
  * The filter is matched against the *rendered* body — the same text an agent would be shown — not against the raw event's top-level `text`. That distinction is the whole point: a webhook or app post carries an empty `text` with all of its content in `attachments`/`blocks`, so matching the raw field made every such post invisible to `contains` filters. `rawMessageBody` runs the payload through the full inbound extraction, so blocks, attachment cards and files all become matchable.
  *
  * There is deliberately no fallback to the raw text and no re-fetch of the message by `ts`: a fallback would silently restore the original bug on exactly the payloads it was meant to fix, and a thread re-fetch can't see a message that has neither a `user` nor a `botId` anyway. If extraction yields an empty body, an empty body is what the filter sees.
+ *
+ * The author filter is matched the same way — against the author the payload actually carries, which for an app post is a `bot_id` and no `user` at all. The decision itself lives in `system/trigger-match.ts`; the only thing done here is assembling both ids, and the assembled pair is what `fireTrigger` is handed too, so the id that decided the fire is the id the fired task is told about.
  */
 async function dispatchChannelMessageTriggers(
   event: { channel: string; user: string; ts: string; raw: unknown },
@@ -952,22 +954,19 @@ async function dispatchChannelMessageTriggers(
   // read) so it is not free.
   const body = await rawMessageBody(event.raw, event.channel);
 
-  const matches = (trigger: Trigger): boolean =>
-    trigger.conditions.some((c) => {
-      if (c.type !== 'channel_message' || c.channel_id !== event.channel) return false;
-      if (c.match?.contains && !body.toLowerCase().includes(c.match.contains.toLowerCase())) return false;
-      if (c.match?.from_user && event.user !== c.match.from_user) return false;
-      return true;
-    });
+  // The author, as BOTH ids the payload can carry. An app post routinely has a
+  // `bot_id` and no `user`, so an author filter tested against `event.user`
+  // alone can never match one — see `trigger-match.ts` for why that mattered.
+  const author = { userId: event.user || undefined, botId: raw?.bot_id };
 
   for (const trigger of triggers) {
-    if (!matches(trigger)) continue;
+    if (!messageMatchesTrigger(trigger, { channelId: event.channel, body, author })) continue;
     try {
       await fireTrigger(trigger, {
         kind: 'message',
         thread,
         body,
-        authorId: event.user || raw?.bot_id || undefined,
+        authorId: author.userId || author.botId,
         channelName,
       });
     } catch (err) {

--- a/src/system/__tests__/trigger-match.test.ts
+++ b/src/system/__tests__/trigger-match.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The pure channel-message match predicate. Dispatch-level behaviour (an app post's `contains` matching the
+ * rendered body, the `B…` author regression end to end) lives in connectors/slack/__tests__/trigger-dispatch.test.ts;
+ * what is pinned here is the decision itself, including the cases that are awkward to reach through Bolt.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Trigger } from '../../types/trigger.js';
+import { authorFilterMatches, isSlackAuthorId, isAppAuthorId, messageMatchesTrigger } from '../trigger-match.js';
+
+const CHANNEL = 'C0WATCHED';
+
+function watcher(match?: { contains?: string; from_user?: string }): Trigger {
+  return {
+    id: 'trg-1', status: 'enabled', created_by: 'U_DEV', created_at: '2026-08-20T00:00:00.000Z',
+    binding: { type: 'channel', channel_id: CHANNEL, channel_name: 'watched' },
+    conditions: [{ type: 'channel_message', channel_id: CHANNEL, ...(match ? { match } : {}) }],
+    action: { prompt: 'look into it' },
+  };
+}
+
+describe('authorFilterMatches', () => {
+  it('matches either id the payload carries', () => {
+    expect(authorFilterMatches('U_DEV', { userId: 'U_DEV' })).toBe(true);
+    expect(authorFilterMatches('B_APP', { botId: 'B_APP' })).toBe(true);
+  });
+
+  // An app calling chat.postMessage with a bot token emits BOTH — its bot user id and its bot id — so
+  // either form of the filter has to name it. Whichever id the person setting the trigger read off the
+  // author line is the one they will use.
+  it('matches both ids when the payload carries both', () => {
+    const author = { userId: 'U_APPUSER', botId: 'B_APP' };
+    expect(authorFilterMatches('U_APPUSER', author)).toBe(true);
+    expect(authorFilterMatches('B_APP', author)).toBe(true);
+    expect(authorFilterMatches('U_SOMEONE', author)).toBe(false);
+  });
+
+  // `handleSlackEvent` normalizes a missing `user` to `''`. If an empty id could match an empty filter the
+  // predicate would fire on every authorless post — the exact population these filters exist to narrow.
+  it('never matches on an empty id, on either side', () => {
+    expect(authorFilterMatches('', { userId: '', botId: 'B_APP' })).toBe(false);
+    expect(authorFilterMatches('U_DEV', { userId: '' })).toBe(false);
+    expect(authorFilterMatches('', {})).toBe(false);
+  });
+});
+
+describe('isSlackAuthorId', () => {
+  it.each(['U08JNK1A6', 'W03RQQTE1EF', 'B0A9ZRW2TS9'])('accepts %s', (id) => {
+    expect(isSlackAuthorId(id)).toBe(true);
+  });
+
+  // A channel id is the near-miss worth refusing explicitly: it is the other id in the same tool call.
+  it.each(['flagbot', '@flagbot', 'C05MFQCEN0N', 'u08jnk1a6', 'U', ''])('refuses %j', (id) => {
+    expect(isSlackAuthorId(id)).toBe(false);
+  });
+
+  it('tells an app id apart from a person', () => {
+    expect(isAppAuthorId('B0A9ZRW2TS9')).toBe(true);
+    expect(isAppAuthorId('U08JNK1A6')).toBe(false);
+  });
+});
+
+describe('messageMatchesTrigger', () => {
+  const base = { channelId: CHANNEL, body: 'Expired Feature Flags Report — 200 flags', author: { botId: 'B_APP' } };
+
+  it('matches `contains` case-insensitively', () => {
+    expect(messageMatchesTrigger(watcher({ contains: 'expired feature flags' }), base)).toBe(true);
+  });
+
+  it('requires every filter on the condition, not just one', () => {
+    const t = watcher({ contains: 'Expired Feature Flags Report', from_user: 'B_APP' });
+    expect(messageMatchesTrigger(t, base)).toBe(true);
+    expect(messageMatchesTrigger(t, { ...base, author: { botId: 'B_OTHER' } })).toBe(false);
+    expect(messageMatchesTrigger(t, { ...base, body: 'something else entirely' })).toBe(false);
+  });
+
+  it('ignores a condition watching a different channel', () => {
+    expect(messageMatchesTrigger(watcher(), { ...base, channelId: 'C0ELSEWHERE' })).toBe(false);
+  });
+
+  it('ignores a schedule condition entirely', () => {
+    const t: Trigger = {
+      ...watcher(),
+      conditions: [{ type: 'schedule', tz: 'UTC', cron: '0 9 * * *', next_run_at: '2026-09-03T09:00:00.000Z' }],
+    };
+    expect(messageMatchesTrigger(t, base)).toBe(false);
+  });
+
+  // Any condition firing is enough — the stored model is a disjunction.
+  it('fires when any one of several conditions matches', () => {
+    const t: Trigger = {
+      ...watcher(),
+      conditions: [
+        { type: 'channel_message', channel_id: CHANNEL, match: { contains: 'never appears' } },
+        { type: 'channel_message', channel_id: CHANNEL, match: { from_user: 'B_APP' } },
+      ],
+    };
+    expect(messageMatchesTrigger(t, base)).toBe(true);
+  });
+
+  it('matches an unfiltered condition on any message in the channel', () => {
+    expect(messageMatchesTrigger(watcher(), { ...base, body: '' })).toBe(true);
+  });
+});

--- a/src/system/trigger-match.ts
+++ b/src/system/trigger-match.ts
@@ -1,0 +1,89 @@
+/**
+ * Channel-message trigger matching — the pure predicate that decides whether an
+ * inbound Slack message fires a trigger. Dependency-free (no Slack client, no
+ * store) so the decision can be unit-asserted directly; the dispatch hook in
+ * `connectors/slack/events.ts` supplies the rendered body and the author.
+ *
+ * The reason this is its own module rather than three lines inside the dispatch
+ * hook is the defect it exists to prevent. A Slack message's author is **not
+ * always a user id**: an app posting through an incoming webhook (or with
+ * `as_user: false`) carries a `bot_id` and no `user` at all. Every other part of
+ * this codebase already knows that — `fetchSlackThread` keeps `botId` and
+ * renders the author line as `<@B…:Name>`, `dispatchChannelMessageTriggers`
+ * gates foreign apps on `bot_id`, and `fireTrigger` takes
+ * `event.user || raw.bot_id` as the author. The author FILTER was the one
+ * consumer that compared against `event.user` alone, so a filter naming the
+ * `B…` id the logs had shown the agent could never match, and the trigger
+ * silently never fired.
+ */
+
+import type { Trigger, TriggerCondition } from '../types/trigger.js';
+
+/**
+ * Every identity Slack attaches to a message's author. At least one is present;
+ * which one depends on how the message was posted, never on who posted it:
+ *  - `userId` — `U…` (or `W…` on Enterprise Grid) for a human, and for an app
+ *    posting as a user.
+ *  - `botId` — `B…` on ANY app-authored post, and frequently the only id there
+ *    is (incoming webhooks and `as_user: false` carry no `user`).
+ */
+export interface MessageAuthor {
+  userId?: string;
+  botId?: string;
+}
+
+/** The parts of an inbound message the match predicate reads. */
+export interface MessageMatchInput {
+  channelId: string;
+  /** The RENDERED body — what an agent would be shown, not the raw `text` field. */
+  body: string;
+  author: MessageAuthor;
+}
+
+/**
+ * Shape of a Slack author id usable as a `from_user` filter: a user (`U…`), an
+ * Enterprise Grid user (`W…`), or an app/bot (`B…`).
+ *
+ * Validating the shape is what turns a mistyped or wrong-kind filter into a
+ * refusal at creation time instead of a trigger that is accepted, announced,
+ * listed as active, and then never fires. Slack ids are uppercase alphanumeric
+ * and at least 9 characters in practice; the floor here is deliberately looser
+ * than that so a future id length cannot make a legitimate filter unusable.
+ */
+const SLACK_AUTHOR_ID = /^[UWB][A-Z0-9]{2,}$/;
+
+/** Is `id` shaped like an author id a message can actually carry? */
+export function isSlackAuthorId(id: string): boolean {
+  return SLACK_AUTHOR_ID.test(id);
+}
+
+/** Does `id` name an app rather than a person? (Only the id shape can tell.) */
+export function isAppAuthorId(id: string): boolean {
+  return id.startsWith('B');
+}
+
+/**
+ * Does the author filter name this message's author?
+ *
+ * Compared against BOTH ids the payload can carry, because which one is present
+ * is a property of how the message was posted rather than of the author. Empty
+ * ids never match — `handleSlackEvent` normalizes a missing `user` to `''`, and
+ * an `''` filter matching an authorless post would fire a trigger on everything.
+ */
+export function authorFilterMatches(filter: string, author: MessageAuthor): boolean {
+  if (!filter) return false;
+  return (!!author.userId && filter === author.userId) || (!!author.botId && filter === author.botId);
+}
+
+/** Does one condition fire on this message? */
+function conditionMatches(c: TriggerCondition, input: MessageMatchInput): boolean {
+  if (c.type !== 'channel_message' || c.channel_id !== input.channelId) return false;
+  if (c.match?.contains && !input.body.toLowerCase().includes(c.match.contains.toLowerCase())) return false;
+  if (c.match?.from_user && !authorFilterMatches(c.match.from_user, input.author)) return false;
+  return true;
+}
+
+/** Does any of the trigger's conditions fire on this message? */
+export function messageMatchesTrigger(trigger: Trigger, input: MessageMatchInput): boolean {
+  return trigger.conditions.some((c) => conditionMatches(c, input));
+}

--- a/src/system/trigger-scheduler.ts
+++ b/src/system/trigger-scheduler.ts
@@ -19,6 +19,7 @@ import { listTriggers, saveTrigger, deleteTrigger } from './trigger-store.js';
 import { AGENT_PROMPTS } from '../agents/prompts.js';
 import { emitEvent } from './event-bus.js';
 import { logger } from './logger.js';
+import { isAppAuthorId } from './trigger-match.js';
 import { postSlackMessage, isChannelReachable } from '../connectors/slack/client.js';
 import { ensureChannelCanvas } from '../connectors/slack/channel-canvas.js';
 import { ensureChannelPins } from '../connectors/slack/channel-pins.js';
@@ -578,15 +579,32 @@ function describeOneOff(iso: string, tz: string): string {
   }
 }
 
-/** Plain-English "when" clause for a single condition. */
-function describeCondition(c: TriggerCondition): string {
+/**
+ * Plain-English "when" clause for a single condition.
+ *
+ * An author filter is rendered as WHO, not as "from a specific person". Two
+ * readers need it: a human seeing the change notice in the bound channel — the
+ * one place the "no silent changes" rule reaches them, and the place someone
+ * being watched finds out — and the agent, which cannot manage what a listing
+ * refuses to name. A `U…` renders as a mention on purpose (a config change is
+ * exactly when the watched person should hear about it); a `B…` cannot be
+ * mentioned at all, so an app is named by its id.
+ *
+ * The watched channel is named only when it differs from the delivery binding,
+ * which is the case a listing is otherwise unable to express — in the common
+ * watch-here-deliver-here trigger it would just be noise.
+ */
+function describeCondition(c: TriggerCondition, bindingChannelId?: string): string {
   if (c.type === 'schedule') {
     return c.cron ? describeSchedule(c.cron, c.tz) : describeOneOff(c.next_run_at, c.tz);
   }
+  const where = c.channel_id === bindingChannelId ? '' : ` in <#${c.channel_id}>`;
   const filters: string[] = [];
   if (c.match?.contains) filters.push(`mentioning "${c.match.contains}"`);
-  if (c.match?.from_user) filters.push('from a specific person');
-  return `on a new message${filters.length ? ' ' + filters.join(' ') : ''}`;
+  if (c.match?.from_user) {
+    filters.push(isAppAuthorId(c.match.from_user) ? `from the app \`${c.match.from_user}\`` : `from <@${c.match.from_user}>`);
+  }
+  return `on a new message${where}${filters.length ? ' ' + filters.join(' ') : ''}`;
 }
 
 /** First sentence / clipped form of the internal prompt — fallback when no summary was set. */
@@ -604,7 +622,8 @@ export function triggerWhat(trigger: Trigger): string {
 
 /** WHEN it runs, across all conditions ("every day at 9:00 AM" / "on a new message …"). */
 export function triggerWhen(trigger: Trigger): string {
-  return trigger.conditions.map(describeCondition).join(' or ');
+  const bound = trigger.binding.type === 'channel' ? trigger.binding.channel_id : undefined;
+  return trigger.conditions.map((c) => describeCondition(c, bound)).join(' or ');
 }
 
 /** WHERE results are delivered ("#general" / "a DM"). */


### PR DESCRIPTION
## The bug

`trg-20260820-1219-w6751m` watches #sweatcoin-mobile for an "Expired Feature Flags Report" from the generator app. It was approved on 2026-08-20, announced in the channel, and has been listed as active ever since. It has **never fired** — its record still carries no `last_fired_at`, and its file on prod has not been written since the minute it was approved. Reports went out on Aug 3, Aug 12, Aug 18 and Sep 1.

Its `from_user` is `B0A9ZRW2TS9`, and the matcher compared that against `event.user` alone:

```ts
if (c.match?.from_user && event.user !== c.match.from_user) return false;
```

An app posting through an incoming webhook carries a `bot_id` and **no `user` at all**, so this was `'' !== 'B0A9ZRW2TS9'` on every report.

Nothing looked wrong from outside. The message was routed, rendered and keyword-matched; only the author comparison failed. **A filter that cannot match is indistinguishable from a channel where nobody posted.**

The `B…` was not a mistake anyone should have caught, either. Archie renders a bot post's author as `<@B0A9ZRW2TS9:Name>` in the knowledge log and in `read_channel_history` — that id is exactly what the agent was shown and correctly copied. Every other consumer already knew: `fetchSlackThread` keeps `botId`, dispatch's own foreign-app gate reads `bot_id`, `fireTrigger` took `event.user || raw.bot_id`. The author filter was the one place the producer and the consumer of an author id disagreed.

## The second half

The same conversation that reported the trigger not firing also showed the agent could not say what it watched:

> the listing I can read doesn't expose *which* sender is pinned (just that it's filtered to one), nor the full internal instruction it runs

That was accurate. `list_triggers` renders one summary line, and an author filter appeared in it as the literal string `from a specific person`. And `update_trigger` **replaces the whole condition list** — so an edit made from the summary would have silently dropped both the keyword and the filter. The agent could delete the trigger but not read it.

## What changed

| | |
|---|---|
| `src/system/trigger-match.ts` *(new, pure)* | `from_user` matched against **both** ids the payload can carry; the same pair is what `fireTrigger` receives, so the id that decided the fire is the id the fired task is told about |
| `tools.ts` | new **`get_trigger(id)`** — full record: watched channel, keyword, author id and what kind of id it is, complete action prompt, binding, history |
| `tools.ts` | `propose_trigger` / `update_trigger` **refuse** a `from_user` that is not `U…`/`W…`/`B…`, naming where to find the right id |
| `trigger-scheduler.ts` | descriptions name the author (mention for a person, id for an app) and name the watched channel when it differs from the delivery binding |
| SKILL + `docs/architecture/triggers.md` | read-before-edit rule, bot-id guidance, and the defect recorded with its reasoning |

Two deliberate calls worth reviewing:

- **The validator is a shape check, not a Slack lookup.** Resolving the id would fail closed on an app the bot cannot see, and a trigger refused for a transient API error is worse than one refused for being unmatchable.
- **`get_trigger` returns the action prompt in full.** Clipping it is what made the summary insufficient in the first place, and a prompt long enough to be a problem is already seeded into a PM turn on every fire.

## Verification

**Unit/integration** — 38 new cases, full suite green (1577 passed / 5 skipped). The dispatch regression is mutation-checked: reverting the matcher to `userId`-only fails exactly that case and nothing else.

**Live**, on a container booted from this branch (sha-attested), driven over the API — 9/9 assertions:

- a `B…` filter is accepted, approved and stored verbatim;
- the approval card reads ``on a new message mentioning "Expired Feature Flags Report" from the app `B0E2EREPORT` `` — not "a specific person";
- a **fresh** PM asked *"what exactly does it watch?"* loads the skill → `list_triggers` → **`get_trigger`**, and answers with the channel id, the keyword, the bot id and *"matched against the message's `bot_id`"*;
- `from_user: "flagbot"` is refused with nothing created — and unprompted, a PM given a *name* now leaves the filter off and asks for the id rather than writing an unmatchable one.

**Not driven live:** the Slack fire itself. It only enters through a real Slack event, and the E2E harness has no workspace by design. That path is covered at the `handleSlackEvent` level with the real router and the real matcher.

## Before merging, two consequences

1. **`trg-20260820-1219-w6751m` starts firing** on the next report in #sweatcoin-mobile, after six weeks of silence. Its action prompt requires the `feature-flag-release-status` skill, `mobile-agent`, `release-manager-agent` and the sweatco-admin connector — worth confirming those are in place. Its dedup step reads the trigger directory, which does not exist yet (created at first spawn), so the first fire correctly sees no history.
2. The next **config change** to that trigger will announce ``from the app `B0A9ZRW2TS9` `` in the channel instead of "from a specific person". Firing still announces nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
