### PR TITLE
fix(research): stop pinning a model on Perplexity requests

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -181,7 +181,7 @@ This hook is wired on every agent's `PostToolUse` array alongside the persistenc
 
 ### Preset Classifier Subagent
 
-The tool spawns one nested `query()` call to a Haiku classifier (`classifyPreset`) that picks a Perplexity preset (`fast` / `low` / `medium`). This subagent runs with `allowedTools: []` — it has no tools at all, only structured JSON output. There is no researcher subagent with web tools, no report-writer subagent, and no "sandwich defense" PreToolUse hooks (the historical sandwich defense has been removed; outbound prompt injection is now handled by Bedrock Guardrails plus the defense-tag wrapper above).
+The tool spawns one nested `query()` call to a Haiku classifier (`classifyPreset`) that picks a Perplexity preset (`fast` / `low` / `medium` / `high`). This subagent runs with `allowedTools: []` — it has no tools at all, only structured JSON output. There is no researcher subagent with web tools, no report-writer subagent, and no "sandwich defense" PreToolUse hooks (the historical sandwich defense has been removed; outbound prompt injection is now handled by Bedrock Guardrails plus the defense-tag wrapper above).
 
 **Source:** `src/mcp/research-tools.ts` (`classifyPreset`)
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -181,7 +181,7 @@ This hook is wired on every agent's `PostToolUse` array alongside the persistenc
 
 ### Preset Classifier Subagent
 
-The tool spawns one nested `query()` call to a Haiku classifier (`classifyPreset`) that picks a Perplexity preset (`fast-search` / `pro-search` / `deep-research`). This subagent runs with `allowedTools: []` — it has no tools at all, only structured JSON output. There is no researcher subagent with web tools, no report-writer subagent, and no "sandwich defense" PreToolUse hooks (the historical sandwich defense has been removed; outbound prompt injection is now handled by Bedrock Guardrails plus the defense-tag wrapper above).
+The tool spawns one nested `query()` call to a Haiku classifier (`classifyPreset`) that picks a Perplexity preset (`fast` / `low` / `medium`). This subagent runs with `allowedTools: []` — it has no tools at all, only structured JSON output. There is no researcher subagent with web tools, no report-writer subagent, and no "sandwich defense" PreToolUse hooks (the historical sandwich defense has been removed; outbound prompt injection is now handled by Bedrock Guardrails plus the defense-tag wrapper above).
 
 **Source:** `src/mcp/research-tools.ts` (`classifyPreset`)
 

--- a/docs/architecture/web-research.md
+++ b/docs/architecture/web-research.md
@@ -37,7 +37,7 @@ Calling Agent
   v
 web_research MCP tool
   |
-  ├── 1. classifyPreset (Haiku) → fast / low / medium
+  ├── 1. classifyPreset (Haiku) → fast / low / medium / high
   |
   ├── 2. callPerplexity (Agent API) → output_text + citations
   |
@@ -46,23 +46,27 @@ web_research MCP tool
 
 ### Step 1: Preset Classification
 
-A Haiku model classifies the query using the same `query()` + `outputFormat: json_schema` pattern as triage (`src/system/triage.ts`):
+A Haiku model classifies the query using the same `query()` + `outputFormat: json_schema` pattern as triage (`src/system/triage.ts`). The presets are a cost ladder, and the classifier is told to pick the cheapest rung that can answer the query:
 
-- **fast**: Simple factual lookups, definitions, single-entity queries
-- **low**: Multi-faceted questions, comparisons, current events
-- **medium**: Comprehensive analysis, market research, technical deep-dives
+| Preset | Shape of the work | Model Perplexity selects | Observed cost on one research query |
+|---|---|---|---|
+| `fast` | One search, no follow-up reading | `openai/gpt-5.6-luna` | $0.003 |
+| `low` | A few searches, can open pages it finds | `openai/gpt-5.6-luna` | $0.003 |
+| `medium` | Many rounds of search and page reading | `openai/gpt-5.6-luna` | $0.035 |
+| `high` | Broadest coverage, strongest reasoning | `openai/gpt-5.6-sol` | $0.280 |
 
-Falls back to `low` on any classification failure. These are Perplexity's current
-tier-based preset names; they replaced `fast-search`, `pro-search`, and
-`deep-research`, respectively.
+Falls back to `low` on any classification failure. These are Perplexity's tier-based preset names, which replaced `fast-search`, `pro-search`, `deep-research`, `advanced-deep-research` and `ultra`. The legacy names still resolve as aliases, so they are not the reason a request fails.
+
+Two further presets exist and are deliberately not offered to the classifier. `xhigh` answers out of its own sandbox rather than the web, measured at zero citations and $1.54 for a single query, which defeats a tool whose output is a sourced report. `wide-research` is asynchronous: it returns a job handle to poll and delivers results as downloadable files rather than in the response body.
 
 ### Step 2: Perplexity Agent API
 
 A single `fetch()` call to `https://api.perplexity.ai/v1/agent` with:
 - `preset`: From step 1
-- `model`: `anthropic/claude-sonnet-4-6`
 - `input`: The research topic + optional context
 - `stream: false`
+
+No `model` is sent. Each preset carries its own tuned model, step budget, reasoning effort, output ceiling and tool set, and any field sent alongside a preset overrides that default. Pinning a model is therefore actively harmful here: the `fast` tier rejects Anthropic models outright with HTTP 400 `invalid request`, and `high` differs from `medium` only in model, so pinning one collapses the two into the same request.
 
 The Agent API follows the OpenAI Responses API format: the response's `output` array is parsed for `message` items (extracting `output_text` blocks and `url_citation` annotations) and `search_results` items (extracting result URLs). Top-level `output_text` and `citations` fields are used as a fallback. Citations are deduped before being returned.
 
@@ -168,6 +172,7 @@ See [Bedrock Guardrails Setup Guide](../guides/bedrock-guardrails-setup.md) for 
 ## Environment Variables
 
 - `PERPLEXITY_API_KEY`: Required for the Perplexity Agent API
+- `PERPLEXITY_MAX_OUTPUT_TOKENS`: Optional — caps report length. Unset by default, which lets each preset use its own output ceiling
 - `ANTHROPIC_API_KEY`: Required for the Haiku preset classifier
 - `BEDROCK_GUARDRAIL_ID`: Optional — enables input/output scanning
 - `BEDROCK_GUARDRAIL_VERSION`: Optional — defaults to `DRAFT`

--- a/docs/architecture/web-research.md
+++ b/docs/architecture/web-research.md
@@ -37,7 +37,7 @@ Calling Agent
   v
 web_research MCP tool
   |
-  ├── 1. classifyPreset (Haiku) → fast-search / pro-search / deep-research
+  ├── 1. classifyPreset (Haiku) → fast / low / medium
   |
   ├── 2. callPerplexity (Agent API) → output_text + citations
   |
@@ -48,11 +48,13 @@ web_research MCP tool
 
 A Haiku model classifies the query using the same `query()` + `outputFormat: json_schema` pattern as triage (`src/system/triage.ts`):
 
-- **fast-search**: Simple factual lookups, definitions, single-entity queries
-- **pro-search**: Multi-faceted questions, comparisons, current events
-- **deep-research**: Comprehensive analysis, market research, technical deep-dives
+- **fast**: Simple factual lookups, definitions, single-entity queries
+- **low**: Multi-faceted questions, comparisons, current events
+- **medium**: Comprehensive analysis, market research, technical deep-dives
 
-Falls back to `pro-search` on any classification failure.
+Falls back to `low` on any classification failure. These are Perplexity's current
+tier-based preset names; they replaced `fast-search`, `pro-search`, and
+`deep-research`, respectively.
 
 ### Step 2: Perplexity Agent API
 

--- a/docs/architecture/web-research.md
+++ b/docs/architecture/web-research.md
@@ -172,7 +172,6 @@ See [Bedrock Guardrails Setup Guide](../guides/bedrock-guardrails-setup.md) for 
 ## Environment Variables
 
 - `PERPLEXITY_API_KEY`: Required for the Perplexity Agent API
-- `PERPLEXITY_MAX_OUTPUT_TOKENS`: Optional — caps report length. Unset by default, which lets each preset use its own output ceiling
 - `ANTHROPIC_API_KEY`: Required for the Haiku preset classifier
 - `BEDROCK_GUARDRAIL_ID`: Optional — enables input/output scanning
 - `BEDROCK_GUARDRAIL_VERSION`: Optional — defaults to `DRAFT`

--- a/src/mcp/__tests__/research-tools.test.ts
+++ b/src/mcp/__tests__/research-tools.test.ts
@@ -7,19 +7,15 @@ function okResponse(payload: unknown) {
 
 describe('Perplexity Agent API integration', () => {
   const originalApiKey = process.env.PERPLEXITY_API_KEY;
-  const originalMaxOutputTokens = process.env.PERPLEXITY_MAX_OUTPUT_TOKENS;
 
   beforeEach(() => {
     process.env.PERPLEXITY_API_KEY = 'test-key';
-    delete process.env.PERPLEXITY_MAX_OUTPUT_TOKENS;
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     if (originalApiKey === undefined) delete process.env.PERPLEXITY_API_KEY;
     else process.env.PERPLEXITY_API_KEY = originalApiKey;
-    if (originalMaxOutputTokens === undefined) delete process.env.PERPLEXITY_MAX_OUTPUT_TOKENS;
-    else process.env.PERPLEXITY_MAX_OUTPUT_TOKENS = originalMaxOutputTokens;
   });
 
   it('exposes the four search tiers, and not the sandbox or collection presets', () => {
@@ -28,55 +24,21 @@ describe('Perplexity Agent API integration', () => {
     expect(PERPLEXITY_PRESETS).not.toContain('wide-research');
   });
 
-  // Pinning a model is what broke the `fast` tier, which rejects Anthropic
-  // models with HTTP 400 regardless of the output cap. The request must carry
-  // the preset and nothing that overrides it.
-  it('sends only the preset and input, with no model override', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(okResponse({
-      output_text: 'Answer',
-      citations: ['https://example.com/source'],
-    }));
-    vi.stubGlobal('fetch', fetchMock);
-
-    await callPerplexity('fast', 'What changed?');
-
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://api.perplexity.ai/v1/agent');
-    const body = JSON.parse(init.body as string);
-    expect(body).toEqual({ preset: 'fast', input: 'What changed?', stream: false });
-    expect(body).not.toHaveProperty('model');
-    expect(body).not.toHaveProperty('max_output_tokens');
-  });
-
-  it('sends every tier without a model override', async () => {
+  it('sends every tier with no fields that override the preset', async () => {
     for (const preset of PERPLEXITY_PRESETS) {
       const fetchMock = vi.fn().mockResolvedValue(okResponse({ output_text: 'x', citations: [] }));
       vi.stubGlobal('fetch', fetchMock);
 
       await callPerplexity(preset, 'q');
 
-      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-      const body = JSON.parse(init.body as string);
-      expect(body.preset).toBe(preset);
-      expect(body).not.toHaveProperty('model');
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.perplexity.ai/v1/agent');
+      expect(JSON.parse(init.body as string)).toEqual({ preset, input: 'q', stream: false });
     }
   });
 
-  it('caps output length only when PERPLEXITY_MAX_OUTPUT_TOKENS is set', async () => {
-    process.env.PERPLEXITY_MAX_OUTPUT_TOKENS = '16384';
-    const fetchMock = vi.fn().mockResolvedValue(okResponse({ output_text: 'x', citations: [] }));
-    vi.stubGlobal('fetch', fetchMock);
-
-    await callPerplexity('medium', 'q');
-
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(JSON.parse(init.body as string).max_output_tokens).toBe(16384);
-  });
-
-  // Shape observed from the live Agent API: citations arrive both as
-  // `search_results` items and as `url_citation` annotations on the message.
-  it('parses text and dedupes citations from the live response envelope', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(okResponse({
+  it('parses text and dedupes citations from the response envelope', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse({
       output: [
         {
           type: 'search_results',
@@ -99,8 +61,7 @@ describe('Perplexity Agent API integration', () => {
           ],
         },
       ],
-    }));
-    vi.stubGlobal('fetch', fetchMock);
+    })));
 
     const result = await callPerplexity('high', 'q');
 
@@ -110,6 +71,18 @@ describe('Perplexity Agent API integration', () => {
       'https://example.com/b',
       'https://example.com/c',
     ]);
+  });
+
+  it('falls back to the top-level text and citations', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse({
+      output_text: 'Answer',
+      citations: ['https://example.com/source'],
+    })));
+
+    await expect(callPerplexity('low', 'q')).resolves.toEqual({
+      output_text: 'Answer',
+      citations: ['https://example.com/source'],
+    });
   });
 
   it('surfaces the status and body when the Agent API rejects the request', async () => {

--- a/src/mcp/__tests__/research-tools.test.ts
+++ b/src/mcp/__tests__/research-tools.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { callPerplexity, PERPLEXITY_PRESETS } from '../research-tools.js';
 
+function okResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), { status: 200 });
+}
+
 describe('Perplexity Agent API integration', () => {
   const originalApiKey = process.env.PERPLEXITY_API_KEY;
   const originalMaxOutputTokens = process.env.PERPLEXITY_MAX_OUTPUT_TOKENS;
@@ -18,31 +22,101 @@ describe('Perplexity Agent API integration', () => {
     else process.env.PERPLEXITY_MAX_OUTPUT_TOKENS = originalMaxOutputTokens;
   });
 
-  it('uses the current tier-based preset names', () => {
-    expect(PERPLEXITY_PRESETS).toEqual(['fast', 'low', 'medium']);
+  it('exposes the four search tiers, and not the sandbox or collection presets', () => {
+    expect(PERPLEXITY_PRESETS).toEqual(['fast', 'low', 'medium', 'high']);
+    expect(PERPLEXITY_PRESETS).not.toContain('xhigh');
+    expect(PERPLEXITY_PRESETS).not.toContain('wide-research');
   });
 
-  it('sends a valid tier-based preset to the Agent API', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+  // Pinning a model is what broke the `fast` tier, which rejects Anthropic
+  // models with HTTP 400 regardless of the output cap. The request must carry
+  // the preset and nothing that overrides it.
+  it('sends only the preset and input, with no model override', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({
       output_text: 'Answer',
       citations: ['https://example.com/source'],
-    }), { status: 200 }));
+    }));
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(callPerplexity('low', 'What changed?')).resolves.toEqual({
-      output_text: 'Answer',
-      citations: ['https://example.com/source'],
-    });
+    await callPerplexity('fast', 'What changed?');
 
-    expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://api.perplexity.ai/v1/agent');
-    expect(JSON.parse(init.body as string)).toEqual({
-      preset: 'low',
-      model: 'anthropic/claude-sonnet-4-6',
-      input: 'What changed?',
-      stream: false,
-      max_output_tokens: 64000,
-    });
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({ preset: 'fast', input: 'What changed?', stream: false });
+    expect(body).not.toHaveProperty('model');
+    expect(body).not.toHaveProperty('max_output_tokens');
+  });
+
+  it('sends every tier without a model override', async () => {
+    for (const preset of PERPLEXITY_PRESETS) {
+      const fetchMock = vi.fn().mockResolvedValue(okResponse({ output_text: 'x', citations: [] }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await callPerplexity(preset, 'q');
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.preset).toBe(preset);
+      expect(body).not.toHaveProperty('model');
+    }
+  });
+
+  it('caps output length only when PERPLEXITY_MAX_OUTPUT_TOKENS is set', async () => {
+    process.env.PERPLEXITY_MAX_OUTPUT_TOKENS = '16384';
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ output_text: 'x', citations: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await callPerplexity('medium', 'q');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).max_output_tokens).toBe(16384);
+  });
+
+  // Shape observed from the live Agent API: citations arrive both as
+  // `search_results` items and as `url_citation` annotations on the message.
+  it('parses text and dedupes citations from the live response envelope', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({
+      output: [
+        {
+          type: 'search_results',
+          results: [
+            { url: 'https://example.com/a' },
+            { url: 'https://example.com/b' },
+          ],
+        },
+        {
+          type: 'message',
+          content: [
+            {
+              type: 'output_text',
+              text: 'Report body.',
+              annotations: [
+                { type: 'url_citation', url: 'https://example.com/a' },
+                { type: 'url_citation', url: 'https://example.com/c' },
+              ],
+            },
+          ],
+        },
+      ],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await callPerplexity('high', 'q');
+
+    expect(result.output_text).toBe('Report body.');
+    expect(result.citations).toEqual([
+      'https://example.com/a',
+      'https://example.com/b',
+      'https://example.com/c',
+    ]);
+  });
+
+  it('surfaces the status and body when the Agent API rejects the request', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'invalid request' } }), { status: 400 }),
+    ));
+
+    await expect(callPerplexity('fast', 'q')).rejects.toThrow(/400.*invalid request/);
   });
 });

--- a/src/mcp/__tests__/research-tools.test.ts
+++ b/src/mcp/__tests__/research-tools.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { callPerplexity, PERPLEXITY_PRESETS } from '../research-tools.js';
+
+describe('Perplexity Agent API integration', () => {
+  const originalApiKey = process.env.PERPLEXITY_API_KEY;
+  const originalMaxOutputTokens = process.env.PERPLEXITY_MAX_OUTPUT_TOKENS;
+
+  beforeEach(() => {
+    process.env.PERPLEXITY_API_KEY = 'test-key';
+    delete process.env.PERPLEXITY_MAX_OUTPUT_TOKENS;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalApiKey === undefined) delete process.env.PERPLEXITY_API_KEY;
+    else process.env.PERPLEXITY_API_KEY = originalApiKey;
+    if (originalMaxOutputTokens === undefined) delete process.env.PERPLEXITY_MAX_OUTPUT_TOKENS;
+    else process.env.PERPLEXITY_MAX_OUTPUT_TOKENS = originalMaxOutputTokens;
+  });
+
+  it('uses the current tier-based preset names', () => {
+    expect(PERPLEXITY_PRESETS).toEqual(['fast', 'low', 'medium']);
+  });
+
+  it('sends a valid tier-based preset to the Agent API', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      output_text: 'Answer',
+      citations: ['https://example.com/source'],
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(callPerplexity('low', 'What changed?')).resolves.toEqual({
+      output_text: 'Answer',
+      citations: ['https://example.com/source'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.perplexity.ai/v1/agent');
+    expect(JSON.parse(init.body as string)).toEqual({
+      preset: 'low',
+      model: 'anthropic/claude-sonnet-4-6',
+      input: 'What changed?',
+      stream: false,
+      max_output_tokens: 64000,
+    });
+  });
+});

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -37,23 +37,26 @@ export interface ResearchToolCallbacks {
 // Preset Classification (Haiku)
 // ============================================================================
 
+export const PERPLEXITY_PRESETS = ['fast', 'low', 'medium'] as const;
+export type PerplexityPreset = typeof PERPLEXITY_PRESETS[number];
+
 const PresetSchema = z.object({
-  preset: z.enum(['fast-search', 'pro-search', 'deep-research']),
+  preset: z.enum(PERPLEXITY_PRESETS),
   reasoning: z.string(),
 });
 
 // Mirror the title-generator pattern: strip the JSON Schema dialect URL
 // ($schema) — the SDK's structured-output validator rejects it, which caused
-// classification to silently fail and always fall back to pro-search.
+// classification to silently fail and always use the fallback preset.
 const rawPresetSchema = toJSONSchema(PresetSchema) as Record<string, unknown>;
 const { $schema: _dropSchema, ...presetJsonSchema } = rawPresetSchema;
 
 const CLASSIFIER_SYSTEM_PROMPT = `You are a research query classifier. Analyze the query and select the most appropriate Perplexity search preset.
 
 Presets:
-- fast-search: Simple factual lookups, definitions, single-entity queries, quick answers
-- pro-search: Multi-faceted questions, comparisons, current events, moderate research
-- deep-research: Comprehensive analysis, market research, technical deep-dives, broad strategic topics
+- fast: Simple factual lookups, definitions, single-entity queries, quick answers
+- low: Multi-faceted questions, comparisons, current events, moderate research
+- medium: Comprehensive analysis, market research, technical deep-dives, broad strategic topics
 
 Respond with JSON only.`;
 
@@ -61,9 +64,9 @@ Respond with JSON only.`;
  * Classify query complexity to select the right Perplexity preset.
  * Uses Haiku with structured JSON output (same lean shape as the title
  * generator, which is the proven-working one-shot pattern).
- * Falls back to pro-search on any failure.
+ * Falls back to low on any failure.
  */
-async function classifyPreset(topic: string, context?: string): Promise<string> {
+async function classifyPreset(topic: string, context?: string): Promise<PerplexityPreset> {
   const prompt = `Classify this research query and select the appropriate Perplexity preset.
 
 Research topic: ${topic}${context ? `\nContext: ${context}` : ''}
@@ -109,10 +112,10 @@ Respond with JSON only.`;
       }
     }
 
-    return result?.preset ?? 'pro-search';
+    return result?.preset ?? 'low';
   } catch (error) {
-    logger.warn('research', 'Preset classification failed, defaulting to pro-search', error);
-    return 'pro-search';
+    logger.warn('research', 'Preset classification failed, defaulting to low', error);
+    return 'low';
   }
 }
 
@@ -128,7 +131,7 @@ interface PerplexityResponse {
 /**
  * Call Perplexity Agent API with the selected preset.
  */
-async function callPerplexity(preset: string, input: string): Promise<PerplexityResponse> {
+export async function callPerplexity(preset: PerplexityPreset, input: string): Promise<PerplexityResponse> {
   const apiKey = process.env.PERPLEXITY_API_KEY!;
 
   const response = await fetch('https://api.perplexity.ai/v1/agent', {
@@ -146,7 +149,7 @@ async function callPerplexity(preset: string, input: string): Promise<Perplexity
       // cap — without it the backend rejects the request with
       // "max_output_tokens is required when using Anthropic models" and returns
       // an empty report. Set to the Sonnet output ceiling so we don't truncate
-      // long deep-research reports; overridable via env.
+      // long research reports; overridable via env.
       max_output_tokens: Number(process.env.PERPLEXITY_MAX_OUTPUT_TOKENS) || 64000,
     }),
   });

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -37,7 +37,13 @@ export interface ResearchToolCallbacks {
 // Preset Classification (Haiku)
 // ============================================================================
 
-export const PERPLEXITY_PRESETS = ['fast', 'low', 'medium'] as const;
+// `xhigh` and `wide-research` are deliberately excluded. `xhigh` answers out of
+// its own sandbox rather than the web — measured at zero citations and $1.54
+// for a single query — which defeats a tool whose output is a sourced report.
+// `wide-research` is asynchronous: it returns a job handle that has to be
+// polled, and its results arrive as downloadable files rather than in the
+// response body.
+export const PERPLEXITY_PRESETS = ['fast', 'low', 'medium', 'high'] as const;
 export type PerplexityPreset = typeof PERPLEXITY_PRESETS[number];
 
 const PresetSchema = z.object({
@@ -51,12 +57,16 @@ const PresetSchema = z.object({
 const rawPresetSchema = toJSONSchema(PresetSchema) as Record<string, unknown>;
 const { $schema: _dropSchema, ...presetJsonSchema } = rawPresetSchema;
 
-const CLASSIFIER_SYSTEM_PROMPT = `You are a research query classifier. Analyze the query and select the most appropriate Perplexity search preset.
+const CLASSIFIER_SYSTEM_PROMPT = `You are a research query classifier. Pick the Perplexity preset that fits the query.
 
-Presets:
-- fast: Simple factual lookups, definitions, single-entity queries, quick answers
-- low: Multi-faceted questions, comparisons, current events, moderate research
-- medium: Comprehensive analysis, market research, technical deep-dives, broad strategic topics
+The presets are a cost ladder, listed cheapest first. Pick the cheapest one that can actually answer the query: depth you do not need is wasted money, and the top rung costs roughly eighty times the bottom one.
+
+- fast: One search, no follow-up reading. A single fact, a definition, a version number, a release date, a yes or no. Use when one good source settles it.
+- low: A few searches, and it can open the pages it finds. Comparisons between named options, current events, recent changes, "how is X usually done". Use when the answer needs several sources reconciled but no real investigation.
+- medium: Many rounds of searching and page reading on the same question. Use when the answer has to be built by chaining evidence across sources: technical deep-dives, landscape surveys, trade-off analyses.
+- high: The broadest search coverage and the strongest reasoning, at roughly eight times the cost of medium. Use only when the query is open-ended and consequential enough that completeness beats both latency and cost: architecture or vendor decisions, security analyses, anything where a missed consideration is expensive.
+
+When two presets both look defensible, pick the cheaper one.
 
 Respond with JSON only.`;
 
@@ -134,6 +144,19 @@ interface PerplexityResponse {
 export async function callPerplexity(preset: PerplexityPreset, input: string): Promise<PerplexityResponse> {
   const apiKey = process.env.PERPLEXITY_API_KEY!;
 
+  // Send the preset and the input, nothing else. Each preset carries its own
+  // tuned model, step budget, reasoning effort, output ceiling and tool set,
+  // and any field sent alongside a preset overrides that default.
+  //
+  // Do not pin a model here. The `fast` tier rejects Anthropic models outright
+  // (HTTP 400 "invalid request", with no cap value accepted), which is what
+  // broke every query classified as simple. `high` also differs from `medium`
+  // only in model, so pinning one silently turns them into the same request.
+  //
+  // `max_output_tokens` is required only for Anthropic models, so it stays
+  // absent unless PERPLEXITY_MAX_OUTPUT_TOKENS is set to cap report length.
+  const maxOutputTokens = Number(process.env.PERPLEXITY_MAX_OUTPUT_TOKENS) || undefined;
+
   const response = await fetch('https://api.perplexity.ai/v1/agent', {
     method: 'POST',
     headers: {
@@ -142,15 +165,9 @@ export async function callPerplexity(preset: PerplexityPreset, input: string): P
     },
     body: JSON.stringify({
       preset,
-      model: 'anthropic/claude-sonnet-4-6',
       input,
       stream: false,
-      // Anthropic models proxied through Perplexity require an explicit output
-      // cap — without it the backend rejects the request with
-      // "max_output_tokens is required when using Anthropic models" and returns
-      // an empty report. Set to the Sonnet output ceiling so we don't truncate
-      // long research reports; overridable via env.
-      max_output_tokens: Number(process.env.PERPLEXITY_MAX_OUTPUT_TOKENS) || 64000,
+      ...(maxOutputTokens ? { max_output_tokens: maxOutputTokens } : {}),
     }),
   });
 

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -53,12 +53,12 @@ const { $schema: _dropSchema, ...presetJsonSchema } = rawPresetSchema;
 
 const CLASSIFIER_SYSTEM_PROMPT = `You are a research query classifier. Pick the Perplexity preset that fits the query.
 
-The presets are a cost ladder, listed cheapest first. Pick the cheapest one that can actually answer the query: depth you do not need is wasted money, and the top rung costs roughly eighty times the bottom one.
+The presets below are a cost ladder, cheapest first. Pick the cheapest one that can answer the query.
 
-- fast: One search, no follow-up reading. A single fact, a definition, a version number, a release date, a yes or no. Use when one good source settles it.
-- low: A few searches, and it can open the pages it finds. Comparisons between named options, current events, recent changes, "how is X usually done". Use when the answer needs several sources reconciled but no real investigation.
-- medium: Many rounds of searching and page reading on the same question. Use when the answer has to be built by chaining evidence across sources: technical deep-dives, landscape surveys, trade-off analyses.
-- high: The broadest search coverage and the strongest reasoning, at roughly eight times the cost of medium. Use only when the query is open-ended and consequential enough that completeness beats both latency and cost: architecture or vendor decisions, security analyses, anything where a missed consideration is expensive.
+- fast: A single fact, a definition, a version number, a release date, or a yes-or-no question. One authoritative source settles it.
+- low: A comparison between named options, a current event, a recent change, or "how is X usually done". Several sources to reconcile, nothing to investigate.
+- medium: A technical deep-dive, a landscape survey, or a trade-off analysis. No single source has the answer, so it has to be assembled from many.
+- high: An architecture or vendor decision, a security analysis, or any open-ended question where a missed consideration is expensive. Costs roughly eight times medium, so pick it only when completeness matters more than cost.
 
 When two presets both look defensible, pick the cheaper one.
 

--- a/src/mcp/research-tools.ts
+++ b/src/mcp/research-tools.ts
@@ -37,12 +37,8 @@ export interface ResearchToolCallbacks {
 // Preset Classification (Haiku)
 // ============================================================================
 
-// `xhigh` and `wide-research` are deliberately excluded. `xhigh` answers out of
-// its own sandbox rather than the web — measured at zero citations and $1.54
-// for a single query — which defeats a tool whose output is a sourced report.
-// `wide-research` is asynchronous: it returns a job handle that has to be
-// polled, and its results arrive as downloadable files rather than in the
-// response body.
+// `xhigh` answers from its own sandbox and returns no citations.
+// `wide-research` is async and delivers results as files.
 export const PERPLEXITY_PRESETS = ['fast', 'low', 'medium', 'high'] as const;
 export type PerplexityPreset = typeof PERPLEXITY_PRESETS[number];
 
@@ -51,9 +47,7 @@ const PresetSchema = z.object({
   reasoning: z.string(),
 });
 
-// Mirror the title-generator pattern: strip the JSON Schema dialect URL
-// ($schema) — the SDK's structured-output validator rejects it, which caused
-// classification to silently fail and always use the fallback preset.
+// The SDK's structured-output validator rejects the $schema dialect URL.
 const rawPresetSchema = toJSONSchema(PresetSchema) as Record<string, unknown>;
 const { $schema: _dropSchema, ...presetJsonSchema } = rawPresetSchema;
 
@@ -144,19 +138,8 @@ interface PerplexityResponse {
 export async function callPerplexity(preset: PerplexityPreset, input: string): Promise<PerplexityResponse> {
   const apiKey = process.env.PERPLEXITY_API_KEY!;
 
-  // Send the preset and the input, nothing else. Each preset carries its own
-  // tuned model, step budget, reasoning effort, output ceiling and tool set,
-  // and any field sent alongside a preset overrides that default.
-  //
-  // Do not pin a model here. The `fast` tier rejects Anthropic models outright
-  // (HTTP 400 "invalid request", with no cap value accepted), which is what
-  // broke every query classified as simple. `high` also differs from `medium`
-  // only in model, so pinning one silently turns them into the same request.
-  //
-  // `max_output_tokens` is required only for Anthropic models, so it stays
-  // absent unless PERPLEXITY_MAX_OUTPUT_TOKENS is set to cap report length.
-  const maxOutputTokens = Number(process.env.PERPLEXITY_MAX_OUTPUT_TOKENS) || undefined;
-
+  // Overriding the preset's model makes `fast` return HTTP 400, and makes
+  // `high` identical to `medium`.
   const response = await fetch('https://api.perplexity.ai/v1/agent', {
     method: 'POST',
     headers: {
@@ -167,7 +150,6 @@ export async function callPerplexity(preset: PerplexityPreset, input: string): P
       preset,
       input,
       stream: false,
-      ...(maxOutputTokens ? { max_output_tokens: maxOutputTokens } : {}),
     }),
   });
 


### PR DESCRIPTION
## What & why

`web_research` was returning HTTP 400 `invalid request`. The first commit here assumed the cause was retired Perplexity preset names. Probing the live Agent API showed that assumption was wrong, so the second commit fixes the actual cause.

**The legacy preset names still work.** They resolve as aliases, not errors:

| request | result |
|---|---|
| `preset=pro-search`, nothing else | 200, resolved to `openai/gpt-5.6-luna` |
| `preset=fast-search`, nothing else | 200, resolved to `openai/gpt-5.6-luna` |

**What actually fails is the `fast` tier combined with a pinned Anthropic model.** Archie sent `model: anthropic/claude-sonnet-4-6` on every call:

| request | result |
|---|---|
| `fast-search` + claude-sonnet-4-6 + cap 64000 | **400 `invalid request`** |
| `fast` + claude-sonnet-4-6 + cap 64000 | **400 `invalid request`** |
| `fast` + claude-sonnet-4-6 + cap 8192 | **400 `invalid request`** |
| `fast` + claude-sonnet-4-6, no cap | **400 `max_output_tokens is required when using Anthropic models`** |
| `fast` + `openai/gpt-5.6-sol` | 200 |
| `pro-search` / `deep-research` / `low` / `medium` + claude-sonnet-4-6 + cap | 200 |

The `fast` tier rejects Anthropic models outright, and no cap value is accepted. Every other tier accepts them. So `web_research` was failing on exactly the queries the classifier called simple and working on all the rest, which is why it looked like an intermittent outage rather than a dead tool. **Renaming `fast-search` to `fast` while keeping the model pin does not fix this** — that exact payload is row two of the table above.

## How it works

**Send the preset and the input, nothing else.** Each preset carries its own tuned model, step budget, reasoning effort, output ceiling and tool set, and per Perplexity's docs any field passed alongside a preset overrides that default. Two things follow. `max_output_tokens` disappears, along with the `PERPLEXITY_MAX_OUTPUT_TOKENS` env var, because both existed solely to satisfy the Anthropic pin; each preset's own ceiling applies instead, from 8,192 on `fast` up to 128,000 on `high`. And `high` becomes a real rung: it differs from `medium` only in model, so under the pin the two produced byte-identical requests.

**Adds `high` to the classifier and rewrites the briefing as an explicit cost ladder.** The rungs span about nine times bottom to top on one query, and the old briefing gave the classifier no cost signal at all. It is now told to pick the cheapest rung that can answer the query, and to break ties downward.

**`xhigh` and `wide-research` stay out.** `xhigh` answers from its own sandbox rather than the web: measured at zero citations and $1.54 for a single query, which defeats a tool whose entire output is a sourced report, and the per-task budget counts calls rather than dollars. `wide-research` is asynchronous, returning a job handle to poll and delivering results as downloadable files rather than in the response body. Both exclusions are recorded in a comment next to the preset list and asserted in a test, since they are the kind of omission someone would otherwise helpfully undo.

## Verification

All four tiers, called through the real `callPerplexity` against the live API:

| preset | resolved model | citations | report |
|---|---|---|---|
| `fast` | `openai/gpt-5.6-luna` | 10 | non-empty |
| `low` | `openai/gpt-5.6-luna` | 15 | non-empty |
| `medium` | `openai/gpt-5.6-luna` | 15 | non-empty |
| `high` | `openai/gpt-5.6-sol` | 25 | non-empty |

`fast`, the tier that was returning 400, now works.

The tiers do different work, on one open-ended research query:

| preset | citations | chars | cost | tools used |
|---|---|---|---|---|
| `medium` | 45 | 11,593 | $0.035 | 3 search, 7 fetch_url |
| `high` | 161 | 9,769 | $0.280 | 12 search |
| `xhigh` | **0** | 13,624 | $1.545 | sandbox only |

Dropping the pin also cut cost. The same simple query ran at $0.003 on `low` against $0.026 when pinned to Claude, because the pin billed Claude token rates plus cache-creation on every call.

Classifier routing, one sample per query. The briefing describes the shape of the query rather than the machinery of each tier, so the classifier has something it can match the input against directly:

| query | picked |
|---|---|
| default port for PostgreSQL | `fast` |
| latest stable Node.js version | `fast` |
| is Redis single-threaded | `fast` |
| maximum size of a DynamoDB item | `fast` |
| Datadog cost per host | `fast` |
| what changed in TypeScript 5.9 | `fast` |
| breaking changes in React 19 | `low` |
| compare pnpm and npm | `low` |
| server-sent events or websockets for a notification feed | `low` |
| survey open-source feature-flag services and trade-offs | `medium` |
| observability tooling mid-size teams use, compared | `medium` |
| security implications of JWTs in localStorage | `high` |
| which message queue to standardise on, with security implications | `high` |
| which cloud provider for the data platform, with lock-in risks | `high` |

Thirteen of fourteen matched what I expected. The exception, TypeScript release notes routing to `fast` rather than `low`, is defensible: one authoritative source settles it, and the briefing says to break ties downward. One sample per query, so this shows the briefing is coherent, not that routing is stable.

One thing to watch: the JWT question chose `high`, and `medium` would likely have answered it at an eighth of the cost. The `high` bullet lists "a security analysis" as a trigger, which catches any security-flavoured question. I left it, on the view that a thin answer to a security question is worse than an occasional 8x call, but it is a knob worth knowing about.

- `npm run typecheck` clean
- `npm test` — 1,583 passed, 5 skipped

## Note on CI

The gitleaks job is red, and not from this PR. It flags two test fixtures in commit 9b53103 on the unmerged `feat/zoom-voice-participant` branch. The job checks out full history and scans all refs, so `main` fails on the same two findings. That needs fixing in `.gitleaks.toml` or the fixtures, separately from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
